### PR TITLE
Fix compilation of hwy_benchmark on ppc32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,8 @@ target_sources(hwy_benchmark PRIVATE
 # Try adding one of -DHWY_COMPILE_ONLY_SCALAR, -DHWY_COMPILE_ONLY_EMU128 or
 # -DHWY_COMPILE_ONLY_STATIC to observe the difference in targets printed.
 target_compile_options(hwy_benchmark PRIVATE ${HWY_FLAGS})
-target_link_libraries(hwy_benchmark hwy)
+target_link_libraries(hwy_benchmark PRIVATE hwy)
+target_link_libraries(hwy_benchmark PRIVATE ${ATOMICS_LIBRARIES})
 set_target_properties(hwy_benchmark
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
 


### PR DESCRIPTION
Fixes compilation error:

/usr/bin/ld: CMakeFiles/hwy_benchmark.dir/hwy/examples/benchmark.cc.o: undefined reference to symbol '__atomic_load_8@@LIBATOMIC_1.0'
/usr/bin/ld: /usr/lib/powerpc-linux-gnu/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status