### PR TITLE
Replace %zu printf usage with uint64_t ones.

### DIFF
--- a/hwy/contrib/image/image.h
+++ b/hwy/contrib/image/image.h
@@ -17,6 +17,7 @@
 
 // SIMD/multicore-friendly planar image representation with row accessors.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -102,7 +103,7 @@ struct ImageBase {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (y >= ysize_) {
-      HWY_ABORT("Row(%zu) >= %u\n", y, ysize_);
+      HWY_ABORT("Row(%" PRIu64 ") >= %u\n", static_cast<uint64_t>(y), ysize_);
     }
 #endif
 
@@ -221,9 +222,14 @@ class Image3 {
 
   Image3(ImageT&& plane0, ImageT&& plane1, ImageT&& plane2) {
     if (!SameSize(plane0, plane1) || !SameSize(plane0, plane2)) {
-      HWY_ABORT("Not same size: %zu x %zu, %zu x %zu, %zu x %zu\n",
-                plane0.xsize(), plane0.ysize(), plane1.xsize(), plane1.ysize(),
-                plane2.xsize(), plane2.ysize());
+      HWY_ABORT("Not same size: %" PRIu64 " x %" PRIu64 ", %" PRIu64
+                " x %" PRIu64 ", %" PRIu64 " x %" PRIu64 "\n",
+                static_cast<uint64_t>(plane0.xsize()),
+                static_cast<uint64_t>(plane0.ysize()),
+                static_cast<uint64_t>(plane1.xsize()),
+                static_cast<uint64_t>(plane1.ysize()),
+                static_cast<uint64_t>(plane2.xsize()),
+                static_cast<uint64_t>(plane2.ysize()));
     }
     planes_[0] = std::move(plane0);
     planes_[1] = std::move(plane1);
@@ -288,7 +294,9 @@ class Image3 {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (c >= kNumPlanes || y >= ysize()) {
-      HWY_ABORT("PlaneRow(%zu, %zu) >= %zu\n", c, y, ysize());
+      HWY_ABORT("PlaneRow(%" PRIu64 ", %" PRIu64 ") >= %" PRIu64 "\n",
+                static_cast<uint64_t>(c), static_cast<uint64_t>(y),
+                static_cast<uint64_t>(ysize()));
     }
 #endif
     // Use the first plane's stride because the compiler might not realize they

--- a/hwy/contrib/sort/sort-inl.h
+++ b/hwy/contrib/sort/sort-inl.h
@@ -22,6 +22,8 @@
 #define HIGHWAY_HWY_CONTRIB_SORT_SORT_INL_H_
 #endif
 
+#include <inttypes.h>
+
 #include "hwy/aligned_allocator.h"
 #include "hwy/highway.h"
 
@@ -125,7 +127,8 @@ class Runs {
     if (IsBitonic()) return;
     for (size_t ir = 0; ir < num_runs_; ++ir) {
       const T* p = &consecutive_[ir * run_length_];
-      printf("run %zu (len %zu)\n", ir, run_length_);
+      printf("run %" PRIu64 " (len %" PRIu64 ")\n", static_cast<uint64_t>(ir),
+             static_cast<uint64_t>(run_length_));
       for (size_t i = 0; i < run_length_; ++i) {
         printf("%.0f\n", static_cast<float>(p[i]));
       }
@@ -142,10 +145,11 @@ class Runs {
 
       for (size_t i = 0; i < run_length_ - 1; ++i) {
         if (!Compare(p[i], p[i + 1], order)) {
-          printf(
-              "ir%zu run_length=%zu alt=%d original order=%d this order=%d\n",
-              ir, run_length_, alternating_, static_cast<int>(kOrder),
-              static_cast<int>(order));
+          printf("ir%" PRIu64 " run_length=%" PRIu64
+                 " alt=%d original order=%d this order=%d\n",
+                 static_cast<uint64_t>(ir), static_cast<uint64_t>(run_length_),
+                 alternating_, static_cast<int>(kOrder),
+                 static_cast<int>(order));
           for (size_t i = 0; i < run_length_; ++i) {
             printf(" %.0f\n", static_cast<float>(p[i]));
           }

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,8 +43,10 @@ void Validate(D d, const TFromD<D>* in, const TFromD<D>* out) {
   // Ensure it matches the sort order
   for (size_t i = 0; i < K(d) - 1; ++i) {
     if (!verify::Compare(out[i], out[i + 1], kOrder)) {
-      printf("range=%zu lane=%zu N=%zu %.0f %.0f\n\n", i, i, N,
-             static_cast<float>(out[i + 0]), static_cast<float>(out[i + 1]));
+      printf("range=%" PRIu64 " lane=%" PRIu64 " N=%" PRIu64 " %.0f %.0f\n\n",
+             static_cast<uint64_t>(i), static_cast<uint64_t>(i),
+             static_cast<uint64_t>(N), static_cast<float>(out[i + 0]),
+             static_cast<float>(out[i + 1]));
       for (size_t i = 0; i < K(d); ++i) {
         printf("%.0f\n", static_cast<float>(out[i]));
       }

--- a/hwy/examples/benchmark.cc
+++ b/hwy/examples/benchmark.cc
@@ -16,7 +16,9 @@
 #define HWY_TARGET_INCLUDE "hwy/examples/benchmark.cc"
 #include "hwy/foreach_target.h"
 
+#include <inttypes.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include <memory>
@@ -79,7 +81,8 @@ void RunBenchmark(const char* caption) {
   for (size_t i = 0; i < num_results; ++i) {
     const double cycles_per_item = results[i].ticks / double(results[i].input);
     const double mad = results[i].variability * cycles_per_item;
-    printf("%6zu: %6.3f (+/- %5.3f)\n", results[i].input, cycles_per_item, mad);
+    printf("%6" PRIu64 ": %6.3f (+/- %5.3f)\n",
+           static_cast<uint64_t>(results[i].input), cycles_per_item, mad);
   }
 }
 

--- a/hwy/nanobenchmark.cc
+++ b/hwy/nanobenchmark.cc
@@ -14,6 +14,7 @@
 
 #include "hwy/nanobenchmark.h"
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>  // abort
@@ -501,17 +502,21 @@ timer::Ticks SampleUntilStable(const double max_rel_mad, double* rel_mad,
 
     if (*rel_mad <= max_rel_mad || abs_mad <= max_abs_mad) {
       if (p.verbose) {
-        printf("%6zu samples => %5zu (abs_mad=%4zu, rel_mad=%4.2f%%)\n",
-               samples.size(), size_t(est), size_t(abs_mad), *rel_mad * 100.0);
+        printf("%6" PRIu64 " samples => %5" PRIu64 " (abs_mad=%4" PRIu64
+               ", rel_mad=%4.2f%%)\n",
+               static_cast<uint64_t>(samples.size()),
+               static_cast<uint64_t>(est), static_cast<uint64_t>(abs_mad),
+               *rel_mad * 100.0);
       }
       return est;
     }
   }
 
   if (p.verbose) {
-    printf(
-        "WARNING: rel_mad=%4.2f%% still exceeds %4.2f%% after %6zu samples.\n",
-        *rel_mad * 100.0, max_rel_mad * 100.0, samples.size());
+    printf("WARNING: rel_mad=%4.2f%% still exceeds %4.2f%% after %6" PRIu64
+           " samples.\n",
+           *rel_mad * 100.0, max_rel_mad * 100.0,
+           static_cast<uint64_t>(samples.size()));
   }
   return est;
 }
@@ -548,8 +553,11 @@ size_t NumSkip(const Func func, const uint8_t* arg, const InputVec& unique,
           ? 0
           : static_cast<size_t>((max_skip + min_duration - 1) / min_duration);
   if (p.verbose) {
-    printf("res=%zu max_skip=%zu min_dur=%zu num_skip=%zu\n",
-           size_t(timer_resolution), max_skip, size_t(min_duration), num_skip);
+    printf("res=%" PRIu64 " max_skip=%" PRIu64 " min_dur=%" PRIu64
+           " num_skip=%" PRIu64 "\n",
+           static_cast<uint64_t>(timer_resolution),
+           static_cast<uint64_t>(max_skip), static_cast<uint64_t>(min_duration),
+           static_cast<uint64_t>(num_skip));
   }
   return num_skip;
 }
@@ -676,14 +684,19 @@ size_t Measure(const Func func, const uint8_t* arg, const FuncInput* inputs,
   const timer::Ticks overhead = Overhead(arg, &full, p);
   const timer::Ticks overhead_skip = Overhead(arg, &subset, p);
   if (overhead < overhead_skip) {
-    fprintf(stderr, "Measurement failed: overhead %zu < %zu\n",
-            size_t(overhead), size_t(overhead_skip));
+    fprintf(stderr, "Measurement failed: overhead %" PRIu64 " < %" PRIu64 "\n",
+            static_cast<uint64_t>(overhead),
+            static_cast<uint64_t>(overhead_skip));
     return 0;
   }
 
   if (p.verbose) {
-    printf("#inputs=%5zu,%5zu overhead=%5zu,%5zu\n", full.size(), subset.size(),
-           size_t(overhead), size_t(overhead_skip));
+    printf("#inputs=%5" PRIu64 ",%5" PRIu64 " overhead=%5" PRIu64 ",%5" PRIu64
+           "\n",
+           static_cast<uint64_t>(full.size()),
+           static_cast<uint64_t>(subset.size()),
+           static_cast<uint64_t>(overhead),
+           static_cast<uint64_t>(overhead_skip));
   }
 
   double max_rel_mad = 0.0;
@@ -695,8 +708,8 @@ size_t Measure(const Func func, const uint8_t* arg, const FuncInput* inputs,
         TotalDuration(func, arg, &subset, p, &max_rel_mad);
 
     if (total < total_skip) {
-      fprintf(stderr, "Measurement failed: total %zu < %zu\n", size_t(total),
-              size_t(total_skip));
+      fprintf(stderr, "Measurement failed: total %" PRIu64 " < %" PRIu64 "\n",
+              static_cast<uint64_t>(total), static_cast<uint64_t>(total_skip));
       return 0;
     }
 

--- a/hwy/nanobenchmark_test.cc
+++ b/hwy/nanobenchmark_test.cc
@@ -14,6 +14,8 @@
 
 #include "hwy/nanobenchmark.h"
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include <random>
@@ -44,8 +46,9 @@ void MeasureDiv(const FuncInput (&inputs)[N]) {
   params.max_evals = kMaxEvals;
   const size_t num_results = Measure(&Div, nullptr, inputs, N, results, params);
   for (size_t i = 0; i < num_results; ++i) {
-    printf("%5zu: %6.2f ticks; MAD=%4.2f%%\n", results[i].input,
-           results[i].ticks, results[i].variability * 100.0);
+    printf("%5" PRIu64 ": %6.2f ticks; MAD=%4.2f%%\n",
+           static_cast<uint64_t>(results[i].input), results[i].ticks,
+           results[i].variability * 100.0);
   }
 }
 

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -1060,7 +1061,9 @@ struct TestReciprocalSquareRoot {
       float err = lanes[i] - 0.090166f;
       if (err < 0.0f) err = -err;
       if (err >= 4E-4f) {
-        HWY_ABORT("Lane %zu(%zu): actual %f err %f\n", i, N, lanes[i], err);
+        HWY_ABORT("Lane %" PRIu64 "(%" PRIu64 "): actual %f err %f\n",
+                  static_cast<uint64_t>(i), static_cast<uint64_t>(N), lanes[i],
+                  err);
       }
     }
   }

--- a/hwy/tests/mask_test.cc
+++ b/hwy/tests/mask_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>  // memcmp
@@ -268,8 +269,10 @@ class TestStoreMaskBits {
       // Requires at least 8 bytes, ensured above.
       const size_t bytes_written = StoreMaskBits(di, mask, actual.get());
       if (bytes_written != expected_num_bytes) {
-        fprintf(stderr, "%s expected %zu bytes, actual %zu\n",
-                TypeName(T(), N).c_str(), expected_num_bytes, bytes_written);
+        fprintf(stderr, "%s expected %" PRIu64 " bytes, actual %" PRIu64 "\n",
+                TypeName(T(), N).c_str(),
+                static_cast<uint64_t>(expected_num_bytes),
+                static_cast<uint64_t>(bytes_written));
 
         HWY_ASSERT(false);
       }
@@ -291,8 +294,9 @@ class TestStoreMaskBits {
       for (; i < N; ++i) {
         const TI is_set = (actual[i / 8] & (1 << (i % 8))) ? 1 : 0;
         if (is_set != bool_lanes[i]) {
-          fprintf(stderr, "%s lane %zu: expected %d, actual %d\n",
-                  TypeName(T(), N).c_str(), i, int(bool_lanes[i]), int(is_set));
+          fprintf(stderr, "%s lane %" PRIu64 ": expected %d, actual %d\n",
+                  TypeName(T(), N).c_str(), static_cast<uint64_t>(i),
+                  int(bool_lanes[i]), int(is_set));
           Print(di, "bools", bools, 0, N);
           Print(d_bits, "expected bytes", Load(d_bits, expected.get()), 0,
                 expected_num_bytes);
@@ -306,8 +310,8 @@ class TestStoreMaskBits {
       for (; i < 8 * bytes_written; ++i) {
         const int bit = (actual[i / 8] & (1 << (i % 8)));
         if (bit != 0) {
-          fprintf(stderr, "%s: bit #%zu should be zero\n",
-                  TypeName(T(), N).c_str(), i);
+          fprintf(stderr, "%s: bit #%" PRIu64 " should be zero\n",
+                  TypeName(T(), N).c_str(), static_cast<uint64_t>(i));
           Print(di, "bools", bools, 0, N);
           Print(d_bits, "expected bytes", Load(d_bits, expected.get()), 0,
                 expected_num_bytes);

--- a/hwy/tests/swizzle_test.cc
+++ b/hwy/tests/swizzle_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -200,14 +201,16 @@ class TestCompress {
                    int line) {
     if (expected_pos != actual_pos) {
       hwy::Abort(__FILE__, line,
-                 "Size mismatch for %s: expected %zu, actual %zu\n",
-                 TypeName(T(), N).c_str(), expected_pos, actual_pos);
+                 "Size mismatch for %s: expected %" PRIu64 ", actual %" PRIu64 "\n",
+                 TypeName(T(), N).c_str(), static_cast<uint64_t>(expected_pos), static_cast<uint64_t>(actual_pos));
     }
     // Upper lanes are undefined. Modified from AssertVecEqual.
     for (size_t i = 0; i < expected_pos; ++i) {
       if (!IsEqual(expected[i], actual_u[i])) {
-        fprintf(stderr, "Mismatch at i=%zu of %zu, line %d:\n\n", i,
-                expected_pos, line);
+        fprintf(stderr,
+                "Mismatch at i=%" PRIu64 " of %" PRIu64 ", line %d:\n\n",
+                static_cast<uint64_t>(i), static_cast<uint64_t>(expected_pos),
+                line);
         Print(di, "mask", Load(di, mask_lanes.get()), 0, N);
         Print(d, "in", Load(d, in.get()), 0, N);
         Print(d, "expect", Load(d, expected.get()), 0, N);
@@ -403,7 +406,8 @@ void PrintCompress32x4Tables() {
 
     for (size_t i = 0; i < N; ++i) {
       for (size_t idx_byte = 0; idx_byte < sizeof(T); ++idx_byte) {
-        printf("%zu,", sizeof(T) * indices[i] + idx_byte);
+        printf("%" PRIu64 ",",
+               static_cast<uint64_t>(sizeof(T) * indices[i] + idx_byte));
       }
     }
   }
@@ -426,7 +430,8 @@ void PrintCompress64x2Tables() {
 
     for (size_t i = 0; i < N; ++i) {
       for (size_t idx_byte = 0; idx_byte < sizeof(T); ++idx_byte) {
-        printf("%zu,", sizeof(T) * indices[i] + idx_byte);
+        printf("%" PRIu64 ",",
+               static_cast<uint64_t>(sizeof(T) * indices[i] + idx_byte));
       }
     }
   }

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -14,6 +14,9 @@
 
 // Target-specific helper functions for use by *_test.cc.
 
+#include <inttypes.h>
+#include <stdint.h>
+
 #include "hwy/base.h"
 #include "hwy/tests/hwy_gtest.h"
 #include "hwy/tests/test_util.h"
@@ -116,8 +119,8 @@ HWY_NOINLINE void AssertMaskEqual(D d, VecArg<Mask<D>> a, VecArg<Mask<D>> b,
   // First check whole bytes (if that many elements are still valid)
   for (; i < N / 8; ++i) {
     if (bits_a[i] != bits_b[i]) {
-      fprintf(stderr, "Mismatch in byte %zu: %d != %d\n", i, bits_a[i],
-              bits_b[i]);
+      fprintf(stderr, "Mismatch in byte %" PRIu64 ": %d != %d\n",
+              static_cast<uint64_t>(i), bits_a[i], bits_b[i]);
       Print(d8, "expect", Load(d8, bits_a.get()), 0, N8);
       Print(d8, "actual", Load(d8, bits_b.get()), 0, N8);
       hwy::Abort(filename, line, "Masks not equal");
@@ -130,8 +133,8 @@ HWY_NOINLINE void AssertMaskEqual(D d, VecArg<Mask<D>> a, VecArg<Mask<D>> b,
     const int valid_a = bits_a[i] & mask;
     const int valid_b = bits_b[i] & mask;
     if (valid_a != valid_b) {
-      fprintf(stderr, "Mismatch in last byte %zu: %d != %d\n", i, valid_a,
-              valid_b);
+      fprintf(stderr, "Mismatch in last byte %" PRIu64 ": %d != %d\n",
+              static_cast<uint64_t>(i), valid_a, valid_b);
       Print(d8, "expect", Load(d8, bits_a.get()), 0, N8);
       Print(d8, "actual", Load(d8, bits_b.get()), 0, N8);
       hwy::Abort(filename, line, "Masks not equal");

--- a/hwy/tests/test_util.cc
+++ b/hwy/tests/test_util.cc
@@ -30,8 +30,9 @@ bool BytesEqual(const void* p1, const void* p2, const size_t size,
   const uint8_t* bytes2 = reinterpret_cast<const uint8_t*>(p2);
   for (size_t i = 0; i < size; ++i) {
     if (bytes1[i] != bytes2[i]) {
-      fprintf(stderr, "Mismatch at byte %zu of %zu: %d != %d\n", i, size,
-              bytes1[i], bytes2[i]);
+      fprintf(stderr, "Mismatch at byte %" PRIu64 " of %" PRIu64 ": %d != %d\n",
+              static_cast<uint64_t>(i), static_cast<uint64_t>(size), bytes1[i],
+              bytes2[i]);
       if (pos != nullptr) {
         *pos = i;
       }
@@ -71,7 +72,8 @@ bool IsEqual(const TypeInfo& info, const void* expected_ptr,
     CopyBytes<8>(actual_ptr, &actual);
     return ComputeUlpDelta(expected, actual) <= 1;
   } else {
-    HWY_ABORT("Unexpected float size %zu\n", info.sizeof_t);
+    HWY_ABORT("Unexpected float size %" PRIu64 "\n",
+              static_cast<uint64_t>(info.sizeof_t));
     return false;
   }
 }
@@ -80,9 +82,12 @@ void TypeName(const TypeInfo& info, size_t N, char* string100) {
   const char prefix = info.is_float ? 'f' : (info.is_signed ? 'i' : 'u');
   // Omit the xN suffix for scalars.
   if (N == 1) {
-    snprintf(string100, 64, "%c%zu", prefix, info.sizeof_t * 8);
+    snprintf(string100, 64, "%c%" PRIu64, prefix,
+             static_cast<uint64_t>(info.sizeof_t * 8));
   } else {
-    snprintf(string100, 64, "%c%zux%zu", prefix, info.sizeof_t * 8, N);
+    snprintf(string100, 64, "%c%" PRIu64 "x%" PRIu64, prefix,
+             static_cast<uint64_t>(info.sizeof_t * 8),
+             static_cast<uint64_t>(N));
   }
 }
 
@@ -138,7 +143,8 @@ void PrintArray(const TypeInfo& info, const char* caption,
   const intptr_t lane = intptr_t(lane_u);
   const size_t begin = static_cast<size_t>(HWY_MAX(0, lane - 2));
   const size_t end = HWY_MIN(begin + max_lanes, N);
-  fprintf(stderr, "%s %s [%zu+ ->]:\n  ", type_name, caption, begin);
+  fprintf(stderr, "%s %s [%" PRIu64 "+ ->]:\n  ", type_name, caption,
+          static_cast<uint64_t>(begin));
   for (size_t i = begin; i < end; ++i) {
     const void* ptr = array_bytes + i * info.sizeof_t;
     char str[100];
@@ -162,8 +168,10 @@ HWY_NORETURN void PrintMismatchAndAbort(const TypeInfo& info,
   char actual_str[100];
   ToString(info, actual_ptr, actual_str);
   Abort(filename, line,
-        "%s, %sx%zu lane %zu mismatch: expected '%s', got '%s'.\n", target_name,
-        type_name, num_lanes, lane, expected_str, actual_str);
+        "%s, %sx%" PRIu64 " lane %" PRIu64
+        " mismatch: expected '%s', got '%s'.\n",
+        target_name, type_name, static_cast<uint64_t>(num_lanes),
+        static_cast<uint64_t>(lane), expected_str, actual_str);
 }
 
 void AssertArrayEqual(const TypeInfo& info, const void* expected_void,

--- a/hwy/tests/test_util_test.cc
+++ b/hwy/tests/test_util_test.cc
@@ -30,13 +30,13 @@ struct TestName {
   HWY_NOINLINE void operator()(T t, D d) {
     char num[10];
     std::string expected = IsFloat<T>() ? "f" : (IsSigned<T>() ? "i" : "u");
-    snprintf(num, sizeof(num), "%zu", sizeof(T) * 8);
+    snprintf(num, sizeof(num), "%u" , static_cast<unsigned>(sizeof(T) * 8));
     expected += num;
 
     const size_t N = Lanes(d);
     if (N != 1) {
       expected += 'x';
-      snprintf(num, sizeof(num), "%zu", N);
+      snprintf(num, sizeof(num), "%u", static_cast<unsigned>(N));
       expected += num;
     }
     const std::string actual = TypeName(t, N);


### PR DESCRIPTION
%zu is not supported everywhere, in particular it is not supported in
MSYS2. Most of the current uses were in unittests, but some public
headers also had some meaning that projects using hwy would hit those
occurrences.

This patch replaces all of these usages in most cases replacing them by
uint64_t, which might be a larger type in 32-bit platforms but that's
not an issue. %zu is only used in combination with printf() to stdout or
stderr in cases where performance is not an issue.