### PR TITLE
Added more demotion operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1059,8 +1059,11 @@ All functions except `Stream` are defined in cache_control.h.
 `DemoteTo` and float-to-int `ConvertTo` return the closest representable value
 if the input exceeds the destination range.
 
-*   `V`,`D`: (`i16,i8`), (`i32,i8`), (`i32,i16`), (`i16,u8`), (`i32,u8`),
-    (`i32,u16`), (`f64,f32`) \
+*   `V`,`D`: (`i16,i8`), (`i32,i8`), (`i64,i8`), (`i32,i16`), (`i64,i16`),
+    (`i64,i32`), (`u16,i8`), (`u32,i8`), (`u64,i8`), (`u32,i16`), (`u64,i16`),
+    (`u64,i32`), (`i16,u8`), (`i32,u8`), (`i64,u8`), (`i32,u16`), (`i64,u16`),
+    (`i64,u32`), (`u16,u8`), (`u32,u8`), (`u64,u8`), (`u32,u16`), (`u64,u16`),
+    (`u64,u32`), (`f64,f32`) \
     <code>Vec&lt;D&gt; **DemoteTo**(D, V a)</code>: returns `a[i]` after packing
     with signed/unsigned saturation to `MakeNarrow<T>`.
 
@@ -1072,11 +1075,26 @@ if the input exceeds the destination range.
     <code>Vec&lt;D&gt; **DemoteTo**(D, V a)</code>: narrows float to half (for
     bf16, it is unspecified whether this truncates or rounds).
 
-*   `D`: `{bf,i}16`, `V`: `RepartitionToWide<D>` \
+*   `V`,`D`: (`i16,i8`), (`i32,i16`), (`i64,i32`), (`u16,i8`), (`u32,i16`),
+    (`u64,i32`), (`i16,u8`), (`i32,u16`), (`i64,u32`), (`u16,u8`), (`u32,u16`),
+    (`u64,u32`), (`f32,bf16`) \
     <code>Vec&lt;D&gt; **ReorderDemote2To**(D, V a, V b)</code>: as above, but
     converts two inputs, `D` and the output have twice as many lanes as `V`, and
     the output order is some permutation of the inputs. Only available if
     `HWY_TARGET != HWY_SCALAR`.
+
+*   `V`,`D`: (`i16,i8`), (`i32,i16`), (`i64,i32`), (`u16,i8`), (`u32,i16`),
+    (`u64,i32`), (`i16,u8`), (`i32,u16`), (`i64,u32`), (`u16,u8`), (`u32,u16`),
+    (`u64,u32`), (`f32,bf16`) \
+    <code>Vec&lt;D&gt; **OrderedDemote2To**(D d, V a, V b)</code>: as above, but
+    converts two inputs, `D` and the output have twice as many lanes as `V`, and
+    the output order is the result of demoting the elements of ```a``` in the lower
+    half of the result followed by the result of demoting the elements of ```b```
+    in the upper half of the result. ```OrderedDemote2To(d, a, b)``` is equivalent
+    to ```Combine(d, DemoteTo(Half<D>(), b), DemoteTo(Half<D>(), a))```, but
+    ```OrderedDemote2To(d, a, b)``` is typically more efficient than
+    ```Combine(d, DemoteTo(Half<D>(), b), DemoteTo(Half<D>(), a))```.
+    Only available if `HWY_TARGET != HWY_SCALAR`.
 
 *   `V`,`D`: (`i32`,`f32`), (`i64`,`f64`) \
     <code>Vec&lt;D&gt; **ConvertTo**(D, V)</code>: converts an integer value to

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -3286,6 +3286,19 @@ template <class D, HWY_IF_I8_D(D)>
 HWY_API Vec64<int8_t> DemoteTo(D /* tag */, Vec128<int16_t> v) {
   return Vec64<int8_t>(vqmovn_s16(v.raw));
 }
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec64<uint16_t> DemoteTo(D /* tag */, Vec128<uint32_t> v) {
+  return Vec64<uint16_t>(vqmovn_u32(v.raw));
+}
+template <class D, HWY_IF_U8_D(D)>
+HWY_API Vec32<uint8_t> DemoteTo(D /* tag */, Vec128<uint32_t> v) {
+  const uint16x4_t a = vqmovn_u32(v.raw);
+  return Vec32<uint8_t>(vqmovn_u16(vcombine_u16(a, a)));
+}
+template <class D, HWY_IF_U8_D(D)>
+HWY_API Vec64<uint8_t> DemoteTo(D /* tag */, Vec128<uint16_t> v) {
+  return Vec64<uint8_t>(vqmovn_u16(v.raw));
+}
 
 // From half vector to partial half
 template <class D, HWY_IF_V_SIZE_LE_D(D, 4), HWY_IF_U16_D(D)>
@@ -3313,6 +3326,81 @@ HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<int32_t, D>> v) {
 template <class D, HWY_IF_V_SIZE_LE_D(D, 4), HWY_IF_I8_D(D)>
 HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<int16_t, D>> v) {
   return VFromD<D>(vqmovn_s16(vcombine_s16(v.raw, v.raw)));
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 4), HWY_IF_U16_D(D)>
+HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<uint32_t, D>> v) {
+  return VFromD<D>(vqmovn_u32(vcombine_u32(v.raw, v.raw)));
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 2), HWY_IF_U8_D(D)>
+HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<uint32_t, D>> v) {
+  const uint16x4_t a = vqmovn_u32(vcombine_u32(v.raw, v.raw));
+  return VFromD<D>(vqmovn_u16(vcombine_u16(a, a)));
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 4), HWY_IF_U8_D(D)>
+HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<uint16_t, D>> v) {
+  return VFromD<D>(vqmovn_u16(vcombine_u16(v.raw, v.raw)));
+}
+
+template <class D, HWY_IF_I32_D(D)>
+HWY_API Vec64<int32_t> DemoteTo(D /* tag */, Vec128<int64_t> v) {
+  return Vec64<int32_t>(vqmovn_s64(v.raw));
+}
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<int64_t> v) {
+return Vec64<uint32_t>(vqmovun_s64(v.raw));
+}
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<uint64_t> v) {
+  return Vec64<uint32_t>(vqmovn_u64(v.raw));
+}
+template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+                  HWY_IF_SIGNED_D(D)>
+HWY_API VFromD<D> DemoteTo(D d, Vec128<uint64_t> v) {
+  const Rebind<int32_t, D> di32;
+  return DemoteTo(d, DemoteTo(di32, v));
+}
+template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+                  HWY_IF_UNSIGNED_D(D)>
+HWY_API VFromD<D> DemoteTo(D d, Vec128<int64_t> v) {
+  const Rebind<uint32_t, D> du32;
+  return DemoteTo(d, DemoteTo(du32, v));
+}
+template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+                  HWY_IF_UNSIGNED_D(D)>
+HWY_API VFromD<D> DemoteTo(D d, Vec128<uint64_t> v) {
+  const Rebind<uint32_t, D> du32;
+  return DemoteTo(d, DemoteTo(du32, v));
+}
+
+template <class D, HWY_IF_I32_D(D)>
+HWY_API Vec32<int32_t> DemoteTo(D /* tag */, Vec64<int64_t> v) {
+  return Vec32<int32_t>(vqmovn_s64(vcombine_s64(v.raw, v.raw)));
+}
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<int64_t> v) {
+return Vec32<uint32_t>(vqmovun_s64(vcombine_s64(v.raw, v.raw)));
+}
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<uint64_t> v) {
+  return Vec32<uint32_t>(vqmovn_u64(vcombine_u64(v.raw, v.raw)));
+}
+template<class D, HWY_IF_SIGNED_D(D),
+                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> DemoteTo(D d, Vec64<int64_t> v) {
+  const Rebind<int32_t, D> di32;
+  return DemoteTo(d, DemoteTo(di32, v));
+}
+template<class D, HWY_IF_UNSIGNED_D(D),
+                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> DemoteTo(D d, Vec64<int64_t> v) {
+  const Rebind<uint32_t, D> du32;
+  return DemoteTo(d, DemoteTo(du32, v));
+}
+template<class D, HWY_IF_LANES_D(D, 1), HWY_IF_UNSIGNED_D(D),
+                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> DemoteTo(D d, Vec64<uint64_t> v) {
+  const Rebind<uint32_t, D> du32;
+  return DemoteTo(d, DemoteTo(du32, v));
 }
 
 #if __ARM_FP & 2
@@ -4783,9 +4871,67 @@ template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_BF16_D(D),
           class V32 = VFromD<Repartition<float, D>>>
 HWY_API VFromD<D> ReorderDemote2To(D dbf16, V32 a, V32 b) {
   const RebindToUnsigned<decltype(dbf16)> du16;
-  const Repartition<uint32_t, decltype(dbf16)> du32;
-  const VFromD<decltype(du32)> b_in_even = ShiftRight<16>(BitCast(du32, b));
-  return BitCast(dbf16, OddEven(BitCast(du16, a), BitCast(du16, b_in_even)));
+  return BitCast(dbf16, ConcatOdd(du16, BitCast(du16, b), BitCast(du16, a)));
+}
+
+template <class D, HWY_IF_I32_D(D)>
+HWY_API Vec128<int32_t> ReorderDemote2To(D d32, Vec128<int64_t> a,
+                                        Vec128<int64_t> b) {
+  const Vec64<int32_t> a32(vqmovn_s64(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d32;
+  return Vec128<int32_t>(vqmovn_high_s64(a32.raw, b.raw));
+#else
+  const Vec64<int32_t> b32(vqmovn_s64(b.raw));
+  return Combine(d32, b32, a32);
+#endif
+}
+
+template <class D, HWY_IF_I32_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d32, VFromD<Repartition<int64_t, D>> a,
+                                   VFromD<Repartition<int64_t, D>> b) {
+  const Rebind<int64_t, decltype(d32)> dt;
+  return DemoteTo(d32, Combine(dt, b, a));
+}
+
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec128<uint32_t> ReorderDemote2To(D d32, Vec128<int64_t> a,
+                                         Vec128<int64_t> b) {
+  const Vec64<uint32_t> a32(vqmovun_s64(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d32;
+  return Vec128<uint32_t>(vqmovun_high_s64(a32.raw, b.raw));
+#else
+  const Vec64<uint32_t> b32(vqmovun_s64(b.raw));
+  return Combine(d32, b32, a32);
+#endif
+}
+
+template <class D, HWY_IF_U32_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d32, VFromD<Repartition<int64_t, D>> a,
+                                   VFromD<Repartition<int64_t, D>> b) {
+  const Rebind<int64_t, decltype(d32)> dt;
+  return DemoteTo(d32, Combine(dt, b, a));
+}
+
+template <class D, HWY_IF_U32_D(D)>
+HWY_API Vec128<uint32_t> ReorderDemote2To(D d32, Vec128<uint64_t> a,
+                                         Vec128<uint64_t> b) {
+  const Vec64<uint32_t> a32(vqmovn_u64(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d32;
+  return Vec128<uint32_t>(vqmovn_high_u64(a32.raw, b.raw));
+#else
+  const Vec64<uint32_t> b32(vqmovn_u64(b.raw));
+  return Combine(d32, b32, a32);
+#endif
+}
+
+template <class D, HWY_IF_U32_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d32, VFromD<Repartition<uint64_t, D>> a,
+                                   VFromD<Repartition<uint64_t, D>> b) {
+  const Rebind<uint64_t, decltype(d32)> dt;
+  return DemoteTo(d32, Combine(dt, b, a));
 }
 
 template <class D, HWY_IF_I16_D(D)>
@@ -4815,6 +4961,137 @@ HWY_API Vec32<int16_t> ReorderDemote2To(D /*d16*/, Vec32<int32_t> a,
   const Full128<int32_t> d32;
   const Vec64<int32_t> ab(vzip1_s32(a.raw, b.raw));
   return Vec32<int16_t>(vqmovn_s32(Combine(d32, ab, ab).raw));
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec128<uint16_t> ReorderDemote2To(D d16, Vec128<int32_t> a,
+                                          Vec128<int32_t> b) {
+  const Vec64<uint16_t> a16(vqmovun_s32(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d16;
+  return Vec128<uint16_t>(vqmovun_high_s32(a16.raw, b.raw));
+#else
+  const Vec64<uint16_t> b16(vqmovun_s32(b.raw));
+  return Combine(d16, b16, a16);
+#endif
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec64<uint16_t> ReorderDemote2To(D /*d16*/, Vec64<int32_t> a,
+                                         Vec64<int32_t> b) {
+  const Full128<int32_t> d32;
+  const Vec128<int32_t> ab = Combine(d32, b, a);
+  return Vec64<uint16_t>(vqmovun_s32(ab.raw));
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec32<uint16_t> ReorderDemote2To(D /*d16*/, Vec32<int32_t> a,
+                                         Vec32<int32_t> b) {
+  const Full128<int32_t> d32;
+  const Vec64<int32_t> ab(vzip1_s32(a.raw, b.raw));
+  return Vec32<uint16_t>(vqmovun_s32(Combine(d32, ab, ab).raw));
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec128<uint16_t> ReorderDemote2To(D d16, Vec128<uint32_t> a,
+                                          Vec128<uint32_t> b) {
+  const Vec64<uint16_t> a16(vqmovn_u32(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d16;
+  return Vec128<uint16_t>(vqmovn_high_u32(a16.raw, b.raw));
+#else
+  const Vec64<uint16_t> b16(vqmovn_u32(b.raw));
+  return Combine(d16, b16, a16);
+#endif
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec64<uint16_t> ReorderDemote2To(D /*d16*/, Vec64<uint32_t> a,
+                                         Vec64<uint32_t> b) {
+  const Full128<uint32_t> d32;
+  const Vec128<uint32_t> ab = Combine(d32, b, a);
+  return Vec64<uint16_t>(vqmovn_u32(ab.raw));
+}
+
+template <class D, HWY_IF_U16_D(D)>
+HWY_API Vec32<uint16_t> ReorderDemote2To(D /*d16*/, Vec32<uint32_t> a,
+                                         Vec32<uint32_t> b) {
+  const Full128<uint32_t> d32;
+  const Vec64<uint32_t> ab(vzip1_u32(a.raw, b.raw));
+  return Vec32<uint16_t>(vqmovn_u32(Combine(d32, ab, ab).raw));
+}
+
+template <class D, HWY_IF_I8_D(D)>
+HWY_API Vec128<int8_t> ReorderDemote2To(D d8, Vec128<int16_t> a,
+                                        Vec128<int16_t> b) {
+  const Vec64<int8_t> a8(vqmovn_s16(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d8;
+  return Vec128<int8_t>(vqmovn_high_s16(a8.raw, b.raw));
+#else
+  const Vec64<int8_t> b8(vqmovn_s16(b.raw));
+  return Combine(d8, b8, a8);
+#endif
+}
+
+template <class D, HWY_IF_I8_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d8, VFromD<Repartition<int16_t, D>> a,
+                                   VFromD<Repartition<int16_t, D>> b) {
+  const Rebind<int16_t, decltype(d8)> dt;
+  return DemoteTo(d8, Combine(dt, b, a));
+}
+
+template <class D, HWY_IF_U8_D(D)>
+HWY_API Vec128<uint8_t> ReorderDemote2To(D d8, Vec128<int16_t> a,
+                                         Vec128<int16_t> b) {
+  const Vec64<uint8_t> a8(vqmovun_s16(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d8;
+  return Vec128<uint8_t>(vqmovun_high_s16(a8.raw, b.raw));
+#else
+  const Vec64<uint8_t> b8(vqmovun_s16(b.raw));
+  return Combine(d8, b8, a8);
+#endif
+}
+
+template <class D, HWY_IF_U8_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d8, VFromD<Repartition<int16_t, D>> a,
+                                   VFromD<Repartition<int16_t, D>> b) {
+  const Rebind<int16_t, decltype(d8)> dt;
+  return DemoteTo(d8, Combine(dt, b, a));
+}
+
+template <class D, HWY_IF_U8_D(D)>
+HWY_API Vec128<uint8_t> ReorderDemote2To(D d8, Vec128<uint16_t> a,
+                                         Vec128<uint16_t> b) {
+  const Vec64<uint8_t> a8(vqmovn_u16(a.raw));
+#if HWY_ARCH_ARM_A64
+  (void)d8;
+  return Vec128<uint8_t>(vqmovn_high_u16(a8.raw, b.raw));
+#else
+  const Vec64<uint8_t> b8(vqmovn_u16(b.raw));
+  return Combine(d8, b8, a8);
+#endif
+}
+
+template <class D, HWY_IF_U8_D(D), HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ReorderDemote2To(D d8, VFromD<Repartition<uint16_t, D>> a,
+                                   VFromD<Repartition<uint16_t, D>> b) {
+  const Rebind<uint16_t, decltype(d8)> dt;
+  return DemoteTo(d8, Combine(dt, b, a));
+}
+
+template <class D, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromD<D>),
+          HWY_IF_LANES_D(D, HWY_MAX_LANES_D(DFromV<V>) * 2)>
+HWY_API VFromD<D> OrderedDemote2To(D d, V a, V b) {
+  return ReorderDemote2To(d, a, b);
+}
+
+template <class D, HWY_IF_BF16_D(D),
+          class V32 = VFromD<Repartition<float, D>>>
+HWY_API VFromD<D> OrderedDemote2To(D dbf16, V32 a, V32 b) {
+  return ReorderDemote2To(dbf16, a, b);
 }
 
 // ================================================== CRYPTO

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1433,13 +1433,27 @@ HWY_API Vec256<bfloat16_t> ReorderDemote2To(DBF16 dbf16, Vec256<float> a,
   return BitCast(dbf16, ConcatOdd(du16, BitCast(du16, b), BitCast(du16, a)));
 }
 
-template <class DI16, HWY_IF_I16_D(DI16)>
-HWY_API Vec256<int16_t> ReorderDemote2To(DI16 d16, Vec256<int32_t> a,
-                                         Vec256<int32_t> b) {
-  const Half<decltype(d16)> d16h;
-  Vec256<int16_t> demoted;
-  demoted.v0 = DemoteTo(d16h, a);
-  demoted.v1 = DemoteTo(d16h, b);
+template <class DN, typename V, HWY_IF_V_SIZE_D(DN, 32),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromD<DN>), HWY_IF_SIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_D(DN, (1 << 1) | (1 << 2) | (1 << 4)),
+          HWY_IF_T_SIZE_V(V, sizeof(TFromD<DN>) * 2)>
+HWY_API VFromD<DN> ReorderDemote2To(DN dn, V a, V b) {
+  const Half<decltype(dn)> dnh;
+  VFromD<DN> demoted;
+  demoted.v0 = DemoteTo(dnh, a);
+  demoted.v1 = DemoteTo(dnh, b);
+  return demoted;
+}
+
+template <class DN, typename V, HWY_IF_V_SIZE_D(DN, 32),
+          HWY_IF_UNSIGNED_D(DN), HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_D(DN, (1 << 1) | (1 << 2) | (1 << 4)),
+          HWY_IF_T_SIZE_V(V, sizeof(TFromD<DN>) * 2)>
+HWY_API VFromD<DN> ReorderDemote2To(DN dn, V a, V b) {
+  const Half<decltype(dn)> dnh;
+  VFromD<DN> demoted;
+  demoted.v0 = DemoteTo(dnh, a);
+  demoted.v1 = DemoteTo(dnh, b);
   return demoted;
 }
 

--- a/hwy/tests/demote_test.cc
+++ b/hwy/tests/demote_test.cc
@@ -54,22 +54,30 @@ struct TestDemoteTo {
     auto expected = AllocateAligned<ToT>(N);
 
     // Narrower range in the wider type, for clamping before we cast
-    const T min = LimitsMin<ToT>();
+    const T min = static_cast<T>(IsSigned<T>() ? LimitsMin<ToT>() : ToT{0});
     const T max = LimitsMax<ToT>();
-
-    const auto value_ok = [&](T& value) {
-      if (!IsFiniteT(value)) return false;
-      return true;
-    };
 
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
       for (size_t i = 0; i < N; ++i) {
-        do {
-          const uint64_t bits = rng();
-          CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
-        } while (!value_ok(from[i]));
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
         expected[i] = static_cast<ToT>(HWY_MIN(HWY_MAX(min, from[i]), max));
+      }
+
+      const auto in = Load(from_d, from.get());
+      HWY_ASSERT_VEC_EQ(to_d, expected.get(), DemoteTo(to_d, in));
+    }
+
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(ToT)>(&bits, &expected[i]);  // not same size
+
+        if(!IsSigned<T>() && IsSigned<ToT>())
+          expected[i] &= static_cast<ToT>(max);
+
+        from[i] = static_cast<T>(expected[i]);
       }
 
       const auto in = Load(from_d, from.get());
@@ -79,17 +87,73 @@ struct TestDemoteTo {
 };
 
 HWY_NOINLINE void TestAllDemoteToInt() {
-  ForDemoteVectors<TestDemoteTo<uint8_t>>()(int16_t());
-  ForDemoteVectors<TestDemoteTo<uint8_t>, 2>()(int32_t());
+  const ForDemoteVectors<TestDemoteTo<uint8_t>> from_i16_to_u8;
+  from_i16_to_u8(int16_t());
+  from_i16_to_u8(uint16_t());
 
-  ForDemoteVectors<TestDemoteTo<int8_t>>()(int16_t());
-  ForDemoteVectors<TestDemoteTo<int8_t>, 2>()(int32_t());
+  const ForDemoteVectors<TestDemoteTo<int8_t>> from_i16_to_i8;
+  from_i16_to_i8(int16_t());
+  from_i16_to_i8(uint16_t());
 
-  const ForDemoteVectors<TestDemoteTo<uint16_t>> to_u16;
-  to_u16(int32_t());
+  const ForDemoteVectors<TestDemoteTo<uint8_t>, 2> from_i32_to_u8;
+  from_i32_to_u8(int32_t());
+  from_i32_to_u8(uint32_t());
 
-  const ForDemoteVectors<TestDemoteTo<int16_t>> to_i16;
-  to_i16(int32_t());
+  const ForDemoteVectors<TestDemoteTo<int8_t>, 2> from_i32_to_i8;
+  from_i32_to_i8(int32_t());
+  from_i32_to_i8(uint32_t());
+
+#if HWY_HAVE_INTEGER64
+#if HWY_HAVE_SCALABLE
+  const ForDemoteVectors<TestDemoteTo<uint8_t>> from_i64_to_u8;
+#else
+  const ForDemoteVectors<TestDemoteTo<uint8_t>, 3> from_i64_to_u8;
+#endif
+  from_i64_to_u8(int64_t());
+  from_i64_to_u8(uint64_t());
+
+#if HWY_HAVE_SCALABLE
+  const ForDemoteVectors<TestDemoteTo<int8_t>> from_i64_to_i8;
+#else
+  const ForDemoteVectors<TestDemoteTo<int8_t>, 3> from_i64_to_i8;
+#endif
+  from_i64_to_i8(int64_t());
+  from_i64_to_i8(uint64_t());
+#endif
+
+  const ForDemoteVectors<TestDemoteTo<uint16_t>> from_i32_to_u16;
+  from_i32_to_u16(int32_t());
+  from_i32_to_u16(uint32_t());
+
+  const ForDemoteVectors<TestDemoteTo<int16_t>> from_i32_to_i16;
+  from_i32_to_i16(int32_t());
+  from_i32_to_i16(uint32_t());
+
+#if HWY_HAVE_INTEGER64
+#if HWY_HAVE_SCALABLE
+  const ForDemoteVectors<TestDemoteTo<uint16_t>> from_i64_to_u16;
+#else
+  const ForDemoteVectors<TestDemoteTo<uint16_t>, 2> from_i64_to_u16;
+#endif
+  from_i64_to_u16(int64_t());
+  from_i64_to_u16(uint64_t());
+
+#if HWY_HAVE_SCALABLE
+  const ForDemoteVectors<TestDemoteTo<int16_t>> from_i64_to_i16;
+#else
+  const ForDemoteVectors<TestDemoteTo<int16_t>, 2> from_i64_to_i16;
+#endif
+  from_i64_to_i16(int64_t());
+  from_i64_to_i16(uint64_t());
+
+  const ForDemoteVectors<TestDemoteTo<uint32_t>> from_i64_to_u32;
+  from_i64_to_u32(int64_t());
+  from_i64_to_u32(uint64_t());
+
+  const ForDemoteVectors<TestDemoteTo<int32_t>> from_i64_to_i32;
+  from_i64_to_i32(int64_t());
+  from_i64_to_i32(uint64_t());
+#endif
 }
 
 HWY_NOINLINE void TestAllDemoteToMixed() {
@@ -140,6 +204,74 @@ HWY_NOINLINE void TestAllDemoteToFloat() {
   const ForDemoteVectors<TestDemoteToFloat<float>, 1> to_float;
   to_float(double());
 #endif
+}
+
+struct TestDemoteToBF16 {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
+    // For floats, we clamp differently and cannot call LimitsMin.
+    static_assert(IsSame<T, float>(),
+                  "TestDemoteToBF16 can only be called if T is float");
+    const Rebind<bfloat16_t, D> to_d;
+    const Rebind<uint32_t, D> du32;
+    const Rebind<uint16_t, D> du16;
+
+    const size_t N = Lanes(from_d);
+    auto from = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<bfloat16_t>(N);
+
+    const auto u16_zero_vect = Zero(du16);
+    const auto u16_one_vect = Set(du16, 1);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        do {
+          const uint64_t bits = rng();
+          CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        } while (!IsFiniteT(from[i]));
+
+        uint32_t fromBits;
+        CopyBytes<sizeof(uint32_t)>(&from[i], &fromBits);
+
+        uint16_t bf16Bits = static_cast<uint16_t>(fromBits >> 16);
+        CopyBytes<sizeof(uint16_t)>(&bf16Bits, &expected[i]);
+      }
+
+      const auto in = Load(from_d, from.get());
+      const auto actual = DemoteTo(to_d, in);
+
+      // Adjust expected to account for any possible rounding that was
+      // carried out by the DemoteTo operation
+      auto expected_vect = BitCast(du16, Load(to_d, expected.get()));
+
+      const auto low_f32_bits = TruncateTo(du16, BitCast(du32, in));
+
+      // max_diff_from_expected is equal to (low_f32_bits == 0 ? 0 : 1)
+      const auto max_diff_from_expected =
+        Add(VecFromMask(du16, Eq(low_f32_bits, u16_zero_vect)), u16_one_vect);
+
+      // expected_adj is equal to
+      // (actual_bits - expected_bits == 1 && max_diff_from_expected != 0) ? 1 : 0,
+      // where actual_bits is the bits of actual and expected_bits is the bits of
+      // expected
+      auto expected_adj = And(max_diff_from_expected,
+        VecFromMask(du16, Eq(Sub(BitCast(du16, actual), expected_vect), u16_one_vect)));
+
+      // Increment expected_vect by expected_adj
+      expected_vect = Add(expected_vect, expected_adj);
+
+      // Store the adjusted expected_vect back into expected
+      Store(BitCast(to_d, expected_vect), to_d, expected.get());
+
+      HWY_ASSERT_VEC_EQ(to_d, expected.get(), actual);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllDemoteToBF16() {
+  const ForDemoteVectors<TestDemoteToBF16, 1> to_bf16;
+  to_bf16(float());
 }
 
 template <class D>
@@ -257,8 +389,249 @@ class TestReorderDemote2To {
   }
 };
 
+class TestIntegerReorderDemote2To {
+#if HWY_TARGET != HWY_SCALAR
+private:
+  // In-place N^2 selection sort to avoid dependencies
+  template<class T>
+  static void Sort(T* p, size_t count) {
+    for (size_t i = 0; i < count - 1; ++i) {
+      // Find min_element
+      size_t idx_min = i;
+      for (size_t j = i + 1; j < count; j++) {
+        if (p[j] < p[idx_min]) {
+          idx_min = j;
+        }
+      }
+
+      // Swap with current
+      const T tmp = p[i];
+      p[i] = p[idx_min];
+      p[idx_min] = tmp;
+    }
+  }
+
+  template<class T, class D, class DN>
+  static void DoIntegerReorderDemote2ToTest(DN dn, T /* t */, D d) {
+    using TN = TFromD<DN>;
+
+    const size_t N = Lanes(d);
+    const size_t twiceN = N * 2;
+    auto from = AllocateAligned<T>(twiceN);
+    auto expected = AllocateAligned<TN>(twiceN);
+    auto actual = AllocateAligned<TN>(twiceN);
+
+    // Narrower range in the wider type, for clamping before we cast
+    const T min = static_cast<T>(IsSigned<T>() ? LimitsMin<TN>() : TN{0});
+    const T max = LimitsMax<TN>();
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        expected[i] = static_cast<TN>(HWY_MIN(HWY_MAX(min, from[i]), max));
+      }
+
+      const auto in_1 = Load(d, from.get());
+      const auto in_2 = Load(d, from.get() + N);
+      const auto demoted_vect = ReorderDemote2To(dn, in_1, in_2);
+      Store(demoted_vect, dn, actual.get());
+      Sort(actual.get(), twiceN);
+      Sort(expected.get(), twiceN);
+      HWY_ASSERT_VEC_EQ(dn, expected.get(), Load(dn, actual.get()));
+    }
+
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(TN)>(&bits, &expected[i]);  // not same size
+        if(!IsSigned<T>() && IsSigned<TN>())
+          expected[i] &= static_cast<TN>(max);
+
+        from[i] = static_cast<T>(expected[i]);
+      }
+
+      const auto in_1 = Load(d, from.get());
+      const auto in_2 = Load(d, from.get() + N);
+      const auto demoted_vect = ReorderDemote2To(dn, in_1, in_2);
+      Store(demoted_vect, dn, actual.get());
+      Sort(actual.get(), twiceN);
+      Sort(expected.get(), twiceN);
+      HWY_ASSERT_VEC_EQ(dn, expected.get(), Load(dn, actual.get()));
+    }
+  }
+#endif
+public:
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*t*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const RepartitionToNarrow<D> dn;
+    const RebindToSigned<decltype(dn)> dn_i;
+    const RebindToUnsigned<decltype(dn)> dn_u;
+
+    DoIntegerReorderDemote2ToTest(dn_i, T(), d);
+    DoIntegerReorderDemote2ToTest(dn_u, T(), d);
+#else
+    (void)d;
+#endif
+  }
+};
+
 HWY_NOINLINE void TestAllReorderDemote2To() {
   ForShrinkableVectors<TestReorderDemote2To>()(float());
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(int16_t());
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(uint16_t());
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(int32_t());
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(uint32_t());
+#if HWY_HAVE_INTEGER64
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(int64_t());
+  ForShrinkableVectors<TestIntegerReorderDemote2To>()(uint64_t());
+#endif
+}
+
+struct TestFloatOrderedDemote2To {
+  template <typename TF, class DF>
+  HWY_NOINLINE void operator()(TF /*t*/, DF df) {
+#if HWY_TARGET != HWY_SCALAR
+    const Repartition<bfloat16_t, decltype(df)> dbf16;
+    const RebindToUnsigned<decltype(dbf16)> du16;
+    const RebindToUnsigned<decltype(df)> du32;
+    const Half<decltype(du16)> du16_half;
+    const size_t N = Lanes(df);
+    const size_t twiceN = N * 2;
+    auto from = AllocateAligned<TF>(twiceN);
+    auto expected = AllocateAligned<bfloat16_t>(twiceN);
+
+    const auto u16_zero_vect = Zero(du16);
+    const auto u16_one_vect = Set(du16, 1);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        do {
+          const uint64_t bits = rng();
+          CopyBytes<sizeof(TF)>(&bits, &from[i]);  // not same size
+        } while(!IsFiniteT(from[i]));
+
+        uint32_t u32Bits;
+        CopyBytes<sizeof(uint32_t)>(&from[i], &u32Bits);
+
+        const uint16_t expected_bf16_bits =
+          static_cast<uint16_t>(u32Bits >> 16);
+
+        CopyBytes<sizeof(bfloat16_t)>(&expected_bf16_bits, &expected[i]);
+      }
+
+      const auto in_1 = Load(df, from.get());
+      const auto in_2 = Load(df, from.get() + N);
+      const auto actual = OrderedDemote2To(dbf16, in_1, in_2);
+
+      // Adjust expected to account for any possible rounding that was
+      // carried out by the OrderedDemote2To operation
+      auto expected_vect = BitCast(du16, Load(dbf16, expected.get()));
+
+      const auto low_f32_bits =
+        Combine(du16, TruncateTo(du16_half, BitCast(du32, in_2)),
+                      TruncateTo(du16_half, BitCast(du32, in_1)));
+      // max_diff_from_expected is equal to (low_f32_bits == 0 ? 0 : 1)
+      const auto max_diff_from_expected =
+        Add(VecFromMask(du16, Eq(low_f32_bits, u16_zero_vect)), u16_one_vect);
+
+      // expected_adj is equal to
+      // (actual_bits - expected_bits == 1 && max_diff_from_expected != 0) ? 1 : 0,
+      // where actual_bits is the bits of actual and expected_bits is the bits of
+      // expected
+      auto expected_adj = And(max_diff_from_expected,
+        VecFromMask(du16, Eq(Sub(BitCast(du16, actual), expected_vect), u16_one_vect)));
+
+      // Increment expected_vect by expected_adj
+      expected_vect = Add(expected_vect, expected_adj);
+
+      // Store the adjusted expected_vect back into expected
+      Store(BitCast(dbf16, expected_vect), dbf16, expected.get());
+
+      HWY_ASSERT_VEC_EQ(dbf16, expected.get(), actual);
+    }
+#else
+    (void)df;
+#endif
+  }
+};
+
+class TestIntegerOrderedDemote2To {
+#if HWY_TARGET != HWY_SCALAR
+private:
+  template<class T, class D, class DN>
+  static void DoIntegerOrderedDemote2ToTest(DN dn, T /*t*/, D d) {
+    using TN = TFromD<DN>;
+
+    const size_t N = Lanes(d);
+    const size_t twiceN = N * 2;
+    auto from = AllocateAligned<T>(twiceN);
+    auto expected = AllocateAligned<TN>(twiceN);
+
+    // Narrower range in the wider type, for clamping before we cast
+    const T min = static_cast<T>(IsSigned<T>() ? LimitsMin<TN>() : TN{0});
+    const T max = LimitsMax<TN>();
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        expected[i] = static_cast<TN>(HWY_MIN(HWY_MAX(min, from[i]), max));
+      }
+
+      const auto in_1 = Load(d, from.get());
+      const auto in_2 = Load(d, from.get() + N);
+      const auto actual = OrderedDemote2To(dn, in_1, in_2);
+      HWY_ASSERT_VEC_EQ(dn, expected.get(), actual);
+    }
+
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(TN)>(&bits, &expected[i]);  // not same size
+        if(!IsSigned<T>() && IsSigned<TN>())
+          expected[i] &= static_cast<TN>(max);
+
+        from[i] = static_cast<T>(expected[i]);
+      }
+
+      const auto in_1 = Load(d, from.get());
+      const auto in_2 = Load(d, from.get() + N);
+      const auto actual = OrderedDemote2To(dn, in_1, in_2);
+      HWY_ASSERT_VEC_EQ(dn, expected.get(), actual);
+    }
+  }
+#endif
+public:
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*t*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const RepartitionToNarrow<D> dn;
+    const RebindToSigned<decltype(dn)> dn_i;
+    const RebindToUnsigned<decltype(dn)> dn_u;
+
+    DoIntegerOrderedDemote2ToTest(dn_i, T(), d);
+    DoIntegerOrderedDemote2ToTest(dn_u, T(), d);
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllOrderedDemote2To() {
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(int16_t());
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(uint16_t());
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(int32_t());
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(uint32_t());
+#if HWY_HAVE_INTEGER64
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(int64_t());
+  ForShrinkableVectors<TestIntegerOrderedDemote2To>()(uint64_t());
+#endif
+  ForShrinkableVectors<TestFloatOrderedDemote2To>()(float());
 }
 
 struct TestI32F64 {
@@ -320,7 +693,9 @@ HWY_BEFORE_TEST(HwyDemoteTest);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToInt);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToMixed);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToFloat);
+HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToBF16);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllReorderDemote2To);
+HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllOrderedDemote2To);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllI32F64);
 #endif  //  !HWY_IS_MSAN
 }  // namespace hwy


### PR DESCRIPTION
Added the following new demotion operations:
- DemoteTo from unsigned integer types to signed integer types
- DemoteTo from unsigned integer types to unsigned integer types
- ReorderDemote2To for {i,u}16->{i,u}8, i32->u16, u32->{u,i}16, and {i,u}64->{i,u}32
- OrderedDemote2To for {i,u}16->{i,u}8, {i,u}32->{u,i}16, {i,u}64->{i,u}32, and f32->bf16

Resolves issue #1124
