### PR TITLE
Change cmake COMPATIBILITY for major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,6 @@ endif()  # BUILD_TESTING
 
 # write HWYConfig file:
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/HWYConfigVersion.cmake" COMPATIBILITY SameMajorVersion)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/HWYConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/HWYConfigVersion.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hwy")
 install(EXPORT hwy_targets FILE HWYConfig.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hwy")


### PR DESCRIPTION
We want to make sure that `find_package(HWY 0.15.0)` actually resolve when using any of hwy 1.0.x versions.

Documentation:
* https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#generating-a-package-version-file