### PR TITLE
Added endian detection macros

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1477,6 +1477,12 @@ The above were previously known as `HWY_CAP_INTEGER64`, `HWY_CAP_FLOAT16`, and
     implemented as `Add(Mul(f, m), a)`. Checking this can be useful for
     increasing the tolerance of expected results (around 1E-5 or 1E-6).
 
+*   `HWY_IS_LITTLE_ENDIAN` expands to 1 on little-endian targets and to 0 on
+    big-endian targets.
+
+*   `HWY_IS_BIG_ENDIAN` expands to 0 on big-endian targets and to 1 on
+    little-endian targets.
+
 The following were used to signal the maximum number of lanes for certain
 operations, but this is no longer necessary (nor possible on SVE/RVV), so they
 are DEPRECATED:

--- a/hwy/base_test.cc
+++ b/hwy/base_test.cc
@@ -153,6 +153,142 @@ HWY_NOINLINE void TestAllPopCount() {
   HWY_ASSERT_EQ(size_t{64}, PopCount(0xFFFFFFFFFFFFFFFFull));
 }
 
+template <class T>
+static HWY_INLINE T TestEndianGetIntegerVal(T val) {
+  static_assert(!IsFloat<T>() && !IsSpecialFloat<T>(),
+                "T must not be a floating-point type");
+  using TU = MakeUnsigned<T>;
+  static_assert(sizeof(T) == sizeof(TU),
+                "sizeof(T) == sizeof(TU) must be true");
+
+  uint8_t result_bytes[sizeof(T)];
+  const TU val_u = static_cast<T>(val);
+
+  for (size_t i = 0; i < sizeof(T); i++) {
+#if HWY_IS_BIG_ENDIAN
+    const size_t shift_amt = (sizeof(T) - 1 - i) * 8;
+#else
+    const size_t shift_amt = i * 8;
+#endif
+    result_bytes[i] = static_cast<uint8_t>((val_u >> shift_amt) & 0xFF);
+  }
+
+  T result;
+  CopyBytes<sizeof(T)>(result_bytes, &result);
+  return result;
+}
+
+template <class T, class... Bytes>
+static HWY_INLINE T TestEndianCreateValueFromBytes(Bytes&&... bytes) {
+  static_assert(sizeof(T) > 0, "sizeof(T) > 0 must be true");
+  static_assert(sizeof...(Bytes) == sizeof(T),
+                "sizeof...(Bytes) == sizeof(T) is true");
+
+  const uint8_t src_bytes[sizeof(T)]{static_cast<uint8_t>(bytes)...};
+
+  T result;
+  CopyBytes<sizeof(T)>(src_bytes, &result);
+  return result;
+}
+
+#define HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(val) \
+  HWY_ASSERT_EQ(val, TestEndianGetIntegerVal(val))
+
+HWY_NOINLINE void TestAllEndian() {
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int8_t{0x01});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint8_t{0x01});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int16_t{0x0102});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint16_t{0x0102});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int32_t{0x01020304});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint32_t{0x01020304});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int64_t{0x0102030405060708});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint64_t{0x0102030405060708});
+
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int16_t{0x0201});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint16_t{0x0201});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int32_t{0x04030201});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint32_t{0x04030201});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(int64_t{0x0807060504030201});
+  HWY_TEST_ENDIAN_CHECK_INTEGER_VAL(uint64_t{0x0807060504030201});
+
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? int16_t{0x0102} : int16_t{0x0201},
+                TestEndianCreateValueFromBytes<int16_t>(0x01, 0x02));
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? uint16_t{0x0102} : uint16_t{0x0201},
+                TestEndianCreateValueFromBytes<uint16_t>(0x01, 0x02));
+  HWY_ASSERT_EQ(
+      HWY_IS_BIG_ENDIAN ? int32_t{0x01020304} : int32_t{0x04030201},
+      TestEndianCreateValueFromBytes<int32_t>(0x01, 0x02, 0x03, 0x04));
+  HWY_ASSERT_EQ(
+      HWY_IS_BIG_ENDIAN ? uint32_t{0x01020304} : uint32_t{0x04030201},
+      TestEndianCreateValueFromBytes<uint32_t>(0x01, 0x02, 0x03, 0x04));
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? int64_t{0x0102030405060708}
+                                  : int64_t{0x0807060504030201},
+                TestEndianCreateValueFromBytes<int64_t>(
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? uint64_t{0x0102030405060708}
+                                  : uint64_t{0x0807060504030201},
+                TestEndianCreateValueFromBytes<uint64_t>(
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08));
+
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? int16_t{-0x5EFE} : int16_t{0x02A1},
+                TestEndianCreateValueFromBytes<int16_t>(0xA1, 0x02));
+  HWY_ASSERT_EQ(
+      HWY_IS_BIG_ENDIAN ? int32_t{-0x5E4D3CFC} : int32_t{0x04C3B2A1},
+      TestEndianCreateValueFromBytes<int32_t>(0xA1, 0xB2, 0xC3, 0x04));
+  HWY_ASSERT_EQ(HWY_IS_BIG_ENDIAN ? int64_t{-0x6E5D4C3B2A1908F8}
+                                  : int64_t{0x08F7E6D5C4B3A291},
+                TestEndianCreateValueFromBytes<int64_t>(
+                    0x91, 0xA2, 0xB3, 0xC4, 0xD5, 0xE6, 0xF7, 0x08));
+
+  HWY_ASSERT_EQ(HWY_IS_LITTLE_ENDIAN ? int16_t{-0x5DFF} : int16_t{0x01A2},
+                TestEndianCreateValueFromBytes<int16_t>(0x01, 0xA2));
+  HWY_ASSERT_EQ(
+      HWY_IS_LITTLE_ENDIAN ? int32_t{-0x3B4C5DFF} : int32_t{0x01A2B3C4},
+      TestEndianCreateValueFromBytes<int32_t>(0x01, 0xA2, 0xB3, 0xC4));
+  HWY_ASSERT_EQ(HWY_IS_LITTLE_ENDIAN ? int64_t{-0x0718293A4B5C6DFF}
+                                     : int64_t{0x0192A3B4C5D6E7F8},
+                TestEndianCreateValueFromBytes<int64_t>(
+                    0x01, 0x92, 0xA3, 0xB4, 0xC5, 0xD6, 0xE7, 0xF8));
+
+#if HWY_IS_BIG_ENDIAN
+  HWY_ASSERT_EQ(1.0f,
+                TestEndianCreateValueFromBytes<float>(0x3F, 0x80, 0x00, 0x00));
+  HWY_ASSERT_EQ(15922433.0f,
+                TestEndianCreateValueFromBytes<float>(0x4B, 0x72, 0xF5, 0x01));
+  HWY_ASSERT_EQ(-12357485.0f,
+                TestEndianCreateValueFromBytes<float>(0xCB, 0x3C, 0x8F, 0x6D));
+#else
+  HWY_ASSERT_EQ(1.0f,
+                TestEndianCreateValueFromBytes<float>(0x00, 0x00, 0x80, 0x3F));
+  HWY_ASSERT_EQ(15922433.0f,
+                TestEndianCreateValueFromBytes<float>(0x01, 0xF5, 0x72, 0x4B));
+  HWY_ASSERT_EQ(-12357485.0f,
+                TestEndianCreateValueFromBytes<float>(0x6D, 0x8F, 0x3C, 0xCB));
+#endif
+
+#if HWY_HAVE_FLOAT64
+#if HWY_IS_BIG_ENDIAN
+  HWY_ASSERT_EQ(1.0, TestEndianCreateValueFromBytes<double>(
+                         0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
+  HWY_ASSERT_EQ(8707235690688195.0,
+                TestEndianCreateValueFromBytes<double>(0x43, 0x3E, 0xEF, 0x2F,
+                                                       0x4A, 0x51, 0xAE, 0xC3));
+  HWY_ASSERT_EQ(-6815854340348452.0,
+                TestEndianCreateValueFromBytes<double>(0xC3, 0x38, 0x36, 0xFB,
+                                                       0xC0, 0xCC, 0x1A, 0x24));
+#else
+  HWY_ASSERT_EQ(1.0, TestEndianCreateValueFromBytes<double>(
+                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F));
+  HWY_ASSERT_EQ(8707235690688195.0,
+                TestEndianCreateValueFromBytes<double>(0xC3, 0xAE, 0x51, 0x4A,
+                                                       0x2F, 0xEF, 0x3E, 0x43));
+  HWY_ASSERT_EQ(-6815854340348452.0,
+                TestEndianCreateValueFromBytes<double>(0x24, 0x1A, 0xCC, 0xC0,
+                                                       0xFB, 0x36, 0x38, 0xC3));
+#endif  // HWY_IS_BIG_ENDIAN
+#endif  // HWY_HAVE_FLOAT64
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -168,6 +304,7 @@ HWY_EXPORT_AND_TEST_P(BaseTest, TestAllType);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllIsSame);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllBitScan);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllPopCount);
+HWY_EXPORT_AND_TEST_P(BaseTest, TestAllEndian);
 }  // namespace hwy
 
 #endif

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -243,4 +243,33 @@
 #define HWY_OS_LINUX 0
 #endif
 
+//------------------------------------------------------------------------------
+// Endianness
+
+#if HWY_COMPILER_MSVC
+#if HWY_ARCH_PPC && defined(_XBOX_VER) && _XBOX_VER >= 200
+// XBox 360 is big-endian
+#define HWY_IS_LITTLE_ENDIAN 0
+#define HWY_IS_BIG_ENDIAN 1
+#else
+// All other targets supported by MSVC are little-endian
+#define HWY_IS_LITTLE_ENDIAN 1
+#define HWY_IS_BIG_ENDIAN 0
+#endif  // HWY_ARCH_PPC && defined(_XBOX_VER) && _XBOX_VER >= 200
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define HWY_IS_LITTLE_ENDIAN 1
+#define HWY_IS_BIG_ENDIAN 0
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define HWY_IS_LITTLE_ENDIAN 0
+#define HWY_IS_BIG_ENDIAN 1
+#else
+#error "Unable to detect endianness or unsupported byte order"
+#endif
+
+#if (HWY_IS_LITTLE_ENDIAN + HWY_IS_BIG_ENDIAN) != 1
+#error "Must only detect one byte order"
+#endif
+
 #endif  // HIGHWAY_HWY_DETECT_COMPILER_ARCH_H_

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -98,7 +98,6 @@
 // --------------------------- Future expansion: 4 targets
 // Bits 39..42 reserved
 
-
 // --------------------------- IBM Power: 9 targets (+ one fallback)
 // Bits 43..46 reserved (4 targets)
 #define HWY_PPC10 (1LL << 47)  // v3.1
@@ -173,9 +172,7 @@
 #endif
 
 // armv7be has not been tested and is not yet supported.
-#if HWY_ARCH_ARM_V7 &&            \
-    (defined(__ARM_BIG_ENDIAN) || \
-     (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN))
+#if HWY_ARCH_ARM_V7 && HWY_IS_BIG_ENDIAN
 #define HWY_BROKEN_ARM7_BIG_ENDIAN (HWY_NEON | HWY_NEON_WITHOUT_AES)
 #else
 #define HWY_BROKEN_ARM7_BIG_ENDIAN 0
@@ -202,9 +199,7 @@
 
 // There are GCC/Clang compiler bugs on big-endian PPC with the -mcpu=power10
 // option if optimizations are enabled
-#if HWY_ARCH_PPC && defined(__BYTE_ORDER__) && \
-    defined(__ORDER_LITTLE_ENDIAN__) &&        \
-    __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#if HWY_ARCH_PPC && HWY_IS_BIG_ENDIAN
 #define HWY_BROKEN_PPC10 (HWY_PPC10)
 #else
 #define HWY_BROKEN_PPC10 0
@@ -436,8 +431,8 @@
 
 // TODO(janwas): not yet known whether these will be set by MSVC
 #if HWY_BASELINE_AVX3 != 0 && defined(__AVX512VNNI__) && defined(__VAES__) && \
-    defined(__VPCLMULQDQ__) && defined(__AVX512VBMI__) &&                  \
-    defined(__AVX512VBMI2__) && defined(__AVX512VPOPCNTDQ__) &&            \
+    defined(__VPCLMULQDQ__) && defined(__AVX512VBMI__) &&                     \
+    defined(__AVX512VBMI2__) && defined(__AVX512VPOPCNTDQ__) &&               \
     defined(__AVX512BITALG__)
 #define HWY_BASELINE_AVX3_DL HWY_AVX3_DL
 #else
@@ -462,11 +457,11 @@
 
 // Allow the user to override this without any guarantee of success.
 #ifndef HWY_BASELINE_TARGETS
-#define HWY_BASELINE_TARGETS                                     \
-  (HWY_BASELINE_SCALAR | HWY_BASELINE_WASM | HWY_BASELINE_PPC8 | \
-   HWY_BASELINE_PPC9 | HWY_BASELINE_PPC10 | HWY_BASELINE_SVE2 |  \
-   HWY_BASELINE_SVE | HWY_BASELINE_NEON | HWY_BASELINE_SSE2 | \
-   HWY_BASELINE_SSSE3 | HWY_BASELINE_SSE4 | HWY_BASELINE_AVX2 | \
+#define HWY_BASELINE_TARGETS                                           \
+  (HWY_BASELINE_SCALAR | HWY_BASELINE_WASM | HWY_BASELINE_PPC8 |       \
+   HWY_BASELINE_PPC9 | HWY_BASELINE_PPC10 | HWY_BASELINE_SVE2 |        \
+   HWY_BASELINE_SVE | HWY_BASELINE_NEON | HWY_BASELINE_SSE2 |          \
+   HWY_BASELINE_SSSE3 | HWY_BASELINE_SSE4 | HWY_BASELINE_AVX2 |        \
    HWY_BASELINE_AVX3 | HWY_BASELINE_AVX3_DL | HWY_BASELINE_AVX3_ZEN4 | \
    HWY_BASELINE_RVV)
 #endif  // HWY_BASELINE_TARGETS
@@ -504,7 +499,7 @@
 // On Arm/PPC, currently only GCC does, and we require Linux to detect CPU
 // capabilities.
 #elif (HWY_ARCH_ARM || HWY_ARCH_PPC) && HWY_COMPILER_GCC_ACTUAL && \
-      HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
+    HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
 #define HWY_HAVE_RUNTIME_DISPATCH 1
 #else
 #define HWY_HAVE_RUNTIME_DISPATCH 0


### PR DESCRIPTION
HWY_IS_BIG_ENDIAN and HWY_IS_LITTLE_ENDIAN macros are added to facilitate writing portable code as the HWY_SCALAR/HWY_EMU128/HWY_PPC8/HWY_PPC9/HWY_PPC10 targets support both big-endian and little-endian targets.

The `__BYTE_ORDER__`, `__ORDER_LITTLE_ENDIAN__`, and `__ORDER_BIG_ENDIAN__` macros have also been around since GCC 4.6 and later and Clang 3.2 and later, and the current trunk of Google Highway will fail to compile with GCC 4.7 or earlier or Clang 3.8 or earlier (even with C++11 or later mode enabled).

Detecting byte order is simpler with MSVC as the XBox 360 is the only big-endian target that was supported by MSVC (with the cl compiler included in the XBox 360 SDK) whereas all other targets supported by MSVC (including x86/x86_64/ARM/AArch64) are little-endian.