### PR TITLE
Fix Bazel build on Bazel 6.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     http_archive,
     name = "com_google_googletest",
-    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
-    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",
-    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+    urls = ["https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip"],
+    sha256 = "8daa1a71395892f7c1ec5f7cb5b099a02e606be720d62f1a6a98f8f8898ec826",
+    strip_prefix = "googletest-e2239ee6043f73722e7aa812a459f54a28552929",
 )
 
 # See https://google.github.io/googletest/quickstart-bazel.html


### PR DESCRIPTION
While trying to build the sort example (https://github.com/google/highway/tree/master/hwy/contrib/sort), it seems that the Bazel build fails with the following error:

```
ERROR: /home/wjuni/.cache/bazel/_bazel_wjuni/672b509305a448efd90e51f59e30c6de/external/bazel_tools/platforms/BUILD:89:6: in alias rule @bazel_tools//platforms:windows: Constraints from @bazel_tools//platforms have been removed. Please use constraints from @platforms repository embedded in Bazel, or preferably declare dependency on https://github.com/bazelbuild/platforms. See https://github.com/bazelbuild/bazel/issues/8622 for details.
ERROR: /home/wjuni/.cache/bazel/_bazel_wjuni/672b509305a448efd90e51f59e30c6de/external/bazel_tools/platforms/BUILD:89:6: Analysis of target '@bazel_tools//platforms:windows' failed
ERROR: /home/wjuni/.cache/bazel/_bazel_wjuni/672b509305a448efd90e51f59e30c6de/external/com_google_googletest/BUILD.bazel:116:11: errors encountered resolving select() keys for @com_google_googletest//:gtest_main
ERROR: Analysis of target '//hwy/contrib/sort:bench_sort' failed; build aborted: 
INFO: Elapsed time: 1.247s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (2 packages loaded, 0 targets configured)
```

As shown in the error message, this is due to the breaking change in Bazel 6 introduced at https://github.com/bazelbuild/bazel/issues/8622 .

It seems that highway includes GoogleTest as its dependency, and there is an issue on the GoogleTest version being used here (https://github.com/google/googletest/commit/609281088cfefc76f9d0ce82e1ff6c30cc3591e5). GoogleTest fixes this issue with the new Bazel at https://github.com/google/googletest/commit/5c08f92c881b666998a4f7852c3cf9e393bf33a7 .

I suggest bumping up the version of GoogleTest to 1.11.0 (https://github.com/google/googletest/commit/e2239ee6043f73722e7aa812a459f54a28552929) which is the minimum release version that fixes this issue.