### PR TITLE
hwy/highway_test.cc: include string.h for memcpy

### DIFF
--- a/hwy/highway_test.cc
+++ b/hwy/highway_test.cc
@@ -15,6 +15,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <bitset>
 


### PR DESCRIPTION
Fixes a compile error caused by implicit function declaration
of memcpy, which is defined in string.h.