### PR TITLE
Added prefetch prior to store for Stream operation on AArch64

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -2993,6 +2993,13 @@ HWY_API void BlendedStore(VFromD<D> v, MFromD<D> m, D d,
 
 template <class D>
 HWY_API void Stream(const VFromD<D> v, D d, TFromD<D>* HWY_RESTRICT aligned) {
+#if HWY_ARCH_ARM_A64
+#if HWY_COMPILER_GCC
+  __builtin_prefetch(aligned, 1, 0);
+#elif HWY_COMPILER_MSVC
+  __prefetch2(aligned, 0x11);
+#endif
+#endif
   Store(v, d, aligned);
 }
 


### PR DESCRIPTION
AArch64 has support for a non-temporal prefetch for store via the ```prfm PSTL1STRM, memory_location``` instruction, and GCC/Clang/MSVC all have intrinsics for the non-temporal prefetch for store operation.

```__builtin_prefetch(aligned, 1, 0)``` is also already there before the store in the PPC8/PPC9/PPC10 implementation of the Stream operation, which compiles to a ```dcbtst``` instruction on PPC8/PPC9/PPC10.