### PR TITLE
Remove simple conversion warnings on ppc8/big-endian

### DIFF
--- a/hwy/tests/reduction_test.cc
+++ b/hwy/tests/reduction_test.cc
@@ -58,7 +58,7 @@ struct TestSumOfLanes {
     // Avoid setting sign bit and cap at double precision
     constexpr size_t kBits = HWY_MIN(sizeof(T) * 8 - 1, 51);
     for (size_t i = 0; i < N; ++i) {
-      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : 0;
+      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : static_cast<T>(0);
       sum += static_cast<double>(in_lanes[i]);
     }
     HWY_ASSERT_VEC_EQ(d, Set(d, T(sum)),
@@ -97,7 +97,7 @@ struct TestMinOfLanes {
     // Avoid setting sign bit and cap at double precision
     constexpr size_t kBits = HWY_MIN(sizeof(T) * 8 - 1, 51);
     for (size_t i = 0; i < N; ++i) {
-      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : 2;
+      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : static_cast<T>(2);
       min = HWY_MIN(min, in_lanes[i]);
     }
     HWY_ASSERT_VEC_EQ(d, Set(d, min), MinOfLanes(d, Load(d, in_lanes.get())));
@@ -151,7 +151,7 @@ struct TestMaxOfLanes {
     // Avoid setting sign bit and cap at double precision
     constexpr size_t kBits = HWY_MIN(sizeof(T) * 8 - 1, 51);
     for (size_t i = 0; i < N; ++i) {
-      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : 0;
+      in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : static_cast<T>(0);
       max = HWY_MAX(max, in_lanes[i]);
     }
     HWY_ASSERT_VEC_EQ(d, Set(d, max), MaxOfLanes(d, Load(d, in_lanes.get())));


### PR DESCRIPTION
Removes:

[ 86%] Building CXX object CMakeFiles/reduction_test.dir/hwy/tests/reduction_test.cc.o In file included from /home/malat/highway/hwy/foreach_target.h:70,
                 from /home/malat/highway/hwy/tests/reduction_test.cc:21:
/home/malat/highway/hwy/tests/reduction_test.cc: In instantiation of 'void hwy::N_SCALAR::TestSumOfLanes::operator()(T, D) [with T = short unsigned int; D = hwy::N_SCALAR::Simd<short unsigned int, 1, 0>]':
/home/malat/highway/hwy/tests/test_util-inl.h:184:13:   required from 'static void hwy::N_SCALAR::detail::ForeachCappedR<T, kMul, kMinArg, Test, kPow2>::Do(size_t, size_t) [with T = short unsigned int; long unsigned int kMul = 1; long unsigned int kMinArg = 1; Test = hwy::N_SCALAR::TestSumOfLanes; int kPow2 = 0; size_t = long unsigned int]'
/home/malat/highway/hwy/tests/test_util-inl.h:554:46:   required from 'void hwy::N_SCALAR::ForPartialVectors<Test>::operator()(T) const [with T = short unsigned int; Test = hwy::N_SCALAR::TestSumOfLanes]'
/home/malat/highway/hwy/tests/test_util-inl.h:611:7:   required from 'void hwy::N_SCALAR::ForUI16(const Func&) [with Func = ForPartialVectors<TestSumOfLanes>]'
/home/malat/highway/hwy/tests/reduction_test.cc:82:10:   required from here
/home/malat/highway/hwy/tests/reduction_test.cc:61:31: warning: conversion from 'int' to 'short unsigned int' may change value [-Wconversion]
   61 |       in_lanes[i] = i < kBits ? static_cast<T>(1ull << i) : 0;
      |                     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~