### PR TITLE
Added algo inl files to HWY_CONTRIB_SOURCES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,9 @@ list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/sort/vqsort-inl.h
     hwy/contrib/sort/vqsort.cc
     hwy/contrib/sort/vqsort.h
+    hwy/contrib/algo/copy-inl.h
+    hwy/contrib/algo/find-inl.h
+    hwy/contrib/algo/transform-inl.h
 )
 endif()  # HWY_ENABLE_CONTRIB
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/algo/find-inl.h
     hwy/contrib/algo/transform-inl.h
 )
-
 endif()  # HWY_ENABLE_CONTRIB
 
 set(HWY_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/algo/find-inl.h
     hwy/contrib/algo/transform-inl.h
 )
+
 endif()  # HWY_ENABLE_CONTRIB
 
 set(HWY_SOURCES


### PR DESCRIPTION
The copy-inl.h, find-inl.h, and transform-inl.h headers are not installed when building highway with cmake.