### PR TITLE
Replace usage of __MACH__ with __APPLE__

### DIFF
--- a/hwy/nanobenchmark.cc
+++ b/hwy/nanobenchmark.cc
@@ -37,7 +37,7 @@
 #include <windows.h>
 #endif
 
-#if defined(__MACH__)
+#if defined(__APPLE__)
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #endif
@@ -148,7 +148,7 @@ inline Ticks Start() {
   LARGE_INTEGER counter;
   (void)QueryPerformanceCounter(&counter);
   t = counter.QuadPart;
-#elif defined(__MACH__)
+#elif defined(__APPLE__)
   t = mach_absolute_time();
 #elif defined(__HAIKU__)
   t = system_time_nsecs();  // since boot
@@ -415,7 +415,7 @@ double InvariantTicksPerSecond() {
   LARGE_INTEGER freq;
   (void)QueryPerformanceFrequency(&freq);
   return double(freq.QuadPart);
-#elif defined(__MACH__)
+#elif defined(__APPLE__)
   // https://developer.apple.com/library/mac/qa/qa1398/_index.html
   mach_timebase_info_data_t timebase;
   (void)mach_timebase_info(&timebase);


### PR DESCRIPTION
It turns out that __MACH__ macro refer to the Mach kernel, which is also
used for GNU/Hurd. Prefer usage of macro __APPLE__ in this case.

This should solve the following compilation error:

nanobenchmark.cc:42:10: fatal error: mach/mach_time.h: No such file or directory

For reference:

* https://developer.apple.com/library/archive/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html#//apple_ref/doc/uid/TP40002850-SW13