### PR TITLE
Remove explicit setting of noexecstack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,21 +306,6 @@ if(UNIX AND NOT APPLE)
     LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/hwy/hwy.version")
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "unknown")
-  # uname -p is broken on this system.  Try uname -m
-  EXECUTE_PROCESS( COMMAND uname -m
-		   OUTPUT_STRIP_TRAILING_WHITESPACE
-		   ERROR_QUIET
-		   OUTPUT_VARIABLE HWY_ARCH)
-else (CMAKE_SYSTEM_PROCESSOR MATCHES "unknown")
-  set(HWY_ARCH ${CMAKE_SYSTEM_PROCESSOR})
-endif (CMAKE_SYSTEM_PROCESSOR MATCHES "unknown")
-message(STATUS "Architecture: " ${HWY_ARCH})
-if (HWY_ARCH MATCHES "mips")
-  target_link_options(hwy PUBLIC "LINKER:-z,noexecstack")
-endif (HWY_ARCH MATCHES "mips")
-
-
 if (HWY_ENABLE_CONTRIB)
 add_library(hwy_contrib ${HWY_LIBRARY_TYPE} ${HWY_CONTRIB_SOURCES})
 target_link_libraries(hwy_contrib hwy)


### PR DESCRIPTION
This setting is set on a particular glibc shipped in current Debian release. This is intentionally done by glibc when targeting minimum kernel 4.8.0 or older with mips hardfloat:

https://github.com/bminor/glibc/blob/595c22ecd8e87a27fd19270ed30fdbae9ad25426/sysdeps/unix/sysv/linux/mips/configure.ac#L138-L143

This backwards compatibility should not be more important than the security hardening of a non-executable stack.

Full reference:
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1025436

This reverts commit 97e4b7b74b4ef4f3765e5b09572ce8c583f33c07.

Co-authored-by: Jessica Clarke <jrtc27@debian.org>