### PR TITLE
Remove a warning with gcc 12.x about maybe-uninitialized

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -2885,11 +2885,18 @@ HWY_API void StoreU(Vec128<bfloat16_t, N> v, Simd<bfloat16_t, N, 0> d,
   return StoreU(Vec128<uint16_t, N>(v.raw), du16, pu16);
 }
 
+HWY_DIAGNOSTICS(push)
+#if HWY_COMPILER_GCC_ACTUAL
+  HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wmaybe-uninitialized")
+#endif
+
 // On ARM, Store is the same as StoreU.
 template <typename T, size_t N>
 HWY_API void Store(Vec128<T, N> v, Simd<T, N, 0> d, T* HWY_RESTRICT aligned) {
   StoreU(v, d, aligned);
 }
+
+HWY_DIAGNOSTICS(pop)
 
 template <typename T, size_t N>
 HWY_API void BlendedStore(Vec128<T, N> v, Mask128<T, N> m, Simd<T, N, 0> d,

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -1025,18 +1025,20 @@ HWY_API Vec128<bfloat16_t, N> Zero(Simd<bfloat16_t, N, 0> /* tag */) {
 template <class D>
 using VFromD = decltype(Zero(D()));
 
-// Returns a vector with uninitialized elements.
-template <typename T, size_t N>
-HWY_API Vec128<T, N> Undefined(Simd<T, N, 0> /*d*/) {
-  HWY_DIAGNOSTICS(push)
-  HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wuninitialized")
+HWY_DIAGNOSTICS(push)
+HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wuninitialized")
 #if HWY_COMPILER_GCC_ACTUAL
   HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wmaybe-uninitialized")
 #endif
+
+// Returns a vector with uninitialized elements.
+template <typename T, size_t N>
+HWY_API Vec128<T, N> Undefined(Simd<T, N, 0> /*d*/) {
   typename detail::Raw128<T, N>::type a;
   return Vec128<T, N>(a);
-  HWY_DIAGNOSTICS(pop)
 }
+
+HWY_DIAGNOSTICS(pop)
 
 // Returns a vector with lane i=[0, N) set to "first" + i.
 template <typename T, size_t N, typename T2>


### PR DESCRIPTION
Symptoms:

In function ‘void vst1_s32(int32_t*, int32x2_t)’,
    inlined from ‘void hwy::N_NEON::StoreU(Vec64<int>, Full64<int>, int32_t*)’ at /<<PKGBUILDDIR>>/hwy/ops/arm_neon-inl.h:2804:11,
    inlined from ‘void hwy::N_NEON::Store(Vec128<T, N>, Simd<T, kNumLanes, 0>, T*) [with T = int; unsigned int N = 2]’ at /<<PKGBUILDDIR>>/hwy/ops/arm_neon-inl.h:2891:9,
    inlined from ‘void hwy::N_NEON::TestSet::operator()(T, D) [with T = int; D = hwy::N_NEON::Simd<int, 2, 0>]’ at /<<PKGBUILDDIR>>/hwy/highway_test.cc:139:10:
/usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h:10907:27: warning: ‘a’ may be used uninitialized [-Wmaybe-uninitialized]
10907 |   __builtin_neon_vst1v2si ((__builtin_neon_si *) __a, __b);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This reverts commit dea876ece169adcebc216edb72b28519ff0d7e4e.