### PR TITLE
Added LeadingZeroCount and a few more new operations plus bug fixes

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -585,6 +585,25 @@ Per-lane variable shifts (slow if SSSE3/SSE4, or 16-bit, or Shr i64 on AVX2):
     <code>V **PopulationCount**(V a)</code>: returns the number of 1-bits in
     each lane, i.e. `PopCount(a[i])`.
 
+*   `V`: `{u,i}` \
+    <code>V **LeadingZeroCount**(V a)</code>: returns the number of
+    leading zeros in each lane. For any lanes where ```a[i]``` is zero,
+    ```sizeof(TFromV<V>) * 8``` is returned in the corresponding result lanes.
+
+*   `V`: `{u,i}` \
+    <code>V **TrailingZeroCount**(V a)</code>: returns the number of
+    trailing zeros in each lane. For any lanes where ```a[i]``` is zero,
+    ```sizeof(TFromV<V>) * 8``` is returned in the corresponding result lanes.
+
+*   `V`: `{u,i}` \
+    <code>V **HighestSetBitIndex**(V a)</code>: returns the index of
+    the highest set bit of each lane. For any lanes of a signed vector type
+    where ```a[i]``` is zero, an unspecified negative value is returned in the
+    corresponding result lanes. For any lanes of an unsigned vector type
+    where ```a[i]``` is zero, an unspecified value that is greater than
+    ```HighestValue<MakeSigned<TFromV<V>>>()``` is returned in the
+    corresponding result lanes.
+
 The following operate on individual bits within each lane. Note that the
 non-operator functions (`And` instead of `&`) must be used for floating-point
 types, and on SVE/RVV.
@@ -1094,6 +1113,17 @@ if the input exceeds the destination range.
     ```Combine(d, DemoteTo(Half<D>(), b), DemoteTo(Half<D>(), a))```.
     Only available if `HWY_TARGET != HWY_SCALAR`.
 
+*   `V`,`D`: (`u16,u8`), (`u32,u16`), (`u64,u32`), \
+    <code>Vec&lt;D&gt; **OrderedTruncate2To**(D d, V a, V b)</code>: as above, but
+    converts two inputs, `D` and the output have twice as many lanes as `V`, and
+    the output order is the result of truncating the elements of ```a``` in the
+    lower half of the result followed by the result of truncating the elements of
+    ```b``` in the upper half of the result. ```OrderedTruncate2To(d, a, b)``` is
+    equivalent to ```Combine(d, TruncateTo(Half<D>(), b), TruncateTo(Half<D>(), a))```,
+    but ```OrderedTruncate2To(d, a, b)``` is typically more efficient than
+    ```Combine(d, TruncateTo(Half<D>(), b), TruncateTo(Half<D>(), a))```.
+    Only available if `HWY_TARGET != HWY_SCALAR`.
+
 *   `V`,`D`: (`i32`,`f32`), (`i64`,`f64`) \
     <code>Vec&lt;D&gt; **ConvertTo**(D, V)</code>: converts an integer value to
     same-sized floating point.
@@ -1312,6 +1342,14 @@ instead because they are more general:
 *   `V`: `{u,i,f}{16,32,64}` \
     <code>V **Reverse**(D, V a)</code> returns a vector with lanes in reversed
     order (`out[i] == a[Lanes(D()) - 1 - i]`).
+
+*   `V`: `{u,i}{16,32,64}` \
+    <code>V **ReverseLaneBytes**(V a)</code> returns a vector where the bytes of
+    each lane are swapped.
+
+*   `V`: `{u,i}{8,16,32,64}` \
+    <code>V **ReverseBits**(V a)</code> returns a vector where the bits of each
+    lane are reversed.
 
 The following `ReverseN` must not be called if `Lanes(D()) < N`:
 

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -1806,8 +1806,7 @@ HWY_API Vec128<float, N> AbsDiff(const Vec128<float, N> a,
 #define HWY_NATIVE_INTEGER_ABS_DIFF
 #endif
 
-HWY_API Vec128<int8_t> AbsDiff(const Vec128<int8_t> a,
-                               const Vec128<int8_t> b) {
+HWY_API Vec128<int8_t> AbsDiff(const Vec128<int8_t> a, const Vec128<int8_t> b) {
   return Vec128<int8_t>(vabdq_s8(a.raw, b.raw));
 }
 
@@ -3070,14 +3069,14 @@ HWY_API void StoreU(VFromD<D> v, D d, bfloat16_t* HWY_RESTRICT p) {
 
 HWY_DIAGNOSTICS(push)
 #if HWY_COMPILER_GCC_ACTUAL
-  HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wmaybe-uninitialized")
+HWY_DIAGNOSTICS_OFF(disable : 4701, ignored "-Wmaybe-uninitialized")
 #endif
 
 // On ARM, Store is the same as StoreU.
-  template <class D>
-  HWY_API void Store(VFromD<D> v, D d, TFromD<D>* HWY_RESTRICT aligned) {
+template <class D>
+HWY_API void Store(VFromD<D> v, D d, TFromD<D>* HWY_RESTRICT aligned) {
   StoreU(v, d, aligned);
-  }
+}
 
 HWY_DIAGNOSTICS(pop)
 
@@ -3365,26 +3364,26 @@ HWY_API Vec64<int32_t> DemoteTo(D /* tag */, Vec128<int64_t> v) {
 }
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<int64_t> v) {
-return Vec64<uint32_t>(vqmovun_s64(v.raw));
+  return Vec64<uint32_t>(vqmovun_s64(v.raw));
 }
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<uint64_t> v) {
   return Vec64<uint32_t>(vqmovn_u64(v.raw));
 }
-template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
-                  HWY_IF_SIGNED_D(D)>
+template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+          HWY_IF_SIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D d, Vec128<uint64_t> v) {
   const Rebind<int32_t, D> di32;
   return DemoteTo(d, DemoteTo(di32, v));
 }
-template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
-                  HWY_IF_UNSIGNED_D(D)>
+template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+          HWY_IF_UNSIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D d, Vec128<int64_t> v) {
   const Rebind<uint32_t, D> du32;
   return DemoteTo(d, DemoteTo(du32, v));
 }
-template<class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
-                  HWY_IF_UNSIGNED_D(D)>
+template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2)),
+          HWY_IF_UNSIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D d, Vec128<uint64_t> v) {
   const Rebind<uint32_t, D> du32;
   return DemoteTo(d, DemoteTo(du32, v));
@@ -3396,26 +3395,26 @@ HWY_API Vec32<int32_t> DemoteTo(D /* tag */, Vec64<int64_t> v) {
 }
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<int64_t> v) {
-return Vec32<uint32_t>(vqmovun_s64(vcombine_s64(v.raw, v.raw)));
+  return Vec32<uint32_t>(vqmovun_s64(vcombine_s64(v.raw, v.raw)));
 }
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<uint64_t> v) {
   return Vec32<uint32_t>(vqmovn_u64(vcombine_u64(v.raw, v.raw)));
 }
-template<class D, HWY_IF_SIGNED_D(D),
-                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+template <class D, HWY_IF_SIGNED_D(D),
+          HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
 HWY_API VFromD<D> DemoteTo(D d, Vec64<int64_t> v) {
   const Rebind<int32_t, D> di32;
   return DemoteTo(d, DemoteTo(di32, v));
 }
-template<class D, HWY_IF_UNSIGNED_D(D),
-                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+template <class D, HWY_IF_UNSIGNED_D(D),
+          HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
 HWY_API VFromD<D> DemoteTo(D d, Vec64<int64_t> v) {
   const Rebind<uint32_t, D> du32;
   return DemoteTo(d, DemoteTo(du32, v));
 }
-template<class D, HWY_IF_LANES_D(D, 1), HWY_IF_UNSIGNED_D(D),
-                  HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
+template <class D, HWY_IF_LANES_D(D, 1), HWY_IF_UNSIGNED_D(D),
+          HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2))>
 HWY_API VFromD<D> DemoteTo(D d, Vec64<uint64_t> v) {
   const Rebind<uint32_t, D> du32;
   return DemoteTo(d, DemoteTo(du32, v));
@@ -4308,6 +4307,77 @@ HWY_API VFromD<D> Reverse8(D, VFromD<D>) {
   HWY_ASSERT(0);  // don't have 8 lanes unless 16-bit
 }
 
+// ------------------------------ ReverseBits
+
+#if HWY_ARCH_ARM_A64
+
+#ifdef HWY_NATIVE_REVERSE_BITS_UI8
+#undef HWY_NATIVE_REVERSE_BITS_UI8
+#else
+#define HWY_NATIVE_REVERSE_BITS_UI8
+#endif
+
+HWY_NEON_DEF_FUNCTION_INT_8(ReverseBits, vrbit, _, 1)
+HWY_NEON_DEF_FUNCTION_UINT_8(ReverseBits, vrbit, _, 1)
+
+#endif
+
+// ------------------------------ ReverseLaneBytes
+
+#ifdef HWY_NATIVE_REVERSE_LANE_BYTES
+#undef HWY_NATIVE_REVERSE_LANE_BYTES
+#else
+#define HWY_NATIVE_REVERSE_LANE_BYTES
+#endif
+
+template <class V, HWY_IF_T_SIZE_V(V, 2), HWY_IF_V_SIZE_LE_D(DFromV<V>, 8)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev16_u8(BitCast(du8, v).raw)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 2), HWY_IF_V_SIZE_D(DFromV<V>, 16)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev16q_u8(BitCast(du8, v).raw)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 4), HWY_IF_V_SIZE_LE_D(DFromV<V>, 8)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev32_u8(BitCast(du8, v).raw)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 4), HWY_IF_V_SIZE_D(DFromV<V>, 16)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev32q_u8(BitCast(du8, v).raw)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 8), HWY_IF_V_SIZE_LE_D(DFromV<V>, 8)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev64_u8(BitCast(du8, v).raw)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 8), HWY_IF_V_SIZE_D(DFromV<V>, 16)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  using VU8 = VFromD<decltype(du8)>;
+  return BitCast(d, VU8(vrev64q_u8(BitCast(du8, v).raw)));
+}
+
 // ------------------------------ Other shuffles (TableLookupBytes)
 
 // Notation: let Vec128<int32_t> have lanes 3,2,1,0 (0 is least-significant).
