### PR TITLE
Ensure `ReorderDemote2To` preserves order on Armv7/RVV

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -4731,14 +4731,14 @@ HWY_API Vec128<int16_t> ReorderDemote2To(Full128<int16_t> d16,
   return Vec128<int16_t>(vqmovn_high_s32(a16.raw, b.raw));
 #else
   const Vec64<int16_t> b16(vqmovn_s32(b.raw));
-  return Combine(d16, a16, b16);
+  return Combine(d16, b16, a16);
 #endif
 }
 
 HWY_API Vec64<int16_t> ReorderDemote2To(Full64<int16_t> /*d16*/,
                                         Vec64<int32_t> a, Vec64<int32_t> b) {
   const Full128<int32_t> d32;
-  const Vec128<int32_t> ab = Combine(d32, a, b);
+  const Vec128<int32_t> ab = Combine(d32, b, a);
   return Vec64<int16_t>(vqmovn_s32(ab.raw));
 }
 

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -3126,7 +3126,7 @@ template <size_t N, int kPow2, hwy::EnableIf<(kPow2 < 3)>* = nullptr,
 HWY_API VFromD<Simd<int16_t, N, kPow2>> ReorderDemote2To(
     Simd<int16_t, N, kPow2> d16, VFromD<D32> a, VFromD<D32> b) {
   const Twice<D32> d32t;
-  const VFromD<decltype(d32t)> ab = Combine(d32t, a, b);
+  const VFromD<decltype(d32t)> ab = Combine(d32t, b, a);
   return DemoteTo(d16, ab);
 }
 
@@ -3137,7 +3137,7 @@ HWY_API VFromD<Simd<int16_t, N, 3>> ReorderDemote2To(Simd<int16_t, N, 3> d16,
   const Half<decltype(d16)> d16h;
   const VFromD<decltype(d16h)> a16 = DemoteTo(d16h, a);
   const VFromD<decltype(d16h)> b16 = DemoteTo(d16h, b);
-  return Combine(d16, a16, b16);
+  return Combine(d16, b16, a16);
 }
 
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)


### PR DESCRIPTION
This is a revisited patch of PR https://github.com/google/highway/pull/1019, now that I have confirmed that the [`simd-highway`](https://github.com/kleisauke/libvips/tree/simd-highway) branch of libvips also works on SVE (tested using [this script](https://gist.github.com/kleisauke/e085c4f3a546c8fe66604bdf484ff3dd)). This PR allows me to drop commit https://github.com/kleisauke/libvips/commit/0ca6a161a01f4c5129b90fcf1197887e05f8616f. 

Note that commit 36671ddd6c27b1619a2d9d81faefbbd00b6eb947 does not always ensure that the order is preserved on RVV, it could still cause a reorder with `vlen=256` (as noticed in https://github.com/google/highway/pull/1019#issuecomment-1336407603). Let me know if you want me to omit this commit from this PR (and retitle it accordingly).

As a possible follow-up, I could document that `ReorderDemote2To` does _not_ preverse the order only when `HWY_HAVE_SCALABLE == 1` (see e.g. commit https://github.com/kleisauke/libvips/commit/fa2355f578fce92586c6e1e1f27a337d84af6ed9).