### PR TITLE
Changed AVXVNNI to AVX512VNNI

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -381,7 +381,7 @@
 #endif
 
 // TODO(janwas): not yet known whether these will be set by MSVC
-#if HWY_BASELINE_AVX3 != 0 && defined(__AVXVNNI__) && defined(__VAES__) && \
+#if HWY_BASELINE_AVX3 != 0 && defined(__AVX512VNNI__) && defined(__VAES__) && \
     defined(__VPCLMULQDQ__) && defined(__AVX512VBMI__) &&                  \
     defined(__AVX512VBMI2__) && defined(__AVX512VPOPCNTDQ__) &&            \
     defined(__AVX512BITALG__)

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -100,7 +100,7 @@
   HWY_TARGET_STR_AVX2 ",avx512f,avx512vl,avx512dq,avx512bw"
 #define HWY_TARGET_STR_AVX3_DL                                    \
   HWY_TARGET_STR_AVX3                                             \
-  ",vpclmulqdq,avx512vbmi,avx512vbmi2,vaes,avxvnni,avx512bitalg," \
+  ",vpclmulqdq,avx512vbmi,avx512vbmi2,vaes,avx512vnni,avx512bitalg," \
   "avx512vpopcntdq"
 
 #if defined(HWY_DISABLE_PPC8_CRYPTO)


### PR DESCRIPTION
Changed defined(__AVXVNNI__) with defined(__AVX512VNNI__) in hwy/detect_targets.h, and changed avxvnni with avx512vnni in hwy/detect_targets.h.

There are also some x86 CPU's with AVX512 support that support AVX512_VNNI but not the new VEX-encoded AVX-VNNI instructions available on Alder Lake, Sapphire Rapids, and newer Intel CPU's.

Resolves issue #1174