@@ -4894,7 +4964,7 @@ HWY_API VFromD<D> ReorderDemote2To(D dbf16, V32 a, V32 b) {
 
 template <class D, HWY_IF_I32_D(D)>
 HWY_API Vec128<int32_t> ReorderDemote2To(D d32, Vec128<int64_t> a,
-                                        Vec128<int64_t> b) {
+                                         Vec128<int64_t> b) {
   const Vec64<int32_t> a32(vqmovn_s64(a.raw));
 #if HWY_ARCH_ARM_A64
   (void)d32;
@@ -4914,7 +4984,7 @@ HWY_API VFromD<D> ReorderDemote2To(D d32, VFromD<Repartition<int64_t, D>> a,
 
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec128<uint32_t> ReorderDemote2To(D d32, Vec128<int64_t> a,
-                                         Vec128<int64_t> b) {
+                                          Vec128<int64_t> b) {
   const Vec64<uint32_t> a32(vqmovun_s64(a.raw));
 #if HWY_ARCH_ARM_A64
   (void)d32;
@@ -4934,7 +5004,7 @@ HWY_API VFromD<D> ReorderDemote2To(D d32, VFromD<Repartition<int64_t, D>> a,
 
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec128<uint32_t> ReorderDemote2To(D d32, Vec128<uint64_t> a,
-                                         Vec128<uint64_t> b) {
+                                          Vec128<uint64_t> b) {
   const Vec64<uint32_t> a32(vqmovn_u64(a.raw));
 #if HWY_ARCH_ARM_A64
   (void)d32;
@@ -5106,8 +5176,7 @@ HWY_API VFromD<D> OrderedDemote2To(D d, V a, V b) {
   return ReorderDemote2To(d, a, b);
 }
 
-template <class D, HWY_IF_BF16_D(D),
-          class V32 = VFromD<Repartition<float, D>>>
+template <class D, HWY_IF_BF16_D(D), class V32 = VFromD<Repartition<float, D>>>
 HWY_API VFromD<D> OrderedDemote2To(D dbf16, V32 a, V32 b) {
   return ReorderDemote2To(dbf16, a, b);
 }
@@ -7025,6 +7094,55 @@ HWY_INLINE VFromD<D> Min128Upper(D d, VFromD<D> a, VFromD<D> b) {
 template <class D>
 HWY_INLINE VFromD<D> Max128Upper(D d, VFromD<D> a, VFromD<D> b) {
   return IfThenElse(Lt128Upper(d, b, a), a, b);
+}
+
+// -------------------- LeadingZeroCount, TrailingZeroCount, HighestSetBitIndex
+
+#ifdef HWY_NATIVE_LEADING_ZERO_COUNT
+#undef HWY_NATIVE_LEADING_ZERO_COUNT
+#else
+#define HWY_NATIVE_LEADING_ZERO_COUNT
+#endif
+
+HWY_NEON_DEF_FUNCTION_INT_8_16_32(LeadingZeroCount, vclz, _, 1)
+HWY_NEON_DEF_FUNCTION_UINT_8_16_32(LeadingZeroCount, vclz, _, 1)
+
+template <class V, HWY_IF_UI64_D(DFromV<V>)>
+HWY_API V LeadingZeroCount(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const Repartition<uint32_t, decltype(d)> du32;
+
+  const auto v_k32 = BitCast(du32, Set(du, 32));
+  const auto v_u32_lzcnt = LeadingZeroCount(BitCast(du32, v)) + v_k32;
+  const auto v_u32_lo_lzcnt =
+      And(v_u32_lzcnt, BitCast(du32, Set(du, 0xFFFFFFFFu)));
+  const auto v_u32_hi_lzcnt =
+      BitCast(du32, ShiftRight<32>(BitCast(du, v_u32_lzcnt)));
+
+  return BitCast(
+      d, IfThenElse(v_u32_hi_lzcnt == v_k32, v_u32_lo_lzcnt, v_u32_hi_lzcnt));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V HighestSetBitIndex(V v) {
+  const DFromV<decltype(v)> d;
+  using T = TFromD<decltype(d)>;
+  return BitCast(d, Set(d, T{sizeof(T) * 8 - 1}) - LeadingZeroCount(v));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V), HWY_IF_T_SIZE_V(V, 1)>
+HWY_API V TrailingZeroCount(V v) {
+  return LeadingZeroCount(ReverseBits(v));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 2) | (1 << 4) | (1 << 8))>
+HWY_API V TrailingZeroCount(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return LeadingZeroCount(
+      ReverseLaneBytes(BitCast(d, ReverseBits(BitCast(du8, v)))));
 }
 
 namespace detail {  // for code folding

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -45,6 +45,16 @@ using Vec = decltype(Zero(D()));
 template <class D>
 using Mask = decltype(MaskFromVec(Zero(D())));
 
+namespace detail {
+#if HWY_TARGET == HWY_RVV
+template <class T>
+using LargestVecScalableTag = ScalableTag<T, HWY_MAX_POW2>;
+#else
+template <class T>
+using LargestVecScalableTag = ScalableTag<T>;
+#endif
+}  // namespace detail
+
 // Returns the closest value to v within [lo, hi].
 template <class V>
 HWY_API V Clamp(const V v, const V lo, const V hi) {
@@ -1022,8 +1032,8 @@ HWY_API VFromD<DN> DemoteTo(DN dn, V v) {
   // using an unsigned Min operation.
   const auto max_signed_val = Set(dn, hwy::HighestValue<TFromD<DN>>());
 
-  return BitCast(dn, Min(BitCast(dn_u, i2i_demote_result),
-                         BitCast(dn_u, max_signed_val)));
+  return BitCast(
+      dn, Min(BitCast(dn_u, i2i_demote_result), BitCast(dn_u, max_signed_val)));
 }
 
 #if HWY_TARGET != HWY_SCALAR || HWY_IDE
@@ -1040,16 +1050,314 @@ HWY_API VFromD<DN> ReorderDemote2To(DN dn, V a, V b) {
   // that are greater than hwy::HighestValue<MakeSigned<TFromV<V>>>() to a
   // negative value.
   const auto i2i_demote_result =
-    ReorderDemote2To(dn, BitCast(di, a), BitCast(di, b));
+      ReorderDemote2To(dn, BitCast(di, a), BitCast(di, b));
 
   // Second, convert any negative values to hwy::HighestValue<TFromD<DN>>()
   // using an unsigned Min operation.
   const auto max_signed_val = Set(dn, hwy::HighestValue<TFromD<DN>>());
 
-  return BitCast(dn, Min(BitCast(dn_u, i2i_demote_result),
-                         BitCast(dn_u, max_signed_val)));
+  return BitCast(
+      dn, Min(BitCast(dn_u, i2i_demote_result), BitCast(dn_u, max_signed_val)));
 }
 #endif
+
+// ------------------------------ OrderedTruncate2To
+
+#if (defined(HWY_NATIVE_ORDERED_TRUNCATE_2_TO) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_ORDERED_TRUNCATE_2_TO
+#undef HWY_NATIVE_ORDERED_TRUNCATE_2_TO
+#else
+#define HWY_NATIVE_ORDERED_TRUNCATE_2_TO
+#endif
+
+// (Must come after HWY_TARGET_TOGGLE, else we don't reset it for scalar)
+#if HWY_TARGET != HWY_SCALAR || HWY_IDE
+template <class DN, HWY_IF_UNSIGNED_D(DN), class V, HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_V(V, sizeof(TFromD<DN>) * 2),
+          HWY_IF_LANES_D(DFromV<VFromD<DN>>, HWY_MAX_LANES_D(DFromV<V>) * 2)>
+HWY_API VFromD<DN> OrderedTruncate2To(DN dn, V a, V b) {
+  return ConcatEven(dn, BitCast(dn, b), BitCast(dn, a));
+}
+#endif  // HWY_TARGET != HWY_SCALAR
+#endif  // HWY_NATIVE_ORDERED_TRUNCATE_2_TO
+
+// -------------------- LeadingZeroCount, TrailingZeroCount, HighestSetBitIndex
+
+#if (defined(HWY_NATIVE_LEADING_ZERO_COUNT) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_LEADING_ZERO_COUNT
+#undef HWY_NATIVE_LEADING_ZERO_COUNT
+#else
+#define HWY_NATIVE_LEADING_ZERO_COUNT
+#endif
+
+namespace detail {
+
+template <class D, HWY_IF_U32_D(D)>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const RebindToFloat<decltype(d)> df;
+#if HWY_TARGET > HWY_AVX3 && HWY_TARGET <= HWY_SSE2
+  const RebindToSigned<decltype(d)> di;
+  const Repartition<int16_t, decltype(d)> di16;
+  const auto f32_bits = BitCast(d, ConvertTo(df, BitCast(di, v)));
+  return BitCast(d, Min(BitCast(di16, ShiftRight<23>(f32_bits)),
+                        BitCast(di16, Set(d, 158))));
+#else
+  const auto f32_bits = BitCast(d, ConvertTo(df, v));
+  return BitCast(d, ShiftRight<23>(f32_bits));
+#endif
+}
+
+template <class V, HWY_IF_U32_D(DFromV<V>)>
+HWY_INLINE V I32RangeU32ToF32BiasedExp(V v) {
+  // I32RangeU32ToF32BiasedExp is similar to UIntToF32BiasedExp, but
+  // I32RangeU32ToF32BiasedExp assumes that v[i] is between 0 and 2147483647.
+  const DFromV<decltype(v)> d;
+  const RebindToFloat<decltype(d)> df;
+#if HWY_TARGET > HWY_AVX3 && HWY_TARGET <= HWY_SSE2
+  const RebindToSigned<decltype(d)> d_src;
+#else
+  const RebindToUnsigned<decltype(d)> d_src;
+#endif
+  const auto f32_bits = BitCast(d, ConvertTo(df, BitCast(d_src, v)));
+  return ShiftRight<23>(f32_bits);
+}
+
+template <class D, HWY_IF_U16_D(D),
+          HWY_IF_LANES_LE_D(D,
+                            HWY_MAX_LANES_D(LargestVecScalableTag<uint32_t>))>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const Rebind<uint32_t, decltype(d)> du32;
+  const auto f32_biased_exp_as_u32 =
+      I32RangeU32ToF32BiasedExp(PromoteTo(du32, v));
+  return TruncateTo(d, f32_biased_exp_as_u32);
+}
+
+#if HWY_TARGET != HWY_SCALAR
+template <class D, HWY_IF_U16_D(D),
+          HWY_IF_LANES_GT_D(D,
+                            HWY_MAX_LANES_D(LargestVecScalableTag<uint32_t>))>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const Half<decltype(d)> dh;
+  const Rebind<uint32_t, decltype(dh)> du32;
+
+  const auto lo_u32 = PromoteTo(du32, LowerHalf(dh, v));
+  const auto hi_u32 = PromoteTo(du32, UpperHalf(dh, v));
+
+  const auto lo_f32_biased_exp_as_u32 = I32RangeU32ToF32BiasedExp(lo_u32);
+  const auto hi_f32_biased_exp_as_u32 = I32RangeU32ToF32BiasedExp(hi_u32);
+#if HWY_TARGET >= HWY_AVX3_ZEN4 && HWY_TARGET <= HWY_SSE2
+  const RebindToSigned<decltype(du32)> di32;
+  const RebindToSigned<decltype(d)> di;
+  return BitCast(d,
+                 OrderedDemote2To(di, BitCast(di32, lo_f32_biased_exp_as_u32),
+                                  BitCast(di32, hi_f32_biased_exp_as_u32)));
+#else
+  return OrderedTruncate2To(d, lo_f32_biased_exp_as_u32,
+                            hi_f32_biased_exp_as_u32);
+#endif
+}
+#endif  // HWY_TARGET != HWY_SCALAR
+
+template <class D, HWY_IF_U8_D(D),
+          HWY_IF_LANES_LE_D(D,
+                            HWY_MAX_LANES_D(LargestVecScalableTag<uint32_t>))>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const Rebind<uint32_t, decltype(d)> du32;
+  const auto f32_biased_exp_as_u32 =
+      I32RangeU32ToF32BiasedExp(PromoteTo(du32, v));
+  return U8FromU32(f32_biased_exp_as_u32);
+}
+
+#if HWY_TARGET != HWY_SCALAR
+template <
+    class D, HWY_IF_U8_D(D),
+    HWY_IF_LANES_GT_D(D, HWY_MAX_LANES_D(LargestVecScalableTag<uint32_t>)),
+    HWY_IF_LANES_LE_D(D, HWY_MAX_LANES_D(LargestVecScalableTag<uint16_t>))>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const Half<decltype(d)> dh;
+  const Rebind<uint32_t, decltype(dh)> du32;
+  const Repartition<uint16_t, decltype(du32)> du16;
+
+  const auto lo_u32 = PromoteTo(du32, LowerHalf(dh, v));
+  const auto hi_u32 = PromoteTo(du32, UpperHalf(dh, v));
+
+  const auto lo_f32_biased_exp_as_u32 = I32RangeU32ToF32BiasedExp(lo_u32);
+  const auto hi_f32_biased_exp_as_u32 = I32RangeU32ToF32BiasedExp(hi_u32);
+
+#if HWY_TARGET >= HWY_AVX3_ZEN4 && HWY_TARGET <= HWY_SSE2
+  const RebindToSigned<decltype(du32)> di32;
+  const RebindToSigned<decltype(du16)> di16;
+  const auto f32_biased_exp_as_i16 =
+      OrderedDemote2To(di16, BitCast(di32, lo_f32_biased_exp_as_u32),
+                       BitCast(di32, hi_f32_biased_exp_as_u32));
+  return DemoteTo(d, f32_biased_exp_as_i16);
+#else
+  const auto f32_biased_exp_as_u16 = OrderedTruncate2To(
+      du16, lo_f32_biased_exp_as_u32, hi_f32_biased_exp_as_u32);
+  return TruncateTo(d, f32_biased_exp_as_u16);
+#endif
+}
+
+template <class D, HWY_IF_U8_D(D),
+          HWY_IF_LANES_GT_D(D,
+                            HWY_MAX_LANES_D(LargestVecScalableTag<uint16_t>))>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+  const Half<decltype(d)> dh;
+  const Half<decltype(dh)> dq;
+  const Rebind<uint32_t, decltype(dq)> du32;
+  const Repartition<uint16_t, decltype(du32)> du16;
+
+  const auto lo_half = LowerHalf(dh, v);
+  const auto hi_half = UpperHalf(dh, v);
+
+  const auto u32_q0 = PromoteTo(du32, LowerHalf(dq, lo_half));
+  const auto u32_q1 = PromoteTo(du32, UpperHalf(dq, lo_half));
+  const auto u32_q2 = PromoteTo(du32, LowerHalf(dq, hi_half));
+  const auto u32_q3 = PromoteTo(du32, UpperHalf(dq, hi_half));
+
+  const auto f32_biased_exp_as_u32_q0 = I32RangeU32ToF32BiasedExp(u32_q0);
+  const auto f32_biased_exp_as_u32_q1 = I32RangeU32ToF32BiasedExp(u32_q1);
+  const auto f32_biased_exp_as_u32_q2 = I32RangeU32ToF32BiasedExp(u32_q2);
+  const auto f32_biased_exp_as_u32_q3 = I32RangeU32ToF32BiasedExp(u32_q3);
+
+#if HWY_TARGET >= HWY_AVX3_ZEN4 && HWY_TARGET <= HWY_SSE2
+  const RebindToSigned<decltype(du32)> di32;
+  const RebindToSigned<decltype(du16)> di16;
+
+  const auto lo_f32_biased_exp_as_i16 =
+      OrderedDemote2To(di16, BitCast(di32, f32_biased_exp_as_u32_q0),
+                       BitCast(di32, f32_biased_exp_as_u32_q1));
+  const auto hi_f32_biased_exp_as_i16 =
+      OrderedDemote2To(di16, BitCast(di32, f32_biased_exp_as_u32_q2),
+                       BitCast(di32, f32_biased_exp_as_u32_q3));
+  return OrderedDemote2To(d, lo_f32_biased_exp_as_i16,
+                          hi_f32_biased_exp_as_i16);
+#else
+  const auto lo_f32_biased_exp_as_u16 = OrderedTruncate2To(
+      du16, f32_biased_exp_as_u32_q0, f32_biased_exp_as_u32_q1);
+  const auto hi_f32_biased_exp_as_u16 = OrderedTruncate2To(
+      du16, f32_biased_exp_as_u32_q2, f32_biased_exp_as_u32_q3);
+  return OrderedTruncate2To(d, lo_f32_biased_exp_as_u16,
+                            hi_f32_biased_exp_as_u16);
+#endif
+}
+#endif  // HWY_TARGET != HWY_SCALAR
+
+#if HWY_TARGET == HWY_SCALAR
+template <class D>
+using F32ExpLzcntMinMaxRepartition = RebindToUnsigned<D>;
+#elif HWY_TARGET >= HWY_SSSE3 && HWY_TARGET <= HWY_SSE2
+template <class D>
+using F32ExpLzcntMinMaxRepartition = Repartition<uint8_t, D>;
+#else
+template <class D>
+using F32ExpLzcntMinMaxRepartition =
+    Repartition<UnsignedFromSize<HWY_MIN(sizeof(TFromD<D>), 4)>, D>;
+#endif
+
+template <class V>
+using F32ExpLzcntMinMaxCmpV = VFromD<F32ExpLzcntMinMaxRepartition<DFromV<V>>>;
+
+template <class V>
+HWY_INLINE F32ExpLzcntMinMaxCmpV<V> F32ExpLzcntMinMaxBitCast(V v) {
+  const DFromV<decltype(v)> d;
+  const F32ExpLzcntMinMaxRepartition<decltype(d)> d2;
+  return BitCast(d2, v);
+}
+
+template <class D, HWY_IF_U64_D(D)>
+HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
+#if HWY_TARGET == HWY_SCALAR
+  const uint64_t u64_val = GetLane(v);
+  const float f32_val = static_cast<float>(u64_val);
+  uint32_t f32_bits;
+  CopySameSize(&f32_val, &f32_bits);
+  return Set(d, static_cast<uint64_t>(f32_bits >> 23));
+#else
+  const Repartition<uint32_t, decltype(d)> du32;
+  const auto f32_biased_exp = UIntToF32BiasedExp(du32, BitCast(du32, v));
+  const auto f32_biased_exp_adj =
+      IfThenZeroElse(Eq(f32_biased_exp, Zero(du32)),
+                     BitCast(du32, Set(d, 0x0000002000000000u)));
+  const auto adj_f32_biased_exp = Add(f32_biased_exp, f32_biased_exp_adj);
+
+  return ShiftRight<32>(BitCast(
+      d, Max(F32ExpLzcntMinMaxBitCast(adj_f32_biased_exp),
+             F32ExpLzcntMinMaxBitCast(Reverse2(du32, adj_f32_biased_exp)))));
+#endif
+}
+
+template <class V, HWY_IF_UNSIGNED_V(V)>
+HWY_INLINE V UIntToF32BiasedExp(V v) {
+  const DFromV<decltype(v)> d;
+  return UIntToF32BiasedExp(d, v);
+}
+
+template <class V, HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_INLINE V NormalizeForUIntTruncConvToF32(V v) {
+  return v;
+}
+
+template <class V, HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 4) | (1 << 8))>
+HWY_INLINE V NormalizeForUIntTruncConvToF32(V v) {
+  // If v[i] >= 16777216 is true, make sure that the bit at
+  // HighestSetBitIndex(v[i]) - 24 is zeroed out to ensure that any inexact
+  // conversion to single-precision floating point is rounded down.
+
+  // This zeroing-out can be accomplished through the AndNot operation below.
+  return AndNot(ShiftRight<24>(v), v);
+}
+
+}  // namespace detail
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V HighestSetBitIndex(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  using TU = TFromD<decltype(du)>;
+
+  const auto f32_biased_exp = detail::UIntToF32BiasedExp(
+      detail::NormalizeForUIntTruncConvToF32(BitCast(du, v)));
+  return BitCast(d, Sub(f32_biased_exp, Set(du, TU{127})));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V LeadingZeroCount(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  using TU = TFromD<decltype(du)>;
+
+  constexpr TU kNumOfBitsInT{sizeof(TU) * 8};
+  const auto f32_biased_exp = detail::UIntToF32BiasedExp(
+      detail::NormalizeForUIntTruncConvToF32(BitCast(du, v)));
+  const auto lz_count = Sub(Set(du, TU{kNumOfBitsInT + 126}), f32_biased_exp);
+
+  return BitCast(d,
+                 Min(detail::F32ExpLzcntMinMaxBitCast(lz_count),
+                     detail::F32ExpLzcntMinMaxBitCast(Set(du, kNumOfBitsInT))));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V TrailingZeroCount(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RebindToSigned<decltype(d)> di;
+  using TU = TFromD<decltype(du)>;
+
+  const auto vi = BitCast(di, v);
+  const auto lowest_bit = BitCast(du, And(vi, Neg(vi)));
+
+  constexpr TU kNumOfBitsInT{sizeof(TU) * 8};
+  const auto f32_biased_exp = detail::UIntToF32BiasedExp(lowest_bit);
+  const auto tz_count = Sub(f32_biased_exp, Set(du, TU{127}));
+
+  return BitCast(d,
+                 Min(detail::F32ExpLzcntMinMaxBitCast(tz_count),
+                     detail::F32ExpLzcntMinMaxBitCast(Set(du, kNumOfBitsInT))));
+}
+#endif  // HWY_NATIVE_LEADING_ZERO_COUNT
 
 // ------------------------------ AESRound
 
@@ -2226,6 +2534,117 @@ HWY_API VFromD<D> LoadExpand(MFromD<D> mask, D d,
 }
 
 #endif  // HWY_NATIVE_EXPAND
+
+// ------------------------------ ReverseLaneBytes
+
+#if (defined(HWY_NATIVE_REVERSE_LANE_BYTES) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_REVERSE_LANE_BYTES
+#undef HWY_NATIVE_REVERSE_LANE_BYTES
+#else
+#define HWY_NATIVE_REVERSE_LANE_BYTES
+#endif
+
+template <class V, HWY_IF_T_SIZE_V(V, 2), HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V ReverseLaneBytes(V v) {
+  alignas(16) static constexpr uint8_t kShuffle[16] = {
+      1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return TableLookupBytes(v, BitCast(d, LoadDup128(du8, kShuffle)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 4), HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V ReverseLaneBytes(V v) {
+  alignas(16) static constexpr uint8_t kShuffle[16] = {
+      3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12};
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return TableLookupBytes(v, BitCast(d, LoadDup128(du8, kShuffle)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 8), HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V ReverseLaneBytes(V v) {
+  alignas(16) static constexpr uint8_t kShuffle[16] = {
+      7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8};
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return TableLookupBytes(v, BitCast(d, LoadDup128(du8, kShuffle)));
+}
+
+#endif  // HWY_NATIVE_REVERSE_LANE_BYTES
+
+// ------------------------------ ReverseBits
+#if (defined(HWY_NATIVE_REVERSE_BITS_UI8) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_REVERSE_BITS_UI8
+#undef HWY_NATIVE_REVERSE_BITS_UI8
+#else
+#define HWY_NATIVE_REVERSE_BITS_UI8
+#endif
+
+namespace detail {
+
+template <int kShiftAmt, int kShrResultMask, class V,
+          HWY_IF_V_SIZE_GT_D(DFromV<V>, ((HWY_TARGET >= HWY_AVX3 &&
+                                          HWY_TARGET <= HWY_SSE2) ||
+                                         HWY_TARGET == HWY_WASM ||
+                                         HWY_TARGET == HWY_WASM_EMU256)
+                                            ? 1 : 0)>
+HWY_INLINE V UI8ReverseBitsStep(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+#if ((HWY_TARGET >= HWY_AVX3 && HWY_TARGET <= HWY_SSE2) || \
+     HWY_TARGET == HWY_WASM || HWY_TARGET == HWY_WASM_EMU256)
+  const Repartition<uint16_t, decltype(d)> d_shift;
+#else
+  const RebindToUnsigned<decltype(d)> d_shift;
+#endif
+
+  const auto v_to_shift = BitCast(d_shift, v);
+  const auto shl_result = BitCast(d, ShiftLeft<kShiftAmt>(v_to_shift));
+  const auto shr_result = BitCast(d, ShiftRight<kShiftAmt>(v_to_shift));
+  const auto shr_result_mask =
+      BitCast(d, Set(du, static_cast<uint8_t>(kShrResultMask)));
+  return Or(And(shr_result, shr_result_mask),
+            AndNot(shr_result_mask, shl_result));
+}
+
+#if ((HWY_TARGET >= HWY_AVX3 && HWY_TARGET <= HWY_SSE2) || \
+     HWY_TARGET == HWY_WASM || HWY_TARGET == HWY_WASM_EMU256)
+template <int kShiftAmt, int kShrResultMask, class V,
+          HWY_IF_V_SIZE_D(DFromV<V>, 1)>
+HWY_INLINE V UI8ReverseBitsStep(V v) {
+  return V{UI8ReverseBitsStep<kShiftAmt, kShrResultMask>(Vec128<uint8_t>{v.raw})
+               .raw};
+}
+#endif
+
+}  // namespace detail
+
+template <class V, HWY_IF_T_SIZE_V(V, 1)>
+HWY_API V ReverseBits(V v) {
+  auto result = detail::UI8ReverseBitsStep<1, 0x55>(v);
+  result = detail::UI8ReverseBitsStep<2, 0x33>(result);
+  result = detail::UI8ReverseBitsStep<4, 0x0F>(result);
+  return result;
+}
+
+#endif  // HWY_NATIVE_REVERSE_BITS_UI8
+
+#if (defined(HWY_NATIVE_REVERSE_BITS_UI16_32_64) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_REVERSE_BITS_UI16_32_64
+#undef HWY_NATIVE_REVERSE_BITS_UI16_32_64
+#else
+#define HWY_NATIVE_REVERSE_BITS_UI16_32_64
+#endif
+
+template <class V, HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 2) | (1 << 4) | (1 << 8)),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V ReverseBits(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return ReverseLaneBytes(BitCast(d, ReverseBits(BitCast(du8, v))));
+}
+#endif  // HWY_NATIVE_REVERSE_BITS_UI16_32_64
 
 // ================================================== Operator wrapper
 

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -99,11 +99,11 @@
 #define HWY_TARGET_STR_AVX2 \
   HWY_TARGET_STR_SSE4 ",avx,avx2" HWY_TARGET_STR_BMI2_FMA HWY_TARGET_STR_F16C
 #define HWY_TARGET_STR_AVX3 \
-  HWY_TARGET_STR_AVX2 ",avx512f,avx512vl,avx512dq,avx512bw"
-#define HWY_TARGET_STR_AVX3_DL                                    \
-  HWY_TARGET_STR_AVX3                                             \
+  HWY_TARGET_STR_AVX2 ",avx512f,avx512cd,avx512vl,avx512dq,avx512bw"
+#define HWY_TARGET_STR_AVX3_DL                                       \
+  HWY_TARGET_STR_AVX3                                                \
   ",vpclmulqdq,avx512vbmi,avx512vbmi2,vaes,avx512vnni,avx512bitalg," \
-  "avx512vpopcntdq"
+  "avx512vpopcntdq,gfni"
 
 #if defined(HWY_DISABLE_PPC8_CRYPTO)
 #define HWY_TARGET_STR_PPC8_CRYPTO ""
@@ -258,7 +258,7 @@
 
 #define HWY_HAVE_SCALABLE 0
 #define HWY_HAVE_INTEGER64 1
-#define HWY_HAVE_FLOAT16 0
+#define HWY_HAVE_FLOAT16 1
 #define HWY_HAVE_FLOAT64 1
 #define HWY_MEM_OPS_MIGHT_FAULT 1
 #define HWY_NATIVE_FMA 1

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -1406,8 +1406,8 @@ HWY_API Vec128<TI, NI> TableLookupBytes(const Vec128<T, N> bytes,
 #if HWY_COMPILER_GCC_ACTUAL && HWY_HAS_BUILTIN(__builtin_shuffle)
   typedef uint8_t GccU8RawVectType __attribute__((__vector_size__(16)));
   return Vec128<TI, NI>{reinterpret_cast<typename detail::Raw128<TI>::type>(
-    __builtin_shuffle(reinterpret_cast<GccU8RawVectType>(bytes.raw),
-                      reinterpret_cast<GccU8RawVectType>(from.raw)))};
+      __builtin_shuffle(reinterpret_cast<GccU8RawVectType>(bytes.raw),
+                        reinterpret_cast<GccU8RawVectType>(from.raw)))};
 #else
   const DFromV<decltype(from)> d;
   const Repartition<uint8_t, decltype(d)> du8;
@@ -1482,7 +1482,7 @@ HWY_API Vec32<T> Shuffle2301(const Vec32<T> a, const Vec32<T> b) {
   const auto ba = Combine(d2, b, a);
 #if HWY_TARGET == HWY_SSE2
   Vec32<uint16_t> ba_shuffled{
-    _mm_shufflelo_epi16(ba.raw, _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_shufflelo_epi16(ba.raw, _MM_SHUFFLE(3, 0, 3, 0))};
   return BitCast(d, Or(ShiftLeft<8>(ba_shuffled), ShiftRight<8>(ba_shuffled)));
 #else
   alignas(16) const T kShuffle[8] = {1, 0, 7, 6};
@@ -1496,9 +1496,9 @@ HWY_API Vec64<T> Shuffle2301(const Vec64<T> a, const Vec64<T> b) {
   const auto ba = Combine(d2, b, a);
 #if HWY_TARGET == HWY_SSE2
   Vec64<uint32_t> ba_shuffled{
-    _mm_shuffle_epi32(ba.raw, _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_shuffle_epi32(ba.raw, _MM_SHUFFLE(3, 0, 3, 0))};
   return Vec64<T>{
-    _mm_shufflelo_epi16(ba_shuffled.raw, _MM_SHUFFLE(2, 3, 0, 1))};
+      _mm_shufflelo_epi16(ba_shuffled.raw, _MM_SHUFFLE(2, 3, 0, 1))};
 #else
   alignas(16) const T kShuffle[8] = {0x0302, 0x0100, 0x0f0e, 0x0d0c};
   return Vec64<T>{TableLookupBytes(ba, Load(d2, kShuffle)).raw};
@@ -1520,9 +1520,9 @@ HWY_API Vec32<T> Shuffle1230(const Vec32<T> a, const Vec32<T> b) {
   const auto zero = Zero(d);
   const Rebind<int16_t, decltype(d)> di16;
   const Vec32<int16_t> a_shuffled{_mm_shufflelo_epi16(
-    _mm_unpacklo_epi8(a.raw, zero.raw), _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_unpacklo_epi8(a.raw, zero.raw), _MM_SHUFFLE(3, 0, 3, 0))};
   const Vec32<int16_t> b_shuffled{_mm_shufflelo_epi16(
-    _mm_unpacklo_epi8(b.raw, zero.raw), _MM_SHUFFLE(1, 2, 1, 2))};
+      _mm_unpacklo_epi8(b.raw, zero.raw), _MM_SHUFFLE(1, 2, 1, 2))};
   const auto ba_shuffled = Combine(di16, b_shuffled, a_shuffled);
   return Vec32<T>{_mm_packus_epi16(ba_shuffled.raw, ba_shuffled.raw)};
 #else
@@ -1537,9 +1537,9 @@ HWY_API Vec64<T> Shuffle1230(const Vec64<T> a, const Vec64<T> b) {
   const DFromV<decltype(a)> d;
 #if HWY_TARGET == HWY_SSE2
   const Vec32<T> a_shuffled{
-    _mm_shufflelo_epi16(a.raw, _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_shufflelo_epi16(a.raw, _MM_SHUFFLE(3, 0, 3, 0))};
   const Vec32<T> b_shuffled{
-    _mm_shufflelo_epi16(b.raw, _MM_SHUFFLE(1, 2, 1, 2))};
+      _mm_shufflelo_epi16(b.raw, _MM_SHUFFLE(1, 2, 1, 2))};
   return Combine(d, b_shuffled, a_shuffled);
 #else
   const Twice<decltype(d)> d2;
@@ -1564,9 +1564,9 @@ HWY_API Vec32<T> Shuffle3012(const Vec32<T> a, const Vec32<T> b) {
   const auto zero = Zero(d);
   const Rebind<int16_t, decltype(d)> di16;
   const Vec32<int16_t> a_shuffled{_mm_shufflelo_epi16(
-    _mm_unpacklo_epi8(a.raw, zero.raw), _MM_SHUFFLE(1, 2, 1, 2))};
+      _mm_unpacklo_epi8(a.raw, zero.raw), _MM_SHUFFLE(1, 2, 1, 2))};
   const Vec32<int16_t> b_shuffled{_mm_shufflelo_epi16(
-    _mm_unpacklo_epi8(b.raw, zero.raw), _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_unpacklo_epi8(b.raw, zero.raw), _MM_SHUFFLE(3, 0, 3, 0))};
   const auto ba_shuffled = Combine(di16, b_shuffled, a_shuffled);
   return Vec32<T>{_mm_packus_epi16(ba_shuffled.raw, ba_shuffled.raw)};
 #else
@@ -1581,9 +1581,9 @@ HWY_API Vec64<T> Shuffle3012(const Vec64<T> a, const Vec64<T> b) {
   const DFromV<decltype(a)> d;
 #if HWY_TARGET == HWY_SSE2
   const Vec32<T> a_shuffled{
-    _mm_shufflelo_epi16(a.raw, _MM_SHUFFLE(1, 2, 1, 2))};
+      _mm_shufflelo_epi16(a.raw, _MM_SHUFFLE(1, 2, 1, 2))};
   const Vec32<T> b_shuffled{
-    _mm_shufflelo_epi16(b.raw, _MM_SHUFFLE(3, 0, 3, 0))};
+      _mm_shufflelo_epi16(b.raw, _MM_SHUFFLE(3, 0, 3, 0))};
   return Combine(d, b_shuffled, a_shuffled);
 #else
   const Twice<decltype(d)> d2;
@@ -2056,17 +2056,17 @@ HWY_API Mask128<uint8_t, N> operator!=(Vec128<uint8_t, N> a,
 }
 template <size_t N>
 HWY_API Mask128<uint16_t, N> operator!=(Vec128<uint16_t, N> a,
-                                       Vec128<uint16_t, N> b) {
+                                        Vec128<uint16_t, N> b) {
   return Not(a == b);
 }
 template <size_t N>
 HWY_API Mask128<uint32_t, N> operator!=(Vec128<uint32_t, N> a,
-                                       Vec128<uint32_t, N> b) {
+                                        Vec128<uint32_t, N> b) {
   return Not(a == b);
 }
 template <size_t N>
 HWY_API Mask128<uint64_t, N> operator!=(Vec128<uint64_t, N> a,
-                                       Vec128<uint64_t, N> b) {
+                                        Vec128<uint64_t, N> b) {
   return Not(a == b);
 }
 template <size_t N>
@@ -2174,14 +2174,14 @@ HWY_INLINE Mask128<T, N> operator>(Vec128<T, N> a, Vec128<T, N> b) {
 
 namespace detail {
 template <typename T, size_t N>
-HWY_INLINE Mask128<T, N> Ge(hwy::SignedTag tag,
-                            Vec128<T, N> a, Vec128<T, N> b) {
+HWY_INLINE Mask128<T, N> Ge(hwy::SignedTag tag, Vec128<T, N> a,
+                            Vec128<T, N> b) {
   return Not(Gt(tag, b, a));
 }
 
 template <typename T, size_t N>
-HWY_INLINE Mask128<T, N> Ge(hwy::UnsignedTag tag,
-                            Vec128<T, N> a, Vec128<T, N> b) {
+HWY_INLINE Mask128<T, N> Ge(hwy::UnsignedTag tag, Vec128<T, N> a,
+                            Vec128<T, N> b) {
   return Not(Gt(tag, b, a));
 }
 
@@ -3786,10 +3786,13 @@ HWY_INLINE T ExtractLane(const Vec128<T, N> v) {
 template <size_t kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 8)>
 HWY_INLINE T ExtractLane(const Vec128<T, N> v) {
   static_assert(kLane < N, "Lane index out of bounds");
-#if HWY_TARGET >= HWY_SSSE3 || HWY_ARCH_X86_32
+#if HWY_ARCH_X86_32
   alignas(16) T lanes[2];
   Store(v, DFromV<decltype(v)>(), lanes);
   return lanes[kLane];
+#elif HWY_TARGET >= HWY_SSSE3
+  return static_cast<T>(_mm_cvtsi128_si64(
+    (kLane == 0) ? v.raw : _mm_shuffle_epi32(v.raw, 0xEE)));
 #else
   return static_cast<T>(_mm_extract_epi64(v.raw, kLane));
 #endif
@@ -4342,8 +4345,8 @@ HWY_API Vec128<T, N> TableLookupLanes(Vec128<T, N> v, Indices128<T, N> idx) {
 #if HWY_COMPILER_GCC_ACTUAL && HWY_HAS_BUILTIN(__builtin_shuffle)
   typedef uint32_t GccU32RawVectType __attribute__((__vector_size__(16)));
   return Vec128<T, N>{reinterpret_cast<typename detail::Raw128<T>::type>(
-    __builtin_shuffle(reinterpret_cast<GccU32RawVectType>(v.raw),
-                      reinterpret_cast<GccU32RawVectType>(idx.raw)))};
+      __builtin_shuffle(reinterpret_cast<GccU32RawVectType>(v.raw),
+                        reinterpret_cast<GccU32RawVectType>(idx.raw)))};
 #else
   const Full128<T> d_full;
   alignas(16) T src_lanes[4];
@@ -4462,22 +4465,25 @@ HWY_API Vec128<T> Reverse(D /* tag */, const Vec128<T> v) {
 // 16-bit
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_T_SIZE_D(D, 2)>
 HWY_API VFromD<D> Reverse(D d, const VFromD<D> v) {
-#if HWY_TARGET <= HWY_AVX3
   constexpr size_t kN = MaxLanes(d);
   if (kN == 1) return v;
   if (kN == 2) {
-    const Repartition<uint32_t, decltype(d)> du32;
-    return BitCast(d, RotateRight<16>(BitCast(du32, v)));
+    return VFromD<D>{_mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(0, 1, 0, 1))};
   }
-  const RebindToSigned<decltype(d)> di;
-  using VI = VFromD<decltype(di)>;
-  alignas(16) static constexpr int16_t kReverse[8] = {7, 6, 5, 4, 3, 2, 1, 0};
-  const VI idx = Load(di, kReverse + (kN == 8 ? 0 : 4));
-  return BitCast(d, VI{_mm_permutexvar_epi16(idx.raw, BitCast(di, v).raw)});
+  if (kN == 4) {
+    return VFromD<D>{_mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(0, 1, 2, 3))};
+  }
+
+#if HWY_TARGET == HWY_SSE2
+  const VFromD<D> rev4{
+      _mm_shufflehi_epi16(_mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(0, 1, 2, 3)),
+                          _MM_SHUFFLE(0, 1, 2, 3))};
+  return VFromD<D>{_mm_shuffle_epi32(rev4.raw, _MM_SHUFFLE(1, 0, 3, 2))};
 #else
-  // TODO(janwas): shuffle instead of rotate
-  const RepartitionToWide<RebindToUnsigned<decltype(d)>> du32;
-  return BitCast(d, RotateRight<16>(Reverse(du32, BitCast(du32, v))));
+  const RebindToSigned<decltype(d)> di;
+  alignas(16) static constexpr int16_t kShuffle[8] = {
+      0x0F0E, 0x0D0C, 0x0B0A, 0x0908, 0x0706, 0x0504, 0x0302, 0x0100};
+  return BitCast(d, TableLookupBytes(v, LoadDup128(di, kShuffle)));
 #endif
 }
 
@@ -4511,8 +4517,9 @@ HWY_API VFromD<D> Reverse2(D d, VFromD<D> v) {
 #elif HWY_TARGET == HWY_SSE2
   constexpr size_t kN = MaxLanes(d);
   __m128i shuf_result = _mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(2, 3, 0, 1));
-  if(kN > 4)
+  if (kN > 4) {
     shuf_result = _mm_shufflehi_epi16(shuf_result, _MM_SHUFFLE(2, 3, 0, 1));
+  }
   return VFromD<D>{shuf_result};
 #else
   const RebindToSigned<decltype(d)> di;
@@ -4536,22 +4543,21 @@ HWY_API VFromD<D> Reverse2(D /* tag */, VFromD<D> v) {
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_T_SIZE_D(D, 2)>
 HWY_API VFromD<D> Reverse4(D d, VFromD<D> v) {
-  const RebindToSigned<decltype(d)> di;
   // 4x 16-bit: a single shufflelo suffices.
   constexpr size_t kN = MaxLanes(d);
-  if (kN == 4) {
-    return BitCast(d, Vec128<int16_t, kN>{_mm_shufflelo_epi16(
-                          BitCast(di, v).raw, _MM_SHUFFLE(0, 1, 2, 3))});
+  if (kN <= 4) {
+    return VFromD<D>{_mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(0, 1, 2, 3))};
   }
 
-#if HWY_TARGET <= HWY_AVX3
-  alignas(16) static constexpr int16_t kReverse4[8] = {3, 2, 1, 0, 7, 6, 5, 4};
-  const Vec128<int16_t, kN> idx = Load(di, kReverse4);
-  return BitCast(d, Vec128<int16_t, kN>{
-                        _mm_permutexvar_epi16(idx.raw, BitCast(di, v).raw)});
+#if HWY_TARGET == HWY_SSE2
+  return VFromD<D>{
+      _mm_shufflehi_epi16(_mm_shufflelo_epi16(v.raw, _MM_SHUFFLE(0, 1, 2, 3)),
+                          _MM_SHUFFLE(0, 1, 2, 3))};
 #else
-  const RepartitionToWide<decltype(di)> dw;
-  return Reverse2(d, BitCast(d, Shuffle2301(BitCast(dw, v))));
+  const RebindToSigned<decltype(d)> di;
+  alignas(16) static constexpr int16_t kShuffle[8] = {
+      0x0706, 0x0504, 0x0302, 0x0100, 0x0F0E, 0x0D0C, 0x0B0A, 0x0908};
+  return BitCast(d, TableLookupBytes(v, LoadDup128(di, kShuffle)));
 #endif
 }
 
@@ -4570,16 +4576,14 @@ HWY_API VFromD<D> Reverse4(D /* tag */, VFromD<D> /* v */) {
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_T_SIZE_D(D, 2)>
 HWY_API VFromD<D> Reverse8(D d, const VFromD<D> v) {
-#if HWY_TARGET <= HWY_AVX3
-  const RebindToSigned<decltype(d)> di;
-  using VI = VFromD<decltype(di)>;
-  alignas(32) static constexpr int16_t kReverse8[16] = {
-      7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8};
-  const VI idx = Load(di, kReverse8);
-  return BitCast(d, VI{_mm_permutexvar_epi16(idx.raw, BitCast(di, v).raw)});
-#else
+#if HWY_TARGET == HWY_SSE2
   const RepartitionToWide<decltype(d)> dw;
   return Reverse2(d, BitCast(d, Shuffle0123(BitCast(dw, v))));
+#else
+  const RebindToSigned<decltype(d)> di;
+  alignas(16) static constexpr int16_t kShuffle[8] = {
+      0x0F0E, 0x0D0C, 0x0B0A, 0x0908, 0x0706, 0x0504, 0x0302, 0x0100};
+  return BitCast(d, TableLookupBytes(v, LoadDup128(di, kShuffle)));
 #endif
 }
 
@@ -4587,6 +4591,58 @@ template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_NOT_T_SIZE_D(D, 2)>
 HWY_API VFromD<D> Reverse8(D /* tag */, VFromD<D> /* v */) {
   HWY_ASSERT(0);  // don't have 8 lanes unless 16-bit
 }
+
+// ------------------------------ ReverseLaneBytes
+
+#if HWY_TARGET == HWY_SSE2
+
+#ifdef HWY_NATIVE_REVERSE_LANE_BYTES
+#undef HWY_NATIVE_REVERSE_LANE_BYTES
+#else
+#define HWY_NATIVE_REVERSE_LANE_BYTES
+#endif
+
+template <class V, HWY_IF_T_SIZE_V(V, 2)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const auto vu = BitCast(du, v);
+  return BitCast(d, Or(ShiftLeft<8>(vu), ShiftRight<8>(vu)));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 4)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint16_t, decltype(d)> du16;
+  return BitCast(d, Reverse2(du16, ReverseLaneBytes(BitCast(du16, v))));
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 8)>
+HWY_API V ReverseLaneBytes(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint16_t, decltype(d)> du16;
+  return BitCast(d, Reverse4(du16, ReverseLaneBytes(BitCast(du16, v))));
+}
+
+#endif  // HWY_TARGET == HWY_SSE2
+
+// ------------------------------ ReverseBits
+
+#if HWY_TARGET <= HWY_AVX3_DL
+
+#ifdef HWY_NATIVE_REVERSE_BITS_UI8
+#undef HWY_NATIVE_REVERSE_BITS_UI8
+#else
+#define HWY_NATIVE_REVERSE_BITS_UI8
+#endif
+
+template <class V, HWY_IF_T_SIZE_V(V, 1), HWY_IF_V_SIZE_LE_D(DFromV<V>, 16)>
+HWY_API V ReverseBits(V v) {
+  const Full128<uint64_t> du64_full;
+  const auto affine_matrix = Set(du64_full, 0x8040201008040201u);
+  return V{_mm_gf2p8affine_epi64_epi8(v.raw, affine_matrix.raw, 0)};
+}
+#endif  // HWY_TARGET <= HWY_AVX3_DL
 
 // ------------------------------ InterleaveLower
 
@@ -4937,7 +4993,7 @@ HWY_API Vec64<T> ConcatOdd(D d, Vec64<T> hi, Vec64<T> lo) {
   const Vec64<int32_t> uH = ShiftRight<16>(BitCast(dw, hi));
   const Vec64<int32_t> uL = ShiftRight<16>(BitCast(dw, lo));
   return Vec64<T>{_mm_shuffle_epi32(_mm_packs_epi32(uL.raw, uH.raw),
-                                   _MM_SHUFFLE(2, 0, 2, 0))};
+                                    _MM_SHUFFLE(2, 0, 2, 0))};
 #else
   const Repartition<uint32_t, decltype(d)> du32;
   // Don't care about upper half, no need to zero.
@@ -5039,7 +5095,7 @@ HWY_API Vec128<T> ConcatEven(D d, Vec128<T> hi, Vec128<T> lo) {
 #elif HWY_TARGET == HWY_SSE2
   const Repartition<uint32_t, decltype(d)> dw;
   return ConcatOdd(d, BitCast(d, ShiftLeft<16>(BitCast(dw, hi))),
-                      BitCast(d, ShiftLeft<16>(BitCast(dw, lo))));
+                   BitCast(d, ShiftLeft<16>(BitCast(dw, lo))));
 #else
   // packs_epi32 saturates 0x8000 to 0x7FFF. Instead ConcatEven within the two
   // inputs, then concatenate them.
@@ -5057,7 +5113,7 @@ HWY_API Vec64<T> ConcatEven(D d, Vec64<T> hi, Vec64<T> lo) {
 #if HWY_TARGET == HWY_SSE2
   const Repartition<uint32_t, decltype(d)> dw;
   return ConcatOdd(d, BitCast(d, ShiftLeft<16>(BitCast(dw, hi))),
-                      BitCast(d, ShiftLeft<16>(BitCast(dw, lo))));
+                   BitCast(d, ShiftLeft<16>(BitCast(dw, lo))));
 #else
   const Repartition<uint32_t, decltype(d)> du32;
   // Don't care about upper half, no need to zero.
@@ -5681,8 +5737,8 @@ HWY_API VFromD<D> DemoteTo(D du16, VFromD<Rebind<uint32_t, D>> v) {
   const DFromV<decltype(v)> du32;
   const RebindToSigned<decltype(du32)> di32;
 #if HWY_TARGET >= HWY_SSSE3
-  const auto too_big = VecFromMask(di32,
-    Gt(BitCast(di32, ShiftRight<16>(v)), Zero(di32)));
+  const auto too_big =
+      VecFromMask(di32, Gt(BitCast(di32, ShiftRight<16>(v)), Zero(di32)));
   const auto clamped = Or(BitCast(di32, v), too_big);
 #if HWY_TARGET == HWY_SSE2
   const RebindToSigned<decltype(du16)> di16;
@@ -5754,8 +5810,8 @@ HWY_API VFromD<D> DemoteTo(D du8, VFromD<Rebind<uint32_t, D>> v) {
   // 0x7FFFFFFF through the u8 Min operation below, which will then be converted
   // to 0xFF through the i32->u8 demotion.
   const Repartition<uint8_t, decltype(du32)> du32_as_du8;
-  const auto clamped = BitCast(di32, Min(BitCast(du32_as_du8, v),
-                                         BitCast(du32_as_du8, max_i32)));
+  const auto clamped = BitCast(
+      di32, Min(BitCast(du32_as_du8, v), BitCast(du32_as_du8, max_i32)));
 #else
   const auto clamped = BitCast(di32, Min(v, max_i32));
 #endif
@@ -5789,8 +5845,8 @@ HWY_API VFromD<D> DemoteTo(D du8, VFromD<Rebind<uint16_t, D>> v) {
   // 0x7FFF through the u8 Min operation below, which will then be converted
   // to 0xFF through the i16->u8 demotion.
   const Repartition<uint8_t, decltype(du16)> du16_as_du8;
-  const auto clamped = BitCast(di16, Min(BitCast(du16_as_du8, v),
-                                         BitCast(du16_as_du8, max_i16)));
+  const auto clamped = BitCast(
+      di16, Min(BitCast(du16_as_du8, v), BitCast(du16_as_du8, max_i16)));
 #else
   const auto clamped = BitCast(di16, Min(v, max_i16));
 #endif
@@ -5913,9 +5969,9 @@ HWY_API Vec128<uint16_t> ReorderDemote2To(D dn, Vec128<int32_t> a,
 #endif
 }
 
-template<class D, HWY_IF_U16_D(D)>
+template <class D, HWY_IF_U16_D(D)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint32_t> a,
-                                         Vec128<uint32_t> b) {
+                                   Vec128<uint32_t> b) {
   const DFromV<decltype(a)> du32;
   const RebindToSigned<decltype(du32)> di32;
   const auto max_i32 = Set(du32, 0x7FFFFFFFu);
@@ -5923,10 +5979,10 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint32_t> a,
 #if HWY_TARGET >= HWY_SSSE3
   const Repartition<uint8_t, decltype(du32)> du32_as_du8;
   // On SSE2/SSSE3, clamp a and b using u8 Min operation
-  const auto clamped_a = BitCast(di32, Min(BitCast(du32_as_du8, a),
-                                           BitCast(du32_as_du8, max_i32)));
-  const auto clamped_b = BitCast(di32, Min(BitCast(du32_as_du8, b),
-                                           BitCast(du32_as_du8, max_i32)));
+  const auto clamped_a = BitCast(
+      di32, Min(BitCast(du32_as_du8, a), BitCast(du32_as_du8, max_i32)));
+  const auto clamped_b = BitCast(
+      di32, Min(BitCast(du32_as_du8, b), BitCast(du32_as_du8, max_i32)));
 #else
   const auto clamped_a = BitCast(di32, Min(a, max_i32));
   const auto clamped_b = BitCast(di32, Min(b, max_i32));
@@ -5935,7 +5991,7 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint32_t> a,
   return ReorderDemote2To(dn, clamped_a, clamped_b);
 }
 
-template<class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U16_D(D)>
+template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U16_D(D)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<uint32_t, D>> a,
                                    VFromD<Repartition<uint32_t, D>> b) {
   const DFromV<decltype(a)> d;
@@ -5978,13 +6034,13 @@ HWY_API Vec64<uint8_t> ReorderDemote2To(D /* tag */, Vec64<int16_t> a,
 }
 template <class D, HWY_IF_U8_D(D)>
 HWY_API Vec128<uint8_t> ReorderDemote2To(D /* tag */, Vec128<int16_t> a,
-                                          Vec128<int16_t> b) {
+                                         Vec128<int16_t> b) {
   return Vec128<uint8_t>{_mm_packus_epi16(a.raw, b.raw)};
 }
 
-template<class D, HWY_IF_U8_D(D)>
+template <class D, HWY_IF_U8_D(D)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint16_t> a,
-                                         Vec128<uint16_t> b) {
+                                   Vec128<uint16_t> b) {
   const DFromV<decltype(a)> du16;
   const RebindToSigned<decltype(du16)> di16;
   const auto max_i16 = Set(du16, 0x7FFFu);
@@ -5992,10 +6048,10 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint16_t> a,
 #if HWY_TARGET >= HWY_SSSE3
   const Repartition<uint8_t, decltype(du16)> du16_as_du8;
   // On SSE2/SSSE3, clamp a and b using u8 Min operation
-  const auto clamped_a = BitCast(di16, Min(BitCast(du16_as_du8, a),
-                                           BitCast(du16_as_du8, max_i16)));
-  const auto clamped_b = BitCast(di16, Min(BitCast(du16_as_du8, b),
-                                           BitCast(du16_as_du8, max_i16)));
+  const auto clamped_a = BitCast(
+      di16, Min(BitCast(du16_as_du8, a), BitCast(du16_as_du8, max_i16)));
+  const auto clamped_b = BitCast(
+      di16, Min(BitCast(du16_as_du8, b), BitCast(du16_as_du8, max_i16)));
 #else
   const auto clamped_a = BitCast(di16, Min(a, max_i16));
   const auto clamped_b = BitCast(di16, Min(b, max_i16));
@@ -6004,7 +6060,7 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, Vec128<uint16_t> a,
   return ReorderDemote2To(dn, clamped_a, clamped_b);
 }
 
-template<class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U8_D(D)>
+template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U8_D(D)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<uint16_t, D>> a,
                                    VFromD<Repartition<uint16_t, D>> b) {
   const DFromV<decltype(a)> d;
@@ -6013,16 +6069,14 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<uint16_t, D>> a,
 }
 
 template <class D, HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromD<D>),
-          HWY_IF_V_SIZE_LE_D(D, 16),
-          class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          HWY_IF_V_SIZE_LE_D(D, 16), class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
           HWY_IF_T_SIZE_V(V, sizeof(TFromD<D>) * 2),
           HWY_IF_LANES_D(D, HWY_MAX_LANES_D(DFromV<V>) * 2)>
 HWY_API VFromD<D> OrderedDemote2To(D d, V a, V b) {
   return ReorderDemote2To(d, a, b);
 }
 
-template <class D, HWY_IF_BF16_D(D),
-          class V32 = VFromD<Repartition<float, D>>>
+template <class D, HWY_IF_BF16_D(D), class V32 = VFromD<Repartition<float, D>>>
 HWY_API VFromD<D> OrderedDemote2To(D dbf16, V32 a, V32 b) {
   const RebindToUnsigned<decltype(dbf16)> du16;
   return BitCast(dbf16, ConcatOdd(du16, BitCast(du16, b), BitCast(du16, a)));
@@ -6107,13 +6161,13 @@ HWY_API Vec128<int16_t> MulFixedPoint15(const Vec128<int16_t> a,
   auto hi_product = MulHigh(a, b);
 
   const VFromD<decltype(di32)> i32_product_lo{
-    _mm_unpacklo_epi16(lo_product.raw, hi_product.raw)};
+      _mm_unpacklo_epi16(lo_product.raw, hi_product.raw)};
   const VFromD<decltype(di32)> i32_product_hi{
-    _mm_unpackhi_epi16(lo_product.raw, hi_product.raw)};
+      _mm_unpackhi_epi16(lo_product.raw, hi_product.raw)};
 
   const auto round_up_incr = Set(di32, 0x4000);
   return ReorderDemote2To(d, ShiftRight<15>(i32_product_lo + round_up_incr),
-                             ShiftRight<15>(i32_product_hi + round_up_incr));
+                          ShiftRight<15>(i32_product_hi + round_up_incr));
 }
 
 template <size_t N, HWY_IF_V_SIZE_LE(int16_t, N, 8)>
@@ -6125,7 +6179,7 @@ HWY_API Vec128<int16_t, N> MulFixedPoint15(const Vec128<int16_t, N> a,
   const auto lo_product = a * b;
   const auto hi_product = MulHigh(a, b);
   const VFromD<decltype(di32)> i32_product{
-    _mm_unpacklo_epi16(lo_product.raw, hi_product.raw)};
+      _mm_unpacklo_epi16(lo_product.raw, hi_product.raw)};
 
   return DemoteTo(d, ShiftRight<15>(i32_product + Set(di32, 0x4000)));
 }
