### PR TITLE
Fix missing exec_prefix variable in libhwy-test.pc

### DIFF
--- a/libhwy-test.pc.in
+++ b/libhwy-test.pc.in
@@ -1,4 +1,5 @@
 prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 


### PR DESCRIPTION
`pkg-config --list-all` otherwise fails with this error:

```
Variable 'exec_prefix' not defined in 'libhwy-test.pc'
```

Copied the `exec_prefix` definition from other `.pc` files in the repo.