### PR TITLE
Fixed FlagsFromCPUID to only clear the AVX2/AVX3 bits on x86_64 if bit 0 of XCR0 is not set

### DIFF
--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -297,7 +297,7 @@ int64_t DetectTargets() {
       // preserved across context switches on x86_64
 
       // Only clear the AVX2/AVX3 bits on x86_64 if bit 1 of XCR0 is not set
-      bits &= min_avx2;
+      bits &= ~min_avx2;
 #else
       bits &= ~(HWY_SSE2 | HWY_SSSE3 | HWY_SSE4 | min_avx2);
 #endif


### PR DESCRIPTION
The previous version of FlagsFromCPUID failed to clear the HWY_AVX2, HWY_AVX3, HWY_AVX3_DL, and HWY_AVX3_ZEN4 bits on x86_64 if bit 1 of XCR0 is not set. This updated version will clear the HWY_AVX2, HWY_AVX3, HWY_AVX3_DL, and HWY_AVX3_ZEN4 bits on x86_64 if bit 1 of XCR0 is not set.