@@ -6206,8 +6260,8 @@ HWY_API VFromD<D> TruncateTo(D /* tag */, VFromD<Rebind<uint32_t, D>> v) {
   const RebindToSigned<decltype(du32)> di32;
   const Rebind<uint16_t, decltype(di32)> du16;
   const RebindToSigned<decltype(du16)> di16;
-  return BitCast(du16, DemoteTo(di16, ShiftRight<16>(
-    BitCast(di32, ShiftLeft<16>(v)))));
+  return BitCast(
+      du16, DemoteTo(di16, ShiftRight<16>(BitCast(di32, ShiftLeft<16>(v)))));
 #else
   const Repartition<uint16_t, decltype(du32)> d;
   return LowerHalf(ConcatEven(d, BitCast(d, v), BitCast(d, v)));
@@ -6221,8 +6275,8 @@ HWY_API VFromD<D> TruncateTo(D /* tag */, VFromD<Rebind<uint16_t, D>> v) {
   const RebindToSigned<decltype(du16)> di16;
   const Rebind<uint8_t, decltype(di16)> du8;
   const RebindToSigned<decltype(du8)> di8;
-  return BitCast(du8, DemoteTo(di8, ShiftRight<8>(
-    BitCast(di16, ShiftLeft<8>(v)))));
+  return BitCast(du8,
+                 DemoteTo(di8, ShiftRight<8>(BitCast(di16, ShiftLeft<8>(v)))));
 #else
   const Repartition<uint8_t, decltype(du16)> d;
   return LowerHalf(ConcatEven(d, BitCast(d, v), BitCast(d, v)));
@@ -6288,11 +6342,11 @@ template <class D, HWY_IF_V_SIZE_LE_D(D, 2), HWY_IF_U8_D(D)>
 HWY_API VFromD<D> DemoteTo(D /* tag */, VFromD<Rebind<uint64_t, D>> v) {
   return VFromD<D>{_mm_cvtusepi64_epi8(v.raw)};
 }
-#else  // AVX2 or below
+#else   // AVX2 or below
 namespace detail {
 template <class D, HWY_IF_UNSIGNED_D(D)>
 HWY_INLINE VFromD<Rebind<uint64_t, D>> DemoteFromU64MaskOutResult(
-  D /*dn*/, VFromD<Rebind<uint64_t, D>> v) {
+    D /*dn*/, VFromD<Rebind<uint64_t, D>> v) {
   return v;
 }
 
@@ -6301,7 +6355,7 @@ HWY_INLINE VFromD<Rebind<uint64_t, D>> DemoteFromU64MaskOutResult(
     D /*dn*/, VFromD<Rebind<uint64_t, D>> v) {
   const DFromV<decltype(v)> du64;
   return And(v,
-    Set(du64, static_cast<uint64_t>(hwy::HighestValue<TFromD<D>>())));
+             Set(du64, static_cast<uint64_t>(hwy::HighestValue<TFromD<D>>())));
 }
 
 template <class D>
@@ -6309,11 +6363,12 @@ HWY_INLINE VFromD<Rebind<uint64_t, D>> DemoteFromU64Saturate(
     D dn, VFromD<Rebind<uint64_t, D>> v) {
   const Rebind<uint64_t, D> du64;
   const RebindToSigned<decltype(du64)> di64;
-  constexpr int kShiftAmt = static_cast<int>(sizeof(TFromD<D>) * 8)
-                            - static_cast<int>(hwy::IsSigned<TFromD<D>>());
+  constexpr int kShiftAmt = static_cast<int>(sizeof(TFromD<D>) * 8) -
+                            static_cast<int>(hwy::IsSigned<TFromD<D>>());
 
-  const auto too_big = BitCast(du64, VecFromMask(di64,
-    Gt(BitCast(di64, ShiftRight<kShiftAmt>(v)), Zero(di64))));
+  const auto too_big = BitCast(
+      du64, VecFromMask(
+                di64, Gt(BitCast(di64, ShiftRight<kShiftAmt>(v)), Zero(di64))));
   return DemoteFromU64MaskOutResult(dn, Or(v, too_big));
 }
 
@@ -6325,7 +6380,7 @@ HWY_INLINE VFromD<D> ReorderDemote2From64To32Combine(D dn, V a, V b) {
 }  // namespace detail
 
 template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2) | (1 << 4)),
-                   HWY_IF_SIGNED_D(D)>
+          HWY_IF_SIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D dn, VFromD<Rebind<int64_t, D>> v) {
   const DFromV<decltype(v)> di64;
   const RebindToUnsigned<decltype(di64)> du64;
@@ -6334,13 +6389,14 @@ HWY_API VFromD<D> DemoteTo(D dn, VFromD<Rebind<int64_t, D>> v) {
   // Negative values are saturated by first saturating their bitwise inverse
   // and then inverting the saturation result
   const auto invert_mask = BitCast(du64, BroadcastSignBit(v));
-  const auto saturated_vals = Xor(invert_mask,
-    detail::DemoteFromU64Saturate(dn, Xor(invert_mask, BitCast(du64, v))));
+  const auto saturated_vals = Xor(
+      invert_mask,
+      detail::DemoteFromU64Saturate(dn, Xor(invert_mask, BitCast(du64, v))));
   return BitCast(dn, TruncateTo(dn_u, saturated_vals));
 }
 
 template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2) | (1 << 4)),
-                   HWY_IF_UNSIGNED_D(D)>
+          HWY_IF_UNSIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D dn, VFromD<Rebind<int64_t, D>> v) {
   const DFromV<decltype(v)> di64;
   const RebindToUnsigned<decltype(di64)> du64;
@@ -6350,17 +6406,16 @@ HWY_API VFromD<D> DemoteTo(D dn, VFromD<Rebind<int64_t, D>> v) {
 }
 
 template <class D, HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2) | (1 << 4)),
-                   HWY_IF_UNSIGNED_D(D)>
+          HWY_IF_UNSIGNED_D(D)>
 HWY_API VFromD<D> DemoteTo(D dn, VFromD<Rebind<uint64_t, D>> v) {
   return TruncateTo(dn, detail::DemoteFromU64Saturate(dn, v));
 }
 #endif  // HWY_TARGET <= HWY_AVX3
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, HWY_MAX_BYTES / 2),
-                   HWY_IF_T_SIZE_D(D, 4),
-                   HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromD<D>)>
+          HWY_IF_T_SIZE_D(D, 4), HWY_IF_NOT_FLOAT_NOR_SPECIAL(TFromD<D>)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<int64_t, D>> a,
-                                         VFromD<Repartition<int64_t, D>> b) {
+                                   VFromD<Repartition<int64_t, D>> b) {
   const DFromV<decltype(a)> d;
   const Twice<decltype(d)> dt;
   return DemoteTo(dn, Combine(dt, b, a));
@@ -6368,7 +6423,7 @@ HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<int64_t, D>> a,
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, HWY_MAX_BYTES / 2), HWY_IF_U32_D(D)>
 HWY_API VFromD<D> ReorderDemote2To(D dn, VFromD<Repartition<uint64_t, D>> a,
-                                         VFromD<Repartition<uint64_t, D>> b) {
+                                   VFromD<Repartition<uint64_t, D>> b) {
   const DFromV<decltype(a)> d;
   const Twice<decltype(d)> dt;
   return DemoteTo(dn, Combine(dt, b, a));
@@ -6386,10 +6441,12 @@ HWY_API Vec128<int32_t> ReorderDemote2To(D dn, Vec128<int64_t> a,
   // and then inverting the saturation result
   const auto invert_mask_a = BitCast(du64, BroadcastSignBit(a));
   const auto invert_mask_b = BitCast(du64, BroadcastSignBit(b));
-  const auto saturated_a = Xor(invert_mask_a,
-    detail::DemoteFromU64Saturate(dnh, Xor(invert_mask_a, BitCast(du64, a))));
-  const auto saturated_b = Xor(invert_mask_b,
-    detail::DemoteFromU64Saturate(dnh, Xor(invert_mask_b, BitCast(du64, b))));
+  const auto saturated_a = Xor(
+      invert_mask_a,
+      detail::DemoteFromU64Saturate(dnh, Xor(invert_mask_a, BitCast(du64, a))));
+  const auto saturated_b = Xor(
+      invert_mask_b,
+      detail::DemoteFromU64Saturate(dnh, Xor(invert_mask_b, BitCast(du64, b))));
 
   return ConcatEven(dn, BitCast(dn, saturated_b), BitCast(dn, saturated_a));
 }
@@ -6401,10 +6458,10 @@ HWY_API Vec128<uint32_t> ReorderDemote2To(D dn, Vec128<int64_t> a,
   const RebindToUnsigned<decltype(di64)> du64;
   const Half<decltype(dn)> dnh;
 
-  const auto saturated_a = detail::DemoteFromU64Saturate(dnh,
-    BitCast(du64, AndNot(BroadcastSignBit(a), a)));
-  const auto saturated_b = detail::DemoteFromU64Saturate(dnh,
-    BitCast(du64, AndNot(BroadcastSignBit(b), b)));
+  const auto saturated_a = detail::DemoteFromU64Saturate(
+      dnh, BitCast(du64, AndNot(BroadcastSignBit(a), a)));
+  const auto saturated_b = detail::DemoteFromU64Saturate(
+      dnh, BitCast(du64, AndNot(BroadcastSignBit(b), b)));
 
   return ConcatEven(dn, BitCast(dn, saturated_b), BitCast(dn, saturated_a));
 }
@@ -6829,7 +6886,7 @@ HWY_INLINE MFromD<D> LoadMaskBits128(D d, uint64_t mask_bits) {
   // {b0, b0, b0, b0, b1, b1, b1, b1, ...} ==>
   // {b0, b0, b0, b0, b0, b0, b0, b0, b1, b1, b1, b1, b1, b1, b1, b1}
   const VFromD<decltype(du)> rep8{
-    _mm_unpacklo_epi32(unpacked_vbits, unpacked_vbits)};
+      _mm_unpacklo_epi32(unpacked_vbits, unpacked_vbits)};
 #else
   // Replicate bytes 8x such that each byte contains the bit that governs it.
   alignas(16) static constexpr uint8_t kRep8[16] = {0, 0, 0, 0, 0, 0, 0, 0,
@@ -8218,6 +8275,31 @@ template <class D, class V = VFromD<D>>
 HWY_API V Max128Upper(D d, const V a, const V b) {
   return IfVecThenElse(detail::Lt128UpperVec(d, b, a), a, b);
 }
+
+// -------------------- LeadingZeroCount, TrailingZeroCount, HighestSetBitIndex
+
+#if HWY_TARGET <= HWY_AVX3
+
+#ifdef HWY_NATIVE_LEADING_ZERO_COUNT
+#undef HWY_NATIVE_LEADING_ZERO_COUNT
+#else
+#define HWY_NATIVE_LEADING_ZERO_COUNT
+#endif
+
+template <class V, HWY_IF_UI32(TFromV<V>), HWY_IF_V_SIZE_LE_D(DFromV<V>, 16)>
+HWY_API V LeadingZeroCount(V v) {
+  return V{_mm_lzcnt_epi32(v.raw)};
+}
+
+template <class V, HWY_IF_UI64(TFromV<V>), HWY_IF_V_SIZE_LE_D(DFromV<V>, 16)>
+HWY_API V LeadingZeroCount(V v) {
+  return V{_mm_lzcnt_epi64(v.raw)};
+}
+
+// HighestSetBitIndex and TrailingZeroCount is implemented in x86_512-inl.h
+// for AVX3 targets
+
+#endif  // HWY_TARGET <= HWY_AVX3
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -137,6 +137,7 @@ enum class FeatureIndex : uint32_t {
 
   kAVX512F,
   kAVX512VL,
+  kAVX512CD,
   kAVX512DQ,
   kAVX512BW,
 
@@ -147,6 +148,7 @@ enum class FeatureIndex : uint32_t {
   kVAES,
   kPOPCNTDQ,
   kBITALG,
+  kGFNI,
 
   kSentinel
 };
@@ -191,11 +193,13 @@ uint64_t FlagsFromCPUID() {
 
     flags |= IsBitSet(abcd[1], 16) ? Bit(FeatureIndex::kAVX512F) : 0;
     flags |= IsBitSet(abcd[1], 17) ? Bit(FeatureIndex::kAVX512DQ) : 0;
+    flags |= IsBitSet(abcd[1], 28) ? Bit(FeatureIndex::kAVX512CD) : 0;
     flags |= IsBitSet(abcd[1], 30) ? Bit(FeatureIndex::kAVX512BW) : 0;
     flags |= IsBitSet(abcd[1], 31) ? Bit(FeatureIndex::kAVX512VL) : 0;
 
     flags |= IsBitSet(abcd[2], 1) ? Bit(FeatureIndex::kVBMI) : 0;
     flags |= IsBitSet(abcd[2], 6) ? Bit(FeatureIndex::kVBMI2) : 0;
+    flags |= IsBitSet(abcd[2], 8) ? Bit(FeatureIndex::kGFNI) : 0;
     flags |= IsBitSet(abcd[2], 9) ? Bit(FeatureIndex::kVAES) : 0;
     flags |= IsBitSet(abcd[2], 10) ? Bit(FeatureIndex::kVPCLMULQDQ) : 0;
     flags |= IsBitSet(abcd[2], 11) ? Bit(FeatureIndex::kVNNI) : 0;
@@ -211,8 +215,7 @@ constexpr uint64_t kGroupSSE2 =
     Bit(FeatureIndex::kSSE) | Bit(FeatureIndex::kSSE2);
 
 constexpr uint64_t kGroupSSSE3 =
-    Bit(FeatureIndex::kSSE3) | Bit(FeatureIndex::kSSSE3) |
-    kGroupSSE2;
+    Bit(FeatureIndex::kSSE3) | Bit(FeatureIndex::kSSSE3) | kGroupSSE2;
 
 constexpr uint64_t kGroupSSE4 =
     Bit(FeatureIndex::kSSE41) | Bit(FeatureIndex::kSSE42) |
@@ -242,13 +245,14 @@ constexpr uint64_t kGroupAVX2 =
 
 constexpr uint64_t kGroupAVX3 =
     Bit(FeatureIndex::kAVX512F) | Bit(FeatureIndex::kAVX512VL) |
-    Bit(FeatureIndex::kAVX512DQ) | Bit(FeatureIndex::kAVX512BW) | kGroupAVX2;
+    Bit(FeatureIndex::kAVX512DQ) | Bit(FeatureIndex::kAVX512BW) |
+    Bit(FeatureIndex::kAVX512CD) | kGroupAVX2;
 
 constexpr uint64_t kGroupAVX3_DL =
     Bit(FeatureIndex::kVNNI) | Bit(FeatureIndex::kVPCLMULQDQ) |
     Bit(FeatureIndex::kVBMI) | Bit(FeatureIndex::kVBMI2) |
     Bit(FeatureIndex::kVAES) | Bit(FeatureIndex::kPOPCNTDQ) |
-    Bit(FeatureIndex::kBITALG) | kGroupAVX3;
+    Bit(FeatureIndex::kBITALG) | Bit(FeatureIndex::kGFNI) | kGroupAVX3;
 
 int64_t DetectTargets() {
   int64_t bits = 0;  // return value of supported targets.

--- a/hwy/tests/combine_test.cc
+++ b/hwy/tests/combine_test.cc
@@ -240,6 +240,29 @@ struct TestConcatOddEven {
     HWY_ASSERT_VEC_EQ(d, odd, ConcatOdd(d, hi, lo));
     HWY_ASSERT_VEC_EQ(d, even, ConcatEven(d, hi, lo));
 
+    const auto v_1 = Set(d, T{1});
+    const auto v_2 = Set(d, T{2});
+    const auto v_3 = Set(d, T{3});
+    const auto v_4 = Set(d, T{4});
+
+    const Half<decltype(d)> dh;
+    const auto v_12 = InterleaveLower(v_1, v_2); /* {1, 2, 1, 2, ...} */
+    const auto v_34 = InterleaveLower(v_3, v_4); /* {3, 4, 3, 4, ...} */
+    const auto v_13 =
+        ConcatLowerLower(d, v_3, v_1); /* {1, 1, ..., 3, 3, ...} */
+    const auto v_24 =
+        ConcatLowerLower(d, v_4, v_2); /* {2, 2, ..., 4, 4, ...} */
+
+    const auto concat_even_1234_result = ConcatEven(d, v_34, v_12);
+    const auto concat_odd_1234_result = ConcatOdd(d, v_34, v_12);
+
+    HWY_ASSERT_VEC_EQ(d, v_13, concat_even_1234_result);
+    HWY_ASSERT_VEC_EQ(d, v_24, concat_odd_1234_result);
+    HWY_ASSERT_VEC_EQ(dh, LowerHalf(dh, v_3),
+                      UpperHalf(dh, concat_even_1234_result));
+    HWY_ASSERT_VEC_EQ(dh, LowerHalf(dh, v_4),
+                      UpperHalf(dh, concat_odd_1234_result));
+
     // This test catches inadvertent saturation.
     const auto min = Set(d, LowestValue<T>());
     const auto max = Set(d, HighestValue<T>());

--- a/hwy/tests/logical_test.cc
+++ b/hwy/tests/logical_test.cc
@@ -213,9 +213,9 @@ struct TestPopulationCount {
     auto data = AllocateAligned<T>(N);
     auto popcnt = AllocateAligned<T>(N);
     for (size_t i = 0; i < AdjustedReps(1 << 18) / N; i++) {
-      for (size_t i = 0; i < N; i++) {
-        data[i] = static_cast<T>(rng());
-        popcnt[i] = static_cast<T>(PopCount(data[i]));
+      for (size_t j = 0; j < N; j++) {
+        data[j] = static_cast<T>(rng());
+        popcnt[j] = static_cast<T>(PopCount(data[j]));
       }
       HWY_ASSERT_VEC_EQ(d, popcnt.get(), PopulationCount(Load(d, data.get())));
     }
@@ -224,6 +224,236 @@ struct TestPopulationCount {
 
 HWY_NOINLINE void TestAllPopulationCount() {
   ForUnsignedTypes(ForPartialVectors<TestPopulationCount>());
+}
+
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T), HWY_IF_T_SIZE(T, 4)>
+static HWY_INLINE T LeadingZeroCountOfValue(T val) {
+  const uint32_t u32_val = static_cast<uint32_t>(val);
+  return static_cast<T>(u32_val ? Num0BitsAboveMS1Bit_Nonzero32(u32_val) : 32);
+}
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T), HWY_IF_T_SIZE(T, 8)>
+static HWY_INLINE T LeadingZeroCountOfValue(T val) {
+  const uint64_t u64_val = static_cast<uint64_t>(val);
+  return static_cast<T>(u64_val ? Num0BitsAboveMS1Bit_Nonzero64(u64_val) : 64);
+}
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T),
+          HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2))>
+static HWY_INLINE T LeadingZeroCountOfValue(T val) {
+  using TU = MakeUnsigned<T>;
+  constexpr uint32_t kNumOfExtraLeadingZeros{32 - (sizeof(T) * 8)};
+  return static_cast<T>(
+      LeadingZeroCountOfValue(static_cast<uint32_t>(static_cast<TU>(val))) -
+      kNumOfExtraLeadingZeros);
+}
+
+struct TestLeadingZeroCount {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+    using TU = MakeUnsigned<T>;
+    const RebindToUnsigned<decltype(d)> du;
+    size_t N = Lanes(d);
+    auto data = AllocateAligned<T>(N);
+    auto lzcnt = AllocateAligned<T>(N);
+
+    constexpr T kNumOfBitsInT{sizeof(T) * 8};
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = kNumOfBitsInT;
+    }
+    HWY_ASSERT_VEC_EQ(d, lzcnt.get(), LeadingZeroCount(Zero(d)));
+
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = T{kNumOfBitsInT - 1};
+    }
+    HWY_ASSERT_VEC_EQ(d, lzcnt.get(), LeadingZeroCount(Set(d, T{1})));
+
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = T{kNumOfBitsInT - 2};
+    }
+    HWY_ASSERT_VEC_EQ(d, lzcnt.get(), LeadingZeroCount(Set(d, T{2})));
+
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = T{0};
+    }
+    HWY_ASSERT_VEC_EQ(
+        d, lzcnt.get(),
+        LeadingZeroCount(BitCast(d, Set(du, TU{1} << (kNumOfBitsInT - 1)))));
+
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = T{1};
+    }
+    HWY_ASSERT_VEC_EQ(d, lzcnt.get(),
+                      LeadingZeroCount(Set(d, T{1} << (kNumOfBitsInT - 2))));
+
+    for (size_t j = 0; j < N; j++) {
+      lzcnt[j] = T{kNumOfBitsInT - 5};
+    }
+    HWY_ASSERT_VEC_EQ(d, lzcnt.get(), LeadingZeroCount(Set(d, T{0x1D})));
+
+    for (size_t i = 0; i < AdjustedReps(1000); i++) {
+      for (size_t j = 0; j < N; j++) {
+        data[j] = static_cast<T>(rng());
+        lzcnt[j] = LeadingZeroCountOfValue(data[j]);
+      }
+      HWY_ASSERT_VEC_EQ(d, lzcnt.get(), LeadingZeroCount(Load(d, data.get())));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllLeadingZeroCount() {
+  ForIntegerTypes(ForPartialVectors<TestLeadingZeroCount>());
+}
+
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T),
+          HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4))>
+static HWY_INLINE T TrailingZeroCountOfValue(T val) {
+  using TU = MakeUnsigned<T>;
+  constexpr size_t kNumOfBitsInT = sizeof(T) * 8;
+  const uint32_t u32_val = static_cast<uint32_t>(static_cast<TU>(val));
+  return static_cast<T>(u32_val ? Num0BitsBelowLS1Bit_Nonzero32(u32_val)
+                                : kNumOfBitsInT);
+}
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T), HWY_IF_T_SIZE(T, 8)>
+static HWY_INLINE T TrailingZeroCountOfValue(T val) {
+  const uint64_t u64_val = static_cast<uint64_t>(val);
+  return static_cast<T>(u64_val ? Num0BitsBelowLS1Bit_Nonzero64(u64_val) : 64);
+}
+
+struct TestTrailingZeroCount {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+    using TU = MakeUnsigned<T>;
+    const RebindToUnsigned<decltype(d)> du;
+
+    size_t N = Lanes(d);
+    auto data = AllocateAligned<T>(N);
+    auto tzcnt = AllocateAligned<T>(N);
+
+    constexpr T kNumOfBitsInT{sizeof(T) * 8};
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = kNumOfBitsInT;
+    }
+    HWY_ASSERT_VEC_EQ(d, tzcnt.get(), TrailingZeroCount(Zero(d)));
+
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = T{0};
+    }
+    HWY_ASSERT_VEC_EQ(d, tzcnt.get(), TrailingZeroCount(Set(d, T{1})));
+
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = T{1};
+    }
+    HWY_ASSERT_VEC_EQ(d, tzcnt.get(), TrailingZeroCount(Set(d, T{2})));
+
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = T{kNumOfBitsInT - 1};
+    }
+    HWY_ASSERT_VEC_EQ(
+        d, tzcnt.get(),
+        TrailingZeroCount(BitCast(d, Set(du, TU{1} << (kNumOfBitsInT - 1)))));
+
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = T{kNumOfBitsInT - 2};
+    }
+    HWY_ASSERT_VEC_EQ(d, tzcnt.get(),
+                      TrailingZeroCount(Set(d, T{1} << (kNumOfBitsInT - 2))));
+
+    for (size_t j = 0; j < N; j++) {
+      tzcnt[j] = T{3};
+    }
+    HWY_ASSERT_VEC_EQ(d, tzcnt.get(), TrailingZeroCount(Set(d, T{0x68})));
+
+    for (size_t i = 0; i < AdjustedReps(1000); i++) {
+      for (size_t j = 0; j < N; j++) {
+        data[j] = static_cast<T>(rng());
+        tzcnt[j] = TrailingZeroCountOfValue(data[j]);
+      }
+      HWY_ASSERT_VEC_EQ(d, tzcnt.get(), TrailingZeroCount(Load(d, data.get())));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllTrailingZeroCount() {
+  ForIntegerTypes(ForPartialVectors<TestTrailingZeroCount>());
+}
+
+class TestHighestSetBitIndex {
+ private:
+  template <class V>
+  static HWY_INLINE V NormalizedHighestSetBitIndex(V v) {
+    const DFromV<decltype(v)> d;
+    const RebindToSigned<decltype(d)> di;
+    const auto hsb_idx = BitCast(di, HighestSetBitIndex(v));
+    return BitCast(d, Or(BroadcastSignBit(hsb_idx), hsb_idx));
+  }
+
+ public:
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+    using TU = MakeUnsigned<T>;
+    const RebindToUnsigned<decltype(d)> du;
+
+    size_t N = Lanes(d);
+    auto data = AllocateAligned<T>(N);
+    auto hsb_index = AllocateAligned<T>(N);
+
+    constexpr T kNumOfBitsInT{sizeof(T) * 8};
+    constexpr T kMsbIdx{kNumOfBitsInT - 1};
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = static_cast<T>(-1);
+    }
+    HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                      NormalizedHighestSetBitIndex(Zero(d)));
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = T{0};
+    }
+    HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                      NormalizedHighestSetBitIndex(Set(d, T{1})));
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = T{1};
+    }
+    HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                      NormalizedHighestSetBitIndex(Set(d, T{3})));
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = T{kNumOfBitsInT - 1};
+    }
+    HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                      NormalizedHighestSetBitIndex(
+                          BitCast(d, Set(du, TU{1} << (kNumOfBitsInT - 1)))));
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = T{kNumOfBitsInT - 2};
+    }
+    HWY_ASSERT_VEC_EQ(
+        d, hsb_index.get(),
+        NormalizedHighestSetBitIndex(Set(d, T{1} << (kNumOfBitsInT - 2))));
+
+    for (size_t j = 0; j < N; j++) {
+      hsb_index[j] = T{5};
+    }
+    HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                      NormalizedHighestSetBitIndex(Set(d, T{0x2B})));
+
+    for (size_t i = 0; i < AdjustedReps(1000); i++) {
+      for (size_t j = 0; j < N; j++) {
+        data[j] = static_cast<T>(rng());
+        hsb_index[j] =
+            static_cast<T>(kMsbIdx - LeadingZeroCountOfValue(data[j]));
+      }
+      HWY_ASSERT_VEC_EQ(d, hsb_index.get(),
+                        NormalizedHighestSetBitIndex(Load(d, data.get())));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllHighestSetBitIndex() {
+  ForIntegerTypes(ForPartialVectors<TestHighestSetBitIndex>());
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -241,6 +471,9 @@ HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllCopySign);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllBroadcastSignBit);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllTestBit);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllPopulationCount);
+HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllLeadingZeroCount);
+HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllTrailingZeroCount);
+HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllHighestSetBitIndex);
 }  // namespace hwy
 
 #endif

--- a/hwy/tests/logical_test.cc
+++ b/hwy/tests/logical_test.cc
@@ -248,7 +248,7 @@ static HWY_INLINE T LeadingZeroCountOfValue(T val) {
 
 struct TestLeadingZeroCount {
   template <class T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+  HWY_ATTR_NO_MSAN HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
     using TU = MakeUnsigned<T>;
     const RebindToUnsigned<decltype(d)> du;
@@ -321,7 +321,7 @@ static HWY_INLINE T TrailingZeroCountOfValue(T val) {
 
 struct TestTrailingZeroCount {
   template <class T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+  HWY_ATTR_NO_MSAN HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
     using TU = MakeUnsigned<T>;
     const RebindToUnsigned<decltype(d)> du;
@@ -390,7 +390,7 @@ class TestHighestSetBitIndex {
 
  public:
   template <class T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+  HWY_ATTR_NO_MSAN HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
     using TU = MakeUnsigned<T>;
     const RebindToUnsigned<decltype(d)> du;

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -25,8 +25,7 @@
 #include "hwy/print-inl.h"
 
 // Per-target include guard
-#if defined(HIGHWAY_HWY_TESTS_TEST_UTIL_INL_H_) == \
-    defined(HWY_TARGET_TOGGLE)
+#if defined(HIGHWAY_HWY_TESTS_TEST_UTIL_INL_H_) == defined(HWY_TARGET_TOGGLE)
 #ifdef HIGHWAY_HWY_TESTS_TEST_UTIL_INL_H_
 #undef HIGHWAY_HWY_TESTS_TEST_UTIL_INL_H_
 #else
@@ -646,6 +645,15 @@ template <class Func>
 void ForUIF3264(const Func& func) {
   ForUIF32(func);
   ForUIF64(func);
+}
+
+template <class Func>
+void ForU163264(const Func& func) {
+  func(uint16_t());
+  func(uint32_t());
+#if HWY_HAVE_INTEGER64
+  func(uint64_t());
+#endif
 }
 
 template <class Func>


### PR DESCRIPTION
The following operations were added:
- LeadingZeroCount - returns the number of leading zeros for each lane (similar to the AVX3 VPLZCNTD/VPLZCNTQ instruction or the GCC/Clang __builtin_clz intrinsic)
- TrailingZeroCount - returns the number of trailing zeros for each lane (similar to the x86 BSF/TZCNT instruction, the GCC/Clang __builtin_ctz intrinsic, or the MSVC _BitScanForward intrinsic)
- HighestSetBitIndex - returns the index of the highest set bit for each lane (similar to the x86 BSR instruction or the MSVC _BitScanReverse intrinsic)
- OrderedTruncate2To - similar to OrderedDemote2To, but truncates values instead of saturating values
- ReverseLaneBytes - swaps the bytes of each lane, more efficient than TableLookupBytes on NEON/SVE/SVE2/SSE2/PPC9/PPC10, used to implement ReverseBits for I16/U16/I32/U32/I64/U64 on some platforms
- ReverseBits - reverses the bits of each lane, used to implement TrailingZeroCount on NEON/SVE

Also fixed bugs with AVX3_DL TruncateTo, SVE ConcatEven for partial vectors, and SVE ConcatOdd for partial vectors.

All of the Highway tests now pass successfully on the HWY_AVX3_DL target with the TruncateTo bug fixes.

Also fixed compilation errors with the FirstN implementation in x86_512-inl.h on 32-bit x86. All of the HWY_AVX3 tests also now pass on 32-bit x86 when compiled with GCC 12.

Some of the Highway source files have also been reformatted.