### PR TITLE
neon: fix i16-based version of ReorderDemote2To

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -4666,14 +4666,14 @@ HWY_API Vec128<int16_t> ReorderDemote2To(Full128<int16_t> d16,
   return Vec128<int16_t>(vqmovn_high_s32(a16.raw, b.raw));
 #else
   const Vec64<int16_t> b16(vqmovn_s32(b.raw));
-  return Combine(d16, a16, b16);
+  return Combine(d16, b16, a16);
 #endif
 }
 
 HWY_API Vec64<int16_t> ReorderDemote2To(Full64<int16_t> /*d16*/,
                                         Vec64<int32_t> a, Vec64<int32_t> b) {
   const Full128<int32_t> d32;
-  const Vec128<int32_t> ab = Combine(d32, a, b);
+  const Vec128<int32_t> ab = Combine(d32, b, a);
   return Vec64<int16_t>(vqmovn_s32(ab.raw));
 }
 


### PR DESCRIPTION
The `hi`/`lo` arguments passed to the `Combine` operation were reversed.

This was noticed while testing the [`simd-highway`](https://github.com/kleisauke/libvips/tree/simd-highway) branch of libvips, which caused an RGB -> BRG conversion during thumbnailing on ARMv7.

Test case:
<details>
  <summary>Details</summary>

```cpp
#include <cstdint>
#include <iostream>

#undef HWY_TARGET_INCLUDE
#define HWY_TARGET_INCLUDE "/src/main.cc"
#include <hwy/foreach_target.h> // IWYU pragma: keep

// Must come after foreach_target.h to avoid redefinition errors.
#include <hwy/highway.h>
#include <hwy/print-inl.h>

HWY_BEFORE_NAMESPACE();
namespace hwy {
namespace HWY_NAMESPACE {

using namespace hwy::HWY_NAMESPACE;

void Test() {
  int32_t in1[4] = {0, 1, 2, 3};
  int32_t in2[4] = {4, 5, 6, 7};

  const ScalableTag<int32_t> di32;
  const ScalableTag<int16_t> di16;

  auto top = LoadU(di32, in1);
  auto bottom = LoadU(di32, in2);

  Print(di32, "top", top, 0, Lanes(di32));
  Print(di32, "bottom", bottom, 0, Lanes(di32));
  Print(di16, "sum", ReorderDemote2To(di16, top, bottom), 0, Lanes(di16));
}

void RunTest() {
  printf("------------------------ %s\n", TargetName(HWY_TARGET));
  Test();
}

// NOLINTNEXTLINE(google-readability-namespace-comments)
} // namespace HWY_NAMESPACE
} // namespace hwy
HWY_AFTER_NAMESPACE();

#if HWY_ONCE
namespace hwy {
HWY_EXPORT(RunTest);

void Run() {
  for (int64_t target : SupportedAndGeneratedTargets()) {
    SetSupportedTargetsForTest(target);
    HWY_DYNAMIC_DISPATCH(RunTest)();
  }
  SetSupportedTargetsForTest(0); // Reset the mask afterwards.
}

} // namespace hwy

int main(int /*argc*/, char ** /*argv*/) {
  hwy::Run();
  return 0;
}
#endif // HWY_ONCE
```
</details>

Raspberry Pi 3B - ARMv7
```bash
------------------------ NEON
i32x4 top [0+ ->]:
  0,1,2,3,
i32x4 bottom [0+ ->]:
  4,5,6,7,
i16x8 sum [0+ ->]:
  0x0004,0x0005,0x0006,0x0007,0x0000,0x0001,0x0002,0x0003,
```

Raspberry Pi 4B - AArch64
```bash
------------------------ NEON
i32x4 top [0+ ->]:
  0,1,2,3,
i32x4 bottom [0+ ->]:
  4,5,6,7,
i16x8 sum [0+ ->]:
  0x0000,0x0001,0x0002,0x0003,0x0004,0x0005,0x0006,0x0007,
```
