### PR TITLE
Fix MSVC detection logic and usage

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -580,13 +580,13 @@ constexpr inline size_t RoundUpTo(size_t what, size_t align) {
 
 // Undefined results for x == 0.
 HWY_API size_t Num0BitsBelowLS1Bit_Nonzero32(const uint32_t x) {
-#ifdef _MSC_VER
+#if HWY_COMPILER_MSVC
   unsigned long index;  // NOLINT
   _BitScanForward(&index, x);
   return index;
-#else
+#else  // HWY_COMPILER_MSVC
   return static_cast<size_t>(__builtin_ctz(x));
-#endif
+#endif  // HWY_COMPILER_MSVC
 }
 
 HWY_API size_t PopCount(uint64_t x) {

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -34,7 +34,10 @@
 //------------------------------------------------------------------------------
 // Detect compiler using predefined macros
 
-#ifdef _MSC_VER
+// clang-cl defines _MSC_VER but doesn't behave like MSVC in other aspects like
+// used in HWY_DIAGNOSTICS(). We include a check that we are not clang for that
+// purpose.
+#if defined(_MSC_VER) && !defined(__clang__)
 #define HWY_COMPILER_MSVC _MSC_VER
 #else
 #define HWY_COMPILER_MSVC 0

--- a/hwy/nanobenchmark.cc
+++ b/hwy/nanobenchmark.cc
@@ -34,11 +34,11 @@
 #include <sys/platform/ppc.h>  // NOLINT __ppc_get_timebase_freq
 #elif HWY_ARCH_X86
 
-#ifdef _MSC_VER
+#if HWY_COMPILER_MSVC
 #include <intrin.h>
 #else
 #include <cpuid.h>  // NOLINT
-#endif              // _MSC_VER
+#endif              // HWY_COMPILER_MSVC
 
 #endif  // HWY_ARCH_X86
 

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -28,11 +28,11 @@
 
 #if HWY_ARCH_X86
 #include <xmmintrin.h>
-#ifdef _MSC_VER
+#if HWY_COMPILER_MSVC
 #include <intrin.h>
-#else
+#else  // HWY_COMPILER_MSVC
 #include <cpuid.h>
-#endif
+#endif // HWY_COMPILER_MSVC
 #endif
 
 namespace hwy {
@@ -48,13 +48,13 @@ bool IsBitSet(const uint32_t reg, const int index) {
 // in abcd array where abcd = {eax, ebx, ecx, edx} (hence the name abcd).
 void Cpuid(const uint32_t level, const uint32_t count,
            uint32_t* HWY_RESTRICT abcd) {
-#ifdef _MSC_VER
+#if HWY_COMPILER_MSVC
   int regs[4];
   __cpuidex(regs, level, count);
   for (int i = 0; i < 4; ++i) {
     abcd[i] = regs[i];
   }
-#else
+#else  // HWY_COMPILER_MSVC
   uint32_t a;
   uint32_t b;
   uint32_t c;
@@ -64,22 +64,22 @@ void Cpuid(const uint32_t level, const uint32_t count,
   abcd[1] = b;
   abcd[2] = c;
   abcd[3] = d;
-#endif
+#endif  // HWY_COMPILER_MSVC
 }
 
 // Returns the lower 32 bits of extended control register 0.
 // Requires CPU support for "OSXSAVE" (see below).
 uint32_t ReadXCR0() {
-#ifdef _MSC_VER
+#if HWY_COMPILER_MSVC
   return static_cast<uint32_t>(_xgetbv(0));
-#else
+#else  // HWY_COMPILER_MSVC
   uint32_t xcr0, xcr0_high;
   const uint32_t index = 0;
   asm volatile(".byte 0x0F, 0x01, 0xD0"
                : "=a"(xcr0), "=d"(xcr0_high)
                : "c"(index));
   return xcr0;
-#endif
+#endif  // HWY_COMPILER_MSVC
 }
 
 #endif  // HWY_ARCH_X86

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -203,9 +203,11 @@ static HWY_INLINE uint32_t Random32(RandomState* rng) {
 // built-in types.
 template <class T>
 inline void PreventElision(T&& output) {
-#ifndef _MSC_VER
+#if HWY_COMPILER_MSVC
   asm volatile("" : "+r"(output) : : "memory");
-#endif
+#else  // HWY_COMPILER_MSVC
+  (void)output;
+#endif  // HWY_COMPILER_MSVC
 }
 
 // Returns a name for the vector/part/scalar. The type prefix is u/i/f for


### PR DESCRIPTION
Clang-cl defines both __clang__ and _MSC_VER which causes issues when building highway for windows with clang-cl. These commits allow to build for Windows with clang-cl.