### PR TITLE
Fix compilation on PPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,10 @@ endif()  # !MSVC
 
 include(CheckIncludeFile)
 check_include_file(sys/auxv.h  HAVE_SYS_AUXV_H)
+check_include_file(asm/hwcap.h HAVE_ASM_HWCAP_H)
+if (NOT HAVE_ASM_HWCAP_H)
+  list(APPEND HWY_FLAGS -DTOOLCHAIN_MISS_ASM_HWCAP_H)
+endif()
 
 # By default prefer STATIC build (legacy behavior)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -42,12 +42,15 @@
 #include <cpuid.h>
 #endif  // HWY_COMPILER_MSVC
 
-#elif (HWY_ARCH_ARM || HWY_ARCH_PPC) && HWY_OS_LINUX && \
-      !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
+#elif (HWY_ARCH_ARM || HWY_ARCH_PPC) && HWY_OS_LINUX
 // sys/auxv.h does not always include asm/hwcap.h, or define HWCAP*, hence we
 // still include this directly. See #1199.
+#ifndef TOOLCHAIN_MISS_ASM_HWCAP_H
 #include <asm/hwcap.h>
+#endif
+#ifndef TOOLCHAIN_MISS_SYS_AUXV_H
 #include <sys/auxv.h>
+#endif
 
 #if HWY_ARCH_PPC
 #ifndef PPC_FEATURE_HAS_ALTIVEC


### PR DESCRIPTION
Fixes compilation error:

highway/hwy/targets.cc:49:10: fatal error: asm/hwcap.h: No such file or directory
   49 | #include <asm/hwcap.h>
      |          ^~~~~~~~~~~~~
compilation terminated.