### PR TITLE
Added AbsDiff for integer vector types and SumsOf8AbsDiff for U8 vector types

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -356,12 +356,17 @@ time-critical code:
     <code>V **Abs**(V a)</code> returns the absolute value of `a[i]`; for
     integers, `LimitsMin()` maps to `LimitsMax() + 1`.
 
-*   `V`: `f32` \
+*   `V`: `{u,i}{8,16,32,64},f32` \
     <code>V **AbsDiff**(V a, V b)</code>: returns `|a[i] - b[i]|` in each lane.
 
 *   `V`: `u8` \
     <code>VU64 **SumsOf8**(V v)</code> returns the sums of 8 consecutive u8
     lanes, zero-extending each sum into a u64 lane. This is slower on RVV/WASM.
+
+*   `V`: `u8` \
+    <code>VU64 **SumsOf8AbsDiff**(V a, V b)</code> returns the same result as
+    `SumsOf8(AbsDiff(a, b))` but `SumsOf8AbsDiff(a, b)` is more efficient than
+    `SumsOf8(AbsDiff(a, b))` on SSSE3/SSE4/AVX2/AVX3.
 
 *   `V`: `{u,i}{8,16}` \
     <code>V **SaturatedAdd**(V a, V b)</code> returns `a[i] + b[i]` saturated to

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -1800,6 +1800,78 @@ HWY_API Vec128<float, N> AbsDiff(const Vec128<float, N> a,
   return Vec128<float, N>(vabd_f32(a.raw, b.raw));
 }
 
