### PR TITLE
Consider non-V extensions RISC-V

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -316,7 +316,7 @@ namespace hwy {
 #if HWY_ARCH_X86
 static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 64;  // AVX-512
 #define HWY_ALIGN_MAX alignas(64)
-#elif HWY_ARCH_RVV
+#elif HWY_ARCH_RVV && defined(__riscv_vector)
 // Not actually an upper bound on the size, but this value prevents crossing a
 // 4K boundary (relevant on Andes).
 static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 4096;
@@ -333,7 +333,7 @@ static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 16;
 // by concatenating base type and bits.
 
 // RVV already has a builtin type and the GCC intrinsics require it.
-#if HWY_ARCH_RVV && HWY_COMPILER_GCC
+#if HWY_ARCH_RVV && HWY_COMPILER_GCC && defined(__riscv_vector)
 #define HWY_NATIVE_FLOAT16 1
 #else
 #define HWY_NATIVE_FLOAT16 0


### PR DESCRIPTION
__fp16 is defined in riscv_vector.h and this is in vector extension.
So if not using RVV, __fp16 is undefined. So highway shouldn't set
HWY_NATIVE_FLOAT16 without vector extension.

And, actually, since VLEN isn't exported to pre-defined macro for compiler/OS,
kMaxVectorSize is too large size. But it is unnecessary without vector
extension. So if compiler doesn't support vector extension, use default (16).