### PR TITLE
Don't include asm/hwcap.h

### DIFF
--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -43,7 +43,6 @@
 #endif  // HWY_COMPILER_MSVC
 
 #elif HWY_ARCH_ARM && HWY_OS_LINUX
-#include <asm/hwcap.h>
 #include <sys/auxv.h>
 #endif  // HWY_ARCH_*
 


### PR DESCRIPTION
sys/auxv.h already provides hwcap macros; on glibc, it includes asm/hwcap.h, and on musl, it includes bits/hwcap.h. manually adding asm/hwcap.h increases unnecessary dependencies and chance of conflicting definitions