### PR TITLE
Fix clang-5 build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build / test
+on: [push]
+jobs:
+
+  # JOB
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install deps
+        run: sudo apt-get install clang-5.0 clang-6.0 cmake
+
+      - name: Clang-5.0
+        run: |
+          CXXFLAGS=-Werror CC=clang-5.0 CXX=clang++-5.0 cmake -B build-clang-5 .
+          cmake --build build-clang-5
+          ctest --test-dir build-clang-5
+
+      - name: Clang-6.0
+        run: |
+          CXXFLAGS=-Werror CC=clang-6.0 CXX=clang++-6.0 cmake -B build-clang-6 .
+          cmake --build build-clang-6
+          ctest --test-dir build-clang-6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ else()
 
   if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     list(APPEND HWY_FLAGS
-      -Wc++2a-extensions
       -Wfloat-overflow-conversion
       -Wfloat-zero-conversion
       -Wfor-loop-analysis
@@ -129,6 +128,9 @@ else()
       # Use color in messages
       -fdiagnostics-show-option -fcolor-diagnostics
     )
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)
+      list(APPEND HWY_FLAGS -Wc++2a-extensions)
+    endif()
   endif()
 
   if (WIN32)


### PR DESCRIPTION
Drive-by: add on-push build-and-test workflows for clang 5/6.

Context:  allow testing of clang-5 build of libjxl (for Mozilla)