### PR TITLE
Use different implementation for PopCount on 32 bit Windows.

### DIFF
--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -200,13 +200,20 @@ HWY_API void CopyBytes(const From* from, To* to) {
 #endif
 }
 
-HWY_API size_t PopCount(const uint64_t x) {
+HWY_API size_t PopCount(uint64_t x) {
 #if HWY_COMPILER_CLANG || HWY_COMPILER_GCC
   return static_cast<size_t>(__builtin_popcountll(x));
-#elif HWY_COMPILER_MSVC
+#elif HWY_COMPILER_MSVC && _WIN64
   return _mm_popcnt_u64(x);
 #else
-#error "not supported"
+  x -=  ((x >> 1) & 0x55555555U);
+  x  = (((x >> 2) & 0x33333333U) + (x & 0x33333333U));
+  x  = (((x >> 4) + x) & 0x0F0F0F0FU);
+  x +=   (x >> 8);
+  x +=   (x >> 16);
+  x +=   (x >> 32);
+  x  = x & 0x0000007FU;
+  return (unsigned int)x;
 #endif
 }
 

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -205,6 +205,8 @@ HWY_API size_t PopCount(uint64_t x) {
   return static_cast<size_t>(__builtin_popcountll(x));
 #elif HWY_COMPILER_MSVC && _WIN64
   return _mm_popcnt_u64(x);
+#elif HWY_COMPILER_MSVC
+  return _mm_popcnt_u32(uint32_t(x)) + _mm_popcnt_u32(uint32_t(x>>32));
 #else
   x -=  ((x >> 1) & 0x55555555U);
   x  = (((x >> 2) & 0x33333333U) + (x & 0x33333333U));

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -203,7 +203,7 @@ HWY_API void CopyBytes(const From* from, To* to) {
 HWY_API size_t PopCount(uint64_t x) {
 #if HWY_COMPILER_CLANG || HWY_COMPILER_GCC
   return static_cast<size_t>(__builtin_popcountll(x));
-#elif HWY_COMPILER_MSVC && _WIN64
+#elif HWY_COMPILER_MSVC && HWY_ARCH_X86_64
   return _mm_popcnt_u64(x);
 #elif HWY_COMPILER_MSVC
   return _mm_popcnt_u32(uint32_t(x)) + _mm_popcnt_u32(uint32_t(x>>32));


### PR DESCRIPTION
I am trying to compile the jpeg-xl library on 32 bit Windows in Visual Studio and I ran into a compilation issue where `_mm_popcnt_u64` was undefined on 32 bit Windows. This PR adds a custom implementation of PopCount and changes the check to add support for 32 bit compilation on Windows. The code that was used comes from this implementation: https://github.com/shines77/strlen_fast/blob/master/src/strlen_fast/popcnt.h. An other option would be to use `std::popcount` but that requires C++20 and I don't think that should be used already.