### PR TITLE
Remove erroneous install destination for share libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,8 +266,7 @@ endif()
 # -------------------------------------------------------- install library
 if (HWY_ENABLE_INSTALL)
 
-install(TARGETS hwy
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS hwy)
 # Install all the headers keeping the relative path to the current directory
 # when installing them.
 foreach (source ${HWY_SOURCES})
@@ -278,8 +277,7 @@ foreach (source ${HWY_SOURCES})
   endif()
 endforeach()
 
-install(TARGETS hwy_contrib
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS hwy_contrib)
 # Install all the headers keeping the relative path to the current directory
 # when installing them.
 foreach (source ${HWY_CONTRIB_SOURCES})
@@ -290,8 +288,7 @@ foreach (source ${HWY_CONTRIB_SOURCES})
   endif()
 endforeach()
 
-install(TARGETS hwy_test
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS hwy_test)
 # Install all the headers keeping the relative path to the current directory
 # when installing them.
 foreach (source ${HWY_TEST_SOURCES})


### PR DESCRIPTION
With this patch, CMake seems to choose the correct installation directories for shared libraries

* .dll in bin
* .lib in lib


I think it should be correct for the static builds.

Otherwise, both dll and lib were going in lib.