### PR TITLE
fix CMake build (missing source file)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(HWY_SOURCES
     hwy/ops/set_macros-inl.h
     hwy/ops/shared-inl.h
     hwy/ops/wasm_128-inl.h
+    hwy/ops/tuple-inl.h
     hwy/ops/x86_128-inl.h
     hwy/ops/x86_256-inl.h
     hwy/ops/x86_512-inl.h


### PR DESCRIPTION
`hwy/ops/tuple-inl.h` was forgotten to be added to `CMakeLists.txt` in 486f0d8729da4f40fcabaed785ed3ca50c7138c0.