### PR TITLE
Set RUNTIME_OUTPUT_DIRECTORY for test executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ foreach (TESTFILE IN LISTS HWY_TEST_FILES)
     target_link_libraries(${TESTNAME} hwy hwy_contrib hwy_test gtest gtest_main)
   endif()
   # Output test targets in the test directory.
-  set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
+  set_target_properties(${TESTNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "tests")
 
   if (HWY_EMSCRIPTEN)
     set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "-s SINGLE_FILE=1")


### PR DESCRIPTION
Setting the target's PREFIX causes ninja to fail claiming multiple rules generate the same executable. The prefix is just a directory name so use RUNTIME_OUTPUT_DIRECTORY instead.