### PR TITLE
Check for the presence of <sys/auxv.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,12 @@ else()
 
 endif()  # !MSVC
 
+include(CheckIncludeFile)
+check_include_file(sys/auxv.h  HAVE_SYS_AUXV_H)
+if (NOT HAVE_SYS_AUXV_H)
+  list(APPEND HWY_FLAGS -DTOOLCHAIN_MISS_SYS_AUXV_H=1)
+endif()
+
 # By default prefer STATIC build (legacy behavior)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(HWY_FORCE_STATIC_LIBS "Ignore BUILD_SHARED_LIBS" OFF)

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -393,7 +393,7 @@
 #define HWY_HAVE_RUNTIME_DISPATCH 1
 // On Arm, currently only GCC does, and we require Linux to detect CPU
 // capabilities.
-#elif HWY_ARCH_ARM && HWY_COMPILER_GCC_ACTUAL && HWY_OS_LINUX
+#elif HWY_ARCH_ARM && HWY_COMPILER_GCC_ACTUAL && HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
 #define HWY_HAVE_RUNTIME_DISPATCH 1
 #else
 #define HWY_HAVE_RUNTIME_DISPATCH 0

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -42,7 +42,7 @@
 #include <cpuid.h>
 #endif  // HWY_COMPILER_MSVC
 
-#elif HWY_ARCH_ARM && HWY_OS_LINUX
+#elif HWY_ARCH_ARM && HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
 #include <sys/auxv.h>
 #endif  // HWY_ARCH_*
 


### PR DESCRIPTION
Not all gcc versions are providing <sys/auxv.h>. Checking for HWY_ARCH_ARM && HWY_COMPILER_GCC_ACTUAL && HWY_OS_LINUX is not sufficient and fail to build in some situations (it was observed for some gcc armv7m toolchains).

This patch adds a check for <sys/auxv.h> and include it only if present.

Signed-off-by: Julien Olivain <ju.o@free.fr>