+#ifdef HWY_NATIVE_INTEGER_ABS_DIFF
+#undef HWY_NATIVE_INTEGER_ABS_DIFF
+#else
+#define HWY_NATIVE_INTEGER_ABS_DIFF
+#endif
+
+HWY_API Vec128<int8_t> AbsDiff(const Vec128<int8_t> a,
+                               const Vec128<int8_t> b) {
+  return Vec128<int8_t>(vabdq_s8(a.raw, b.raw));
+}
+
+HWY_API Vec128<uint8_t> AbsDiff(const Vec128<uint8_t> a,
+                                const Vec128<uint8_t> b) {
+  return Vec128<uint8_t>(vabdq_u8(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint8_t, N, 8)>
+HWY_API Vec128<int8_t, N> AbsDiff(const Vec128<int8_t, N> a,
+                                  const Vec128<int8_t, N> b) {
+  return Vec128<int8_t, N>(vabd_s8(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint8_t, N, 8)>
+HWY_API Vec128<uint8_t, N> AbsDiff(const Vec128<uint8_t, N> a,
+                                   const Vec128<uint8_t, N> b) {
+  return Vec128<uint8_t, N>(vabd_u8(a.raw, b.raw));
+}
+
+HWY_API Vec128<int16_t> AbsDiff(const Vec128<int16_t> a,
+                                const Vec128<int16_t> b) {
+  return Vec128<int16_t>(vabdq_s16(a.raw, b.raw));
+}
+
+HWY_API Vec128<uint16_t> AbsDiff(const Vec128<uint16_t> a,
+                                 const Vec128<uint16_t> b) {
+  return Vec128<uint16_t>(vabdq_u16(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint16_t, N, 8)>
+HWY_API Vec128<int16_t, N> AbsDiff(const Vec128<int16_t, N> a,
+                                   const Vec128<int16_t, N> b) {
+  return Vec128<int16_t, N>(vabd_s16(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint16_t, N, 8)>
+HWY_API Vec128<uint16_t, N> AbsDiff(const Vec128<uint16_t, N> a,
+                                    const Vec128<uint16_t, N> b) {
+  return Vec128<uint16_t, N>(vabd_u16(a.raw, b.raw));
+}
+
+HWY_API Vec128<int32_t> AbsDiff(const Vec128<int32_t> a,
+                                const Vec128<int32_t> b) {
+  return Vec128<int32_t>(vabdq_s32(a.raw, b.raw));
+}
+
+HWY_API Vec128<uint32_t> AbsDiff(const Vec128<uint32_t> a,
+                                 const Vec128<uint32_t> b) {
+  return Vec128<uint32_t>(vabdq_u32(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint32_t, N, 8)>
+HWY_API Vec128<int32_t, N> AbsDiff(const Vec128<int32_t, N> a,
+                                   const Vec128<int32_t, N> b) {
+  return Vec128<int32_t, N>(vabd_s32(a.raw, b.raw));
+}
+
+template <size_t N, HWY_IF_V_SIZE_LE(uint32_t, N, 8)>
+HWY_API Vec128<uint32_t, N> AbsDiff(const Vec128<uint32_t, N> a,
+                                    const Vec128<uint32_t, N> b) {
+  return Vec128<uint32_t, N>(vabd_u32(a.raw, b.raw));
+}
+
 // ------------------------------ Floating-point multiply-add variants
 
 // Returns add + mul * x
@@ -2073,6 +2145,20 @@ HWY_API Vec128<T, N> operator|(const Vec128<T, N> a, const Vec128<T, N> b) {
 template <typename T, size_t N>
 HWY_API Vec128<T, N> operator^(const Vec128<T, N> a, const Vec128<T, N> b) {
   return Xor(a, b);
+}
+
+// ------------------------------ I64/U64 AbsDiff
+
+template <size_t N>
+HWY_API Vec128<int64_t, N> AbsDiff(const Vec128<int64_t, N> a,
+                                   const Vec128<int64_t, N> b) {
+  return Max(a, b) - Min(a, b);
+}
+
+template <size_t N>
+HWY_API Vec128<uint64_t, N> AbsDiff(const Vec128<uint64_t, N> a,
+                                    const Vec128<uint64_t, N> b) {
+  return Or(detail::SaturatedSub(a, b), detail::SaturatedSub(b, a));
 }
 
 // ------------------------------ PopulationCount

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -569,7 +569,13 @@ HWY_SVE_FOREACH_UI08(HWY_SVE_RETV_ARGVV, SaturatedSub, qsub)
 HWY_SVE_FOREACH_UI16(HWY_SVE_RETV_ARGVV, SaturatedSub, qsub)
 
 // ------------------------------ AbsDiff
-HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGPVV, AbsDiff, abd)
+#ifdef HWY_NATIVE_INTEGER_ABS_DIFF
+#undef HWY_NATIVE_INTEGER_ABS_DIFF
+#else
+#define HWY_NATIVE_INTEGER_ABS_DIFF
+#endif
+
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGPVV, AbsDiff, abd)
 
 // ------------------------------ ShiftLeft[Same]
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -963,6 +963,37 @@ HWY_API void StoreInterleaved4(V part0, V part1, V part2, V part3, D d,
 
 #endif  // HWY_NATIVE_LOAD_STORE_INTERLEAVED
 
+// ------------------------------ Integer AbsDiff and SumsOf8AbsDiff
+
+#if (defined(HWY_NATIVE_INTEGER_ABS_DIFF) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_INTEGER_ABS_DIFF
+#undef HWY_NATIVE_INTEGER_ABS_DIFF
+#else
+#define HWY_NATIVE_INTEGER_ABS_DIFF
+#endif
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V AbsDiff(V a, V b) {
+  return Sub(Max(a, b), Min(a, b));
+}
+
+#endif  // HWY_NATIVE_INTEGER_ABS_DIFF
+
+#if (defined(HWY_NATIVE_SUMS_OF_8_ABS_DIFF) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#undef HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#else
+#define HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#endif
+
+template <class V, HWY_IF_U8_D(DFromV<V>),
+          HWY_IF_V_SIZE_GT_D(DFromV<V>, (HWY_TARGET == HWY_SCALAR ? 0 : 4))>
+HWY_API Vec<Repartition<uint64_t, DFromV<V>>> SumsOf8AbsDiff(V a, V b) {
+  return SumsOf8(AbsDiff(a, b));
+}
+
+#endif  // HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+
 // ------------------------------ AESRound
 
 // Cannot implement on scalar: need at least 16 bytes for TableLookupBytes.

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -1204,6 +1204,33 @@ HWY_API Vec128<T, N> Max(Vec128<T, N> a,
   return Vec128<T, N>{vec_max(a.raw, b.raw)};
 }
 
+// ------------------------------- Integer AbsDiff for PPC9/PPC10
+
+#if HWY_TARGET <= HWY_PPC9
+#ifdef HWY_NATIVE_INTEGER_ABS_DIFF
+#undef HWY_NATIVE_INTEGER_ABS_DIFF
+#else
+#define HWY_NATIVE_INTEGER_ABS_DIFF
+#endif
+
+template <class V, HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4))>
+HWY_API V AbsDiff(const V a, const V b) {
+  return V{vec_absd(a.raw, b.raw)};
+}
+
+template <class V, HWY_IF_U64_D(DFromV<V>)>
+HWY_API V AbsDiff(const V a, const V b) {
+  return Sub(Max(a, b), Min(a, b));
+}
+
+template <class V, HWY_IF_SIGNED_V(V)>
+HWY_API V AbsDiff(const V a, const V b) {
+  return Sub(Max(a, b), Min(a, b));
+}
+
+#endif  // HWY_TARGET <= HWY_PPC9
+
 // ================================================== MEMORY (3)
 
 // ------------------------------ Non-temporal stores

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -3089,7 +3089,7 @@ HWY_RVV_FOREACH_F(HWY_RVV_RETV_ARGV2, Abs, fsgnjx, _ALL)
 #undef HWY_RVV_RETV_ARGV2
 
 // ------------------------------ AbsDiff (Abs, Sub)
-template <class V>
+template <class V, HWY_IF_FLOAT_V(V)>
 HWY_API V AbsDiff(const V a, const V b) {
   return Abs(Sub(a, b));
 }

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -423,6 +423,7 @@ using Twice = typename D::Twice;
 #define HWY_IF_SIGNED_V(V) HWY_IF_SIGNED(TFromV<V>)
 #define HWY_IF_FLOAT_V(V) HWY_IF_FLOAT(TFromV<V>)
 #define HWY_IF_NOT_FLOAT_V(V) HWY_IF_NOT_FLOAT(TFromV<V>)
+#define HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V) HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromV<V>)
 #define HWY_IF_T_SIZE_V(V, bytes) HWY_IF_T_SIZE(TFromV<V>, bytes)
 #define HWY_IF_NOT_T_SIZE_V(V, bytes) HWY_IF_NOT_T_SIZE(TFromV<V>, bytes)
 #define HWY_IF_T_SIZE_ONE_OF_V(V, bit_array) \

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -2440,6 +2440,18 @@ HWY_API Vec128<uint64_t, N / 8> SumsOf8(const Vec128<uint8_t, N> v) {
   return Vec128<uint64_t, N / 8>{_mm_sad_epu8(v.raw, _mm_setzero_si128())};
 }
 
+#ifdef HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#undef HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#else
+#define HWY_NATIVE_SUMS_OF_8_ABS_DIFF
+#endif
+
+template <size_t N>
+HWY_API Vec128<uint64_t, N / 8> SumsOf8AbsDiff(const Vec128<uint8_t, N> a,
+                                               const Vec128<uint8_t, N> b) {
+  return Vec128<uint64_t, N / 8>{_mm_sad_epu8(a.raw, b.raw)};
+}
+
 // ------------------------------ SaturatedAdd
 
 // Returns a + b clamped to the destination range.

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -1538,6 +1538,10 @@ HWY_API Vec256<uint64_t> SumsOf8(Vec256<uint8_t> v) {
   return Vec256<uint64_t>{_mm256_sad_epu8(v.raw, _mm256_setzero_si256())};
 }
 
+HWY_API Vec256<uint64_t> SumsOf8AbsDiff(Vec256<uint8_t> a, Vec256<uint8_t> b) {
+  return Vec256<uint64_t>{_mm256_sad_epu8(a.raw, b.raw)};
+}
+
 // ------------------------------ SaturatedAdd
 
 // Returns a + b clamped to the destination range.

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -760,6 +760,11 @@ HWY_API Vec512<uint64_t> SumsOf8(const Vec512<uint8_t> v) {
   return Vec512<uint64_t>{_mm512_sad_epu8(v.raw, _mm512_setzero_si512())};
 }
 
+HWY_API Vec512<uint64_t> SumsOf8AbsDiff(const Vec512<uint8_t> a,
+                                        const Vec512<uint8_t> b) {
+  return Vec512<uint64_t>{_mm512_sad_epu8(a.raw, b.raw)};
+}
+
 // ------------------------------ SaturatedAdd
 
 // Returns a + b clamped to the destination range.


### PR DESCRIPTION
The AbsDiff operation was added for integer vector types as NEON/SVE have instructions that can compute ```|a[i] - b[i]|``` for any of the integer vector types and as PPC9/PPC10 have instructions that can compute ```|a[i] - b[i]|``` for U8/U16/U32 vectors.

The SumsOf8AbsDiff operation was also added as SSE3/SSSE4/AVX2/AVX3 can carry out the ```SumsOf8(AbsDiff(a, b))``` operation through a single psadbw/vpsadbw instruction via the ```_mm_sad_epu8```, ```_mm256_sad_epu8```, and ```_mm512_sad_epu8``` intrinsics.