### PR TITLE
Remove CMake legacy code logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,13 +461,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
-
-# The gtest/gtest_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
-  include_directories("${gtest_SOURCE_DIR}/include")
-endif()
 endif()  # HWY_SYSTEM_GTEST
 
 set(HWY_TEST_FILES


### PR DESCRIPTION
hwy cmake build system requires cmake 3.10 since commit 94a72d0c