### PR TITLE
Made changes to BitsFromMask implementation on big-endian PPC10 and added HWY_PPC10 to HWY_BROKEN_TARGETS on big-endian PPC

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -208,13 +208,24 @@
 #define HWY_BROKEN_RVV 0
 #endif
 
+// There are GCC/Clang compiler bugs on big-endian PPC with the -mcpu=power10
+// option if optimizations are enabled
+#if HWY_ARCH_PPC && defined(__BYTE_ORDER__) && \
+    defined(__ORDER_LITTLE_ENDIAN__) &&        \
+    __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#define HWY_BROKEN_PPC10 HWY_PPC10
+#else
+#define HWY_BROKEN_PPC10 0
+#endif
+
 // Allow the user to override this without any guarantee of success.
 #ifndef HWY_BROKEN_TARGETS
 
-#define HWY_BROKEN_TARGETS                                  \
-  (HWY_BROKEN_CLANG6 | HWY_BROKEN_32BIT | HWY_BROKEN_MSVC | \
-   HWY_BROKEN_AVX3_DL_ZEN4 | HWY_BROKEN_ARM7_BIG_ENDIAN |   \
-   HWY_BROKEN_ARM7_WITHOUT_VFP4 | HWY_BROKEN_SVE | HWY_BROKEN_RVV)
+#define HWY_BROKEN_TARGETS                                          \
+  (HWY_BROKEN_CLANG6 | HWY_BROKEN_32BIT | HWY_BROKEN_MSVC |         \
+   HWY_BROKEN_AVX3_DL_ZEN4 | HWY_BROKEN_ARM7_BIG_ENDIAN |           \
+   HWY_BROKEN_ARM7_WITHOUT_VFP4 | HWY_BROKEN_SVE | HWY_BROKEN_RVV | \
+   HWY_BROKEN_PPC10)
 
 #endif  // HWY_BROKEN_TARGETS
 

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2844,8 +2844,8 @@ struct CompressIsPartition {
 
 namespace detail {
 
-#if HWY_TARGET > HWY_PPC10  // fallback for missing vec_extractm
-
+#if HWY_TARGET > HWY_PPC10 || __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+// fallback for missing vec_extractm
 template <size_t N>
 HWY_INLINE uint64_t ExtractSignBits(Vec128<uint8_t, N> sign_bits,
                                     __vector unsigned char bit_shuffle) {
@@ -2865,7 +2865,7 @@ HWY_INLINE uint64_t BitsFromMask(hwy::SizeTag<1> /*tag*/,
   const DFromM<decltype(mask)> d;
   const Repartition<uint8_t, decltype(d)> du8;
   const VFromD<decltype(du8)> sign_bits = BitCast(du8, VecFromMask(d, mask));
-#if HWY_TARGET <= HWY_PPC10
+#if HWY_TARGET <= HWY_PPC10 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return static_cast<uint64_t>(vec_extractm(sign_bits.raw));
 #else
   const __vector unsigned char kBitShuffle = {
@@ -2882,7 +2882,7 @@ HWY_INLINE uint64_t BitsFromMask(hwy::SizeTag<2> /*tag*/,
   const Repartition<uint8_t, decltype(d)> du8;
   const VFromD<decltype(du8)> sign_bits = BitCast(du8, VecFromMask(d, mask));
 
-#if HWY_TARGET <= HWY_PPC10
+#if HWY_TARGET <= HWY_PPC10 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   const RebindToUnsigned<decltype(d)> du;
   return static_cast<uint64_t>(vec_extractm(BitCast(du, sign_bits).raw));
 #else
@@ -2903,7 +2903,7 @@ HWY_INLINE uint64_t BitsFromMask(hwy::SizeTag<4> /*tag*/,
   const DFromM<decltype(mask)> d;
   const Repartition<uint8_t, decltype(d)> du8;
   const VFromD<decltype(du8)> sign_bits = BitCast(du8, VecFromMask(d, mask));
-#if HWY_TARGET <= HWY_PPC10
+#if HWY_TARGET <= HWY_PPC10 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   const RebindToUnsigned<decltype(d)> du;
   return static_cast<uint64_t>(vec_extractm(BitCast(du, sign_bits).raw));
 #else
@@ -2924,7 +2924,7 @@ HWY_INLINE uint64_t BitsFromMask(hwy::SizeTag<8> /*tag*/,
   const DFromM<decltype(mask)> d;
   const Repartition<uint8_t, decltype(d)> du8;
   const VFromD<decltype(du8)> sign_bits = BitCast(du8, VecFromMask(d, mask));
-#if HWY_TARGET <= HWY_PPC10
+#if HWY_TARGET <= HWY_PPC10 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   const RebindToUnsigned<decltype(d)> du;
   return static_cast<uint64_t>(vec_extractm(BitCast(du, sign_bits).raw));
 #else


### PR DESCRIPTION
Some of the Highway unit tests are currently failing on big-endian PPC10 if the ```-mcpu=power10``` and ```-O3``` options are specified (at least with the ppc64 cross compiler on x86_64), but the all of the Highway unit tests pass on big-endian PPC10 if optimizations are disabled.

Also updated BitsFromMask on big-endian HWY_PPC10 to use the PPC8/PPC9 BitsFromMask implementation.