### PR TITLE
Add missing include of stdlib.h for exit() prototype.

### DIFF
--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h> // exit()
 
 #include <atomic>
 


### PR DESCRIPTION
This should fix the following compilation error seen on riscv64:

/<<PKGBUILDDIR>>/hwy/targets.cc:205:3: error: ‘exit’ was not declared in this scope
  205 |   exit(1);  // trap/abort just freeze Spike
      |   ^~~~
/<<PKGBUILDDIR>>/hwy/targets.cc:209:1: error: ‘noreturn’ function does return [-Werror]