### PR TITLE
Build and test on Windows MSYS2

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -55,3 +55,46 @@ jobs:
           path: ~/.cache/bazel
           key: bazel-${{ runner.os }}
       - run: bazel build //...
+
+  windows_msys2:
+    name: Windows MSYS2 / ${{ matrix.arch }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            msystem: mingw64
+          - arch: i686
+            msystem: mingw32
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: false
+          install: >-
+            base-devel
+            git
+            mingw-w64-${{ matrix.arch }}-cmake
+            mingw-w64-${{ matrix.arch }}-gcc
+            mingw-w64-${{ matrix.arch }}-gtest
+            mingw-w64-${{ matrix.arch }}-ninja
+
+      - name: CMake configure
+        # Enable only SCALAR and AVX2 to speed up the build/test.
+        run: |
+          cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-DHWY_DISABLED_TARGETS=\"~(HWY_SCALAR|HWY_AVX2)\"" \
+            -DHWY_WARNINGS_ARE_ERRORS=ON \
+            -DHWY_SYSTEM_GTEST=ON \
+            -B out \
+            -G Ninja
+      - name: CMake build
+        run: cmake --build out
+      - name: Test
+        run: ctest --test-dir out --parallel 2 --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(POLICY CMP0083)
   cmake_policy(SET CMP0083 NEW)
 endif()
 
-project(hwy VERSION 0.15.0)  # Keep in sync with highway.h version
+project(hwy LANGUAGES CXX VERSION 0.15.0)  # Keep in sync with highway.h version
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -378,8 +378,13 @@ foreach (TESTFILE IN LISTS HWY_TEST_FILES)
   else()
     target_link_libraries(${TESTNAME} hwy hwy_contrib hwy_test gtest gtest_main)
   endif()
-  # Output test targets in the test directory.
-  set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
+
+  # MINGW with Ninja generates two build rules for the same file when setting a
+  # prefix in the target. We skip the prefix in MINGW to workaround the issue.
+  if(NOT MINGW OR NOT ${CMAKE_GENERATOR} STREQUAL "Ninja")
+    # Output test targets in the test directory.
+    set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
+  endif()
 
   if (HWY_EMSCRIPTEN)
     set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "-s SINGLE_FILE=1")


### PR DESCRIPTION
New GitHub workflow to build and test on a Windows MSYS2 build in 32 and
64 bits.

This patch sets the `LANGUAGES` to `CXX` in the cmake project to avoid
setting up the `C` language which is not used by the project.

Due to a bug in cmake ninja generator with MSYS we can't set a prefix on
the target because it creates a duplicated ninja rule.