### PR TITLE
Fix exporting symbols between contrib and main dll

### DIFF
--- a/hwy/contrib/image/image.h
+++ b/hwy/contrib/image/image.h
@@ -33,7 +33,7 @@ namespace hwy {
 
 // Type-independent parts of Image<> - reduces code duplication and facilitates
 // moving member function implementations to cc file.
-struct HWY_DLLEXPORT ImageBase {
+struct HWY_CONTRIB_DLLEXPORT ImageBase {
   // Returns required alignment in bytes for externally allocated memory.
   static size_t VectorSize();
 

--- a/hwy/highway_export.h
+++ b/hwy/highway_export.h
@@ -17,9 +17,14 @@
 #ifdef HWY_STATIC_DEFINE
 #define HWY_DLLEXPORT
 #define HWY_NO_EXPORT
+#define HWY_CONTRIB_DLLEXPORT
+#define HWY_CONTRIB_NO_EXPORT
+#define HWY_TEST_DLLEXPORT
+#define HWY_TEST_NO_EXPORT
 #else
+
 #ifndef HWY_DLLEXPORT
-#if defined(hwy_EXPORTS) || defined(hwy_contrib_EXPORTS) || defined(hwy_test_EXPORTS)
+#if defined(hwy_EXPORTS)
 /* We are building this library */
 #ifdef _WIN32
 #define HWY_DLLEXPORT __declspec(dllexport)
@@ -43,6 +48,59 @@
 #define HWY_NO_EXPORT __attribute__((visibility("hidden")))
 #endif
 #endif
+
+#ifndef HWY_CONTRIB_DLLEXPORT
+#if defined(hwy_contrib_EXPORTS)
+/* We are building this library */
+#ifdef _WIN32
+#define HWY_CONTRIB_DLLEXPORT __declspec(dllexport)
+#else
+#define HWY_CONTRIB_DLLEXPORT __attribute__((visibility("default")))
+#endif
+#else
+/* We are using this library */
+#ifdef _WIN32
+#define HWY_CONTRIB_DLLEXPORT __declspec(dllimport)
+#else
+#define HWY_CONTRIB_DLLEXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#endif
+
+#ifndef HWY_CONTRIB_NO_EXPORT
+#ifdef _WIN32
+#define HWY_CONTRIB_NO_EXPORT
+#else
+#define HWY_CONTRIB_NO_EXPORT __attribute__((visibility("hidden")))
+#endif
+#endif
+
+#ifndef HWY_TEST_DLLEXPORT
+#if defined(hwy_test_EXPORTS)
+/* We are building this library */
+#ifdef _WIN32
+#define HWY_TEST_DLLEXPORT __declspec(dllexport)
+#else
+#define HWY_TEST_DLLEXPORT __attribute__((visibility("default")))
+#endif
+#else
+/* We are using this library */
+#ifdef _WIN32
+#define HWY_TEST_DLLEXPORT __declspec(dllimport)
+#else
+#define HWY_TEST_DLLEXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#endif
+
+#ifndef HWY_TEST_NO_EXPORT
+#ifdef _WIN32
+#define HWY_TEST_NO_EXPORT
+#else
+#define HWY_TEST_NO_EXPORT __attribute__((visibility("hidden")))
+#endif
+#endif
+
 #endif
 
 #endif /* HWY_DLLEXPORT_H */

--- a/hwy/tests/test_util.h
+++ b/hwy/tests/test_util.h
@@ -86,8 +86,8 @@ inline void PreventElision(T&& output) {
 #endif  // HWY_COMPILER_MSVC
 }
 
-HWY_DLLEXPORT bool BytesEqual(const void* p1, const void* p2, const size_t size,
-                              size_t* pos = nullptr);
+HWY_TEST_DLLEXPORT bool BytesEqual(const void* p1, const void* p2,
+                                   const size_t size, size_t* pos = nullptr);
 
 void AssertStringEqual(const char* expected, const char* actual,
                        const char* target_name, const char* filename, int line);
@@ -131,25 +131,25 @@ HWY_INLINE TypeInfo MakeTypeInfo() {
   return info;
 }
 
-HWY_DLLEXPORT bool IsEqual(const TypeInfo& info, const void* expected_ptr,
-                           const void* actual_ptr);
+HWY_TEST_DLLEXPORT bool IsEqual(const TypeInfo& info, const void* expected_ptr,
+                                const void* actual_ptr);
 
-HWY_DLLEXPORT void TypeName(const TypeInfo& info, size_t N, char* string100);
+HWY_TEST_DLLEXPORT void TypeName(const TypeInfo& info, size_t N, char* string100);
 
-HWY_DLLEXPORT void PrintArray(const TypeInfo& info, const char* caption,
-                              const void* array_void, size_t N,
-                              size_t lane_u = 0, size_t max_lanes = 7);
+HWY_TEST_DLLEXPORT void PrintArray(const TypeInfo& info, const char* caption,
+                                   const void* array_void, size_t N,
+                                   size_t lane_u = 0, size_t max_lanes = 7);
 
-HWY_DLLEXPORT HWY_NORETURN void PrintMismatchAndAbort(
+HWY_TEST_DLLEXPORT HWY_NORETURN void PrintMismatchAndAbort(
     const TypeInfo& info, const void* expected_ptr, const void* actual_ptr,
     const char* target_name, const char* filename, int line, size_t lane = 0,
     size_t num_lanes = 1);
 
-HWY_DLLEXPORT void AssertArrayEqual(const TypeInfo& info,
-                                    const void* expected_void,
-                                    const void* actual_void, size_t N,
-                                    const char* target_name,
-                                    const char* filename, int line);
+HWY_TEST_DLLEXPORT void AssertArrayEqual(const TypeInfo& info,
+                                         const void* expected_void,
+                                         const void* actual_void, size_t N,
+                                         const char* target_name,
+                                         const char* filename, int line);
 
 }  // namespace detail
 


### PR DESCRIPTION
I believe this fixes https://github.com/google/highway/issues/525

By exporting the different symbols based on the different libraries that are built.

I'm not sure if you a test for a dynamically linked build.