### PR TITLE
Updated detail::CryptoTag in ppc_vsx-inl.h for Clang 16 and later

### DIFF
--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2628,7 +2628,7 @@ HWY_API Mask128<T, N> IsFinite(Vec128<T, N> v) {
 #endif
 
 namespace detail {
-#if HWY_COMPILER_CLANG
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1600
 using CipherTag = Full128<uint64_t>;
 #else
 using CipherTag = Full128<uint8_t>;


### PR DESCRIPTION
A recent change in Clang 16 and later has changed the return type and parameter types of ```vec_cipher_be``` and ```vec_cipherlast_be``` to ```__vector unsigned char```.

Updated detail::CryptoTag to reflect the changes that have been made for Clang 16 and later.