### PR TITLE
Fixing unroll pragma for GCC

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -138,8 +138,11 @@
 // nielskm: GCC does not support '#pragma GCC unroll' without the factor.
 #define HWY_UNROLL(factor) HWY_PRAGMA(GCC unroll factor)
 #define HWY_DEFAULT_UNROLL HWY_UNROLL(4)
-#else
+#elif HWY_COMPILER_CLANG || HWY_COMPILER_ICC || HWY_COMPILER_ICX
 #define HWY_UNROLL(factor) HWY_PRAGMA(unroll factor)
+#define HWY_DEFAULT_UNROLL HWY_UNROLL()
+#else
+#define HWY_UNROLL(factor)
 #define HWY_DEFAULT_UNROLL HWY_UNROLL()
 #endif
 

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -134,6 +134,16 @@
 #define HWY_MIN(a, b) ((a) < (b) ? (a) : (b))
 #define HWY_MAX(a, b) ((a) > (b) ? (a) : (b))
 
+#if HWY_COMPILER_GCC_ACTUAL
+// nielskm: GCC does not support '#pragma GCC unroll' without the factor.
+#define HWY_UNROLL(factor) HWY_PRAGMA(GCC unroll factor)
+#define HWY_DEFAULT_UNROLL HWY_UNROLL(4)
+#else
+#define HWY_UNROLL(factor) HWY_PRAGMA(unroll factor)
+#define HWY_DEFAULT_UNROLL HWY_UNROLL()
+#endif
+
+
 // Compile-time fence to prevent undesirable code reordering. On Clang x86, the
 // typical asm volatile("" : : : "memory") has no effect, whereas atomic fence
 // does, without generating code.

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -624,11 +624,7 @@ HWY_INLINE size_t ScanEqual(D d, Traits st, const T* HWY_RESTRICT keys,
   const size_t lanes_per_group = kLoops * 2 * N;
 
   for (; i + lanes_per_group <= num; i += lanes_per_group) {
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC unroll 4
-#else
-#pragma unroll
-#endif
+    HWY_DEFAULT_UNROLL
     for (size_t loop = 0; loop < kLoops; ++loop) {
       const V v0 = Load(d, keys + i + loop * 2 * N);
       const V v1 = Load(d, keys + i + loop * 2 * N + N);

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -624,7 +624,11 @@ HWY_INLINE size_t ScanEqual(D d, Traits st, const T* HWY_RESTRICT keys,
   const size_t lanes_per_group = kLoops * 2 * N;
 
   for (; i + lanes_per_group <= num; i += lanes_per_group) {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC unroll 4
+#else
 #pragma unroll
+#endif
     for (size_t loop = 0; loop < kLoops; ++loop) {
       const V v0 = Load(d, keys + i + loop * 2 * N);
       const V v1 = Load(d, keys + i + loop * 2 * N + N);

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -50,6 +50,12 @@
 #define HWY_COMPILER_ICC 0
 #endif
 
+#ifdef __INTEL_LLVM_COMPILER
+#define HWY_COMPILER_ICX __INTEL_LLVM_COMPILER
+#else
+#define HWY_COMPILER_ICX 0
+#endif
+
 // HWY_COMPILER_GCC is a generic macro for all compilers implementing the GNU
 // compiler extensions (eg. Clang, Intel...)
 #ifdef __GNUC__


### PR DESCRIPTION
- Changing `#pragma unroll` to `#pragma GCC unroll 4` for GCC compiler. The value of 4 can be changed if needed.

This fixes #933 .