### PR TITLE
Fix inlcude headers for c++ to avoid compilation errors with PRIu64

### DIFF
--- a/hwy/contrib/image/image.h
+++ b/hwy/contrib/image/image.h
@@ -17,10 +17,10 @@
 
 // SIMD/multicore-friendly planar image representation with row accessors.
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 #include <cstddef>
 #include <utility>  // std::move

--- a/hwy/contrib/sort/sort-inl.h
+++ b/hwy/contrib/sort/sort-inl.h
@@ -22,7 +22,7 @@
 #define HIGHWAY_HWY_CONTRIB_SORT_SORT_INL_H_
 #endif
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "hwy/aligned_allocator.h"
 #include "hwy/highway.h"

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <inttypes.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 #include "hwy/tests/include_farm_sve.h"
 // ^ must come before highway.h.

--- a/hwy/examples/benchmark.cc
+++ b/hwy/examples/benchmark.cc
@@ -16,10 +16,10 @@
 #define HWY_TARGET_INCLUDE "hwy/examples/benchmark.cc"
 #include "hwy/foreach_target.h"
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
 
 #include <memory>
 #include <numeric>  // iota

--- a/hwy/nanobenchmark.cc
+++ b/hwy/nanobenchmark.cc
@@ -14,12 +14,12 @@
 
 #include "hwy/nanobenchmark.h"
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>  // abort
-#include <string.h>  // memcpy
-#include <time.h>    // clock_gettime
+#include <cinttypes>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>  // abort
+#include <cstring>  // memcpy
+#include <ctime>    // clock_gettime
 
 #include <algorithm>  // sort
 #include <array>

--- a/hwy/nanobenchmark_test.cc
+++ b/hwy/nanobenchmark_test.cc
@@ -14,9 +14,9 @@
 
 #include "hwy/nanobenchmark.h"
 
-#include <inttypes.h>
-#include <stdint.h>
-#include <stdio.h>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
 
 #include <random>
 

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
 
 #include <algorithm>
 #include <limits>

--- a/hwy/tests/mask_test.cc
+++ b/hwy/tests/mask_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>  // memcmp
+#include <cinttypes>
+#include <stddef>
+#include <stdint>
+#include <string>  // memcmp
 
 #include "hwy/tests/include_farm_sve.h"
 // ^ must come before highway.h.

--- a/hwy/tests/shift_test.cc
+++ b/hwy/tests/shift_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
 
 #include <algorithm>
 #include <limits>

--- a/hwy/tests/swizzle_test.cc
+++ b/hwy/tests/swizzle_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 #include <array>  // IWYU pragma: keep
 

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -14,8 +14,8 @@
 
 // Target-specific helper functions for use by *_test.cc.
 
-#include <inttypes.h>
-#include <stdint.h>
+#include <cinttypes>
+#include <cstdint>
 
 #include "hwy/base.h"
 #include "hwy/tests/hwy_gtest.h"

--- a/hwy/tests/test_util.cc
+++ b/hwy/tests/test_util.cc
@@ -14,9 +14,9 @@
 
 #include "hwy/tests/test_util.h"
 
-#include <inttypes.h>
-#include <stddef.h>
-#include <stdio.h>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdio>
 
 #include <cmath>
 

--- a/hwy/tests/test_util.h
+++ b/hwy/tests/test_util.h
@@ -17,9 +17,9 @@
 
 // Target-independent helper functions for use by *_test.cc.
 
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 #include <string>
 


### PR DESCRIPTION
Without this, you get an error about undefined `PRIu64`

You probably only need the `<inttypes.h>` -> `<cinttypes>` but I think this is going to help in the long run.

See: https://stackoverflow.com/questions/8132399/how-to-printf-uint64-t-fails-with-spurious-trailing-in-format/8132440#comment9979590_8132440
See: https://stackoverflow.com/questions/12497894/d-stdc-format-macros-gnu-compiler-option