### PR TITLE
cmake: Make sure to export public definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,9 +263,6 @@ endif()  # !MSVC
 
 include(CheckIncludeFile)
 check_include_file(sys/auxv.h  HAVE_SYS_AUXV_H)
-if (NOT HAVE_SYS_AUXV_H)
-  list(APPEND HWY_FLAGS -DTOOLCHAIN_MISS_SYS_AUXV_H=1)
-endif()
 
 # By default prefer STATIC build (legacy behavior)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
@@ -291,6 +288,9 @@ else()
 endif()
 
 add_library(hwy ${HWY_LIBRARY_TYPE} ${HWY_SOURCES})
+if(NOT HAVE_SYS_AUXV_H)
+  target_compile_options(hwy PUBLIC TOOLCHAIN_MISS_SYS_AUXV_H)
+endif()
 target_compile_definitions(hwy PUBLIC "${DLLEXPORT_TO_DEFINE}")
 target_compile_options(hwy PRIVATE ${HWY_FLAGS})
 set_property(TARGET hwy PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
HAVE_SYS_AUXV_H was being set in the PRIVATE definition list