### PR TITLE
 Added ResizeBitCast and ZeroExtendResizeBitCast operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1065,6 +1065,36 @@ All functions except `Stream` are defined in cache_control.h.
 *   <code>Vec&lt;D&gt; **BitCast**(D, V)</code>: returns the bits of `V`
     reinterpreted as type `Vec<D>`.
 
+*   <code>Vec&lt;D&gt; **ResizeBitCast**(D, V)</code>: resizes `V` to a vector
+    of `Lanes(D()) * sizeof(TFromD<D>)` bytes, and then returns the bits of the
+    resized vector reinterpreted as type `Vec<D>`.
+
+    If `Vec<D>` is a larger vector than `V`, then the contents of any bytes of
+    past the first `Lanes(DFromV<V>()) * sizeof(TFromV<V>)` bytes of the result
+    vector is unspecified.
+
+*   <code>Vec&lt;DTo&gt; **ZeroExtendResizeBitCast**(DTo, DFrom, V)</code>:
+    resizes `V`, which is a vector of type `Vec<DFrom>`, to a vector of
+    `Lanes(D()) * sizeof(TFromD<D>)` bytes, and then returns the bits of the
+    resized vector reinterpreted as type `Vec<DTo>`.
+
+    If `Lanes(DTo()) * sizeof(TFromD<DTo>)` is greater than
+    `Lanes(DFrom()) * sizeof(TFromD<DFrom>)`, then any bytes past the first
+    `Lanes(DFrom()) * sizeof(TFromD<DFrom>)` bytes of the result vector are
+    zeroed out.
+
+*   <code>Vec&lt;D&gt; **ZeroExtendResizeBitCast**(D, V)</code>:
+    resizes `V` to a vector of `Lanes(D()) * sizeof(TFromD<D>)` bytes, and then
+    returns the bits of the resized vector reinterpreted as type `Vec<D>`.
+
+    If `Lanes(DTo()) * sizeof(TFromD<DTo>)` is greater than
+    `Lanes(DFromV<V>()) * sizeof(TFromV<V>)`, then any bytes past the first
+    `Lanes(DFromV<V>()) * sizeof(TFromV<V>)` bytes of the result vector are
+    zeroed out.
+
+    `ZeroExtendResizeBitCast(d, v)` is equivalent to
+    `ZeroExtendResizeBitCast(d, DFromV<decltype(v)>(), v)`.
+
 *   `V`,`D`: (`u8,u16`), (`u16,u32`), (`u8,u32`), (`u32,u64`), (`u8,i16`), \
     (`u8,i32`), (`u16,i32`), (`i8,i16`), (`i8,i32`), (`i16,i32`), (`i32,i64`)
     <code>Vec&lt;D&gt; **PromoteTo**(D, V part)</code>: returns `part[i]` zero-

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1069,7 +1069,7 @@ All functions except `Stream` are defined in cache_control.h.
     of `Lanes(D()) * sizeof(TFromD<D>)` bytes, and then returns the bits of the
     resized vector reinterpreted as type `Vec<D>`.
 
-    If `Vec<D>` is a larger vector than `V`, then the contents of any bytes of
+    If `Vec<D>` is a larger vector than `V`, then the contents of any bytes
     past the first `Lanes(DFromV<V>()) * sizeof(TFromV<V>)` bytes of the result
     vector is unspecified.
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1083,18 +1083,6 @@ All functions except `Stream` are defined in cache_control.h.
     `Lanes(DFrom()) * sizeof(TFromD<DFrom>)` bytes of the result vector are
     zeroed out.
 
-*   <code>Vec&lt;D&gt; **ZeroExtendResizeBitCast**(D, V)</code>:
-    resizes `V` to a vector of `Lanes(D()) * sizeof(TFromD<D>)` bytes, and then
-    returns the bits of the resized vector reinterpreted as type `Vec<D>`.
-
-    If `Lanes(DTo()) * sizeof(TFromD<DTo>)` is greater than
-    `Lanes(DFromV<V>()) * sizeof(TFromV<V>)`, then any bytes past the first
-    `Lanes(DFromV<V>()) * sizeof(TFromV<V>)` bytes of the result vector are
-    zeroed out.
-
-    `ZeroExtendResizeBitCast(d, v)` is equivalent to
-    `ZeroExtendResizeBitCast(d, DFromV<decltype(v)>(), v)`.
-
 *   `V`,`D`: (`u8,u16`), (`u16,u32`), (`u8,u32`), (`u32,u64`), (`u8,i16`), \
     (`u8,i32`), (`u16,i32`), (`i8,i16`), (`i8,i32`), (`i16,i32`), (`i32,i64`)
     <code>Vec&lt;D&gt; **PromoteTo**(D, V part)</code>: returns `part[i]` zero-

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -432,6 +432,14 @@ HWY_SVE_FOREACH(HWY_SVE_GET, Get, get)
 HWY_SVE_GET(bfloat, bf, 16, 8, Get, get)
 #undef HWY_SVE_GET
 
+// ------------------------------ ResizeBitCast
+
+// Same as BitCast on SVE
+template <class D, class FromV>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, v);
+}
+
 // ================================================== LOGICAL
 
 // detail::*N() functions accept a scalar argument to avoid extra Set().

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -91,6 +91,86 @@ HWY_API Vec<D> Inf(D d) {
   return BitCast(d, Set(du, max_x2 >> 1));
 }
 
+// ------------------------------ ZeroExtendResizeBitCast
+
+// The implementation of detail::ZeroExtendResizeBitCast for the HWY_EMU128
+// target is in emu128-inl.h, and the implementation of
+// detail::ZeroExtendResizeBitCast for the HWY_SCALAR target is in scalar-inl.h
+#if HWY_TARGET != HWY_EMU128 && HWY_TARGET != HWY_SCALAR
+namespace detail {
+
+#if HWY_HAVE_SCALABLE
+template <size_t kFromVectSize, size_t kToVectSize, class DTo, class DFrom>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<kFromVectSize> /* from_size_tag */,
+    hwy::SizeTag<kToVectSize> /* to_size_tag */, DTo d_to, DFrom d_from,
+    VFromD<DFrom> v) {
+  using TFrom = TFromD<DFrom>;
+  using TTo = TFromD<DTo>;
+  using TResize = UnsignedFromSize<HWY_MIN(sizeof(TFrom), sizeof(TTo))>;
+
+  const Repartition<TResize, decltype(d_from)> d_resize_from;
+  const Repartition<TResize, decltype(d_to)> d_resize_to;
+  return BitCast(d_to, IfThenElseZero(FirstN(d_resize_to, Lanes(d_resize_from)),
+                                      ResizeBitCast(d_resize_to, v)));
+}
+#else   // target that uses fixed-size vectors
+// Truncating or same-size resizing cast: same as ResizeBitCast
+template <size_t kFromVectSize, size_t kToVectSize, class DTo, class DFrom,
+          HWY_IF_LANES_LE(kToVectSize, kFromVectSize)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<kFromVectSize> /* from_size_tag */,
+    hwy::SizeTag<kToVectSize> /* to_size_tag */, DTo d_to, DFrom /*d_from*/,
+    VFromD<DFrom> v) {
+  return ResizeBitCast(d_to, v);
+}
+
+// Resizing cast to vector that has twice the number of lanes of the source
+// vector
+template <size_t kFromVectSize, size_t kToVectSize, class DTo, class DFrom,
+          HWY_IF_LANES(kToVectSize, kFromVectSize * 2)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<kFromVectSize> /* from_size_tag */,
+    hwy::SizeTag<kToVectSize> /* to_size_tag */, DTo d_to, DFrom d_from,
+    VFromD<DFrom> v) {
+  const Twice<decltype(d_from)> dt_from;
+  return BitCast(d_to, ZeroExtendVector(dt_from, v));
+}
+
+// Resizing cast to vector that has more than twice the number of lanes of the
+// source vector
+template <size_t kFromVectSize, size_t kToVectSize, class DTo, class DFrom,
+          HWY_IF_LANES_GT(kToVectSize, kFromVectSize * 2)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<kFromVectSize> /* from_size_tag */,
+    hwy::SizeTag<kToVectSize> /* to_size_tag */, DTo d_to, DFrom /*d_from*/,
+    VFromD<DFrom> v) {
+  using TFrom = TFromD<DFrom>;
+  constexpr size_t kNumOfFromLanes = kFromVectSize / sizeof(TFrom);
+  const Repartition<TFrom, decltype(d_to)> d_resize_to;
+  return BitCast(d_to, IfThenElseZero(FirstN(d_resize_to, kNumOfFromLanes),
+                                      ResizeBitCast(d_resize_to, v)));
+}
+#endif  // HWY_HAVE_SCALABLE
+
+}  // namespace detail
+#endif  // HWY_TARGET != HWY_EMU128 && HWY_TARGET != HWY_SCALAR
+
+template <class DTo, class DFrom>
+HWY_API VFromD<DTo> ZeroExtendResizeBitCast(DTo d_to, DFrom d_from,
+                                            VFromD<DFrom> v) {
+  using TFrom = TFromD<DFrom>;
+  using TTo = TFromD<DTo>;
+  return detail::ZeroExtendResizeBitCast(
+      hwy::SizeTag<HWY_MAX_LANES_D(DFrom) * sizeof(TFrom)>(),
+      hwy::SizeTag<HWY_MAX_LANES_D(DTo) * sizeof(TTo)>(), d_to, d_from, v);
+}
+
+template <class DTo, class FromV>
+HWY_API VFromD<DTo> ZeroExtendResizeBitCast(DTo d_to, FromV v) {
+  return ZeroExtendResizeBitCast(d_to, DFromV<decltype(v)>(), v);
+}
+
 // ------------------------------ SafeFillN
 
 template <class D, typename T = TFromD<D>>

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -159,16 +159,9 @@ HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
 template <class DTo, class DFrom>
 HWY_API VFromD<DTo> ZeroExtendResizeBitCast(DTo d_to, DFrom d_from,
                                             VFromD<DFrom> v) {
-  using TFrom = TFromD<DFrom>;
-  using TTo = TFromD<DTo>;
-  return detail::ZeroExtendResizeBitCast(
-      hwy::SizeTag<HWY_MAX_LANES_D(DFrom) * sizeof(TFrom)>(),
-      hwy::SizeTag<HWY_MAX_LANES_D(DTo) * sizeof(TTo)>(), d_to, d_from, v);
-}
-
-template <class DTo, class FromV>
-HWY_API VFromD<DTo> ZeroExtendResizeBitCast(DTo d_to, FromV v) {
-  return ZeroExtendResizeBitCast(d_to, DFromV<decltype(v)>(), v);
+  return detail::ZeroExtendResizeBitCast(hwy::SizeTag<d_from.MaxBytes()>(),
+                                         hwy::SizeTag<d_to.MaxBytes()>(), d_to,
+                                         d_from, v);
 }
 
 // ------------------------------ SafeFillN

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -196,6 +196,17 @@ HWY_API VFromD<D> BitCast(D /*d*/,
       reinterpret_cast<typename detail::Raw128<TFromD<D>>::type>(v.raw)};
 }
 
+// ------------------------------ ResizeBitCast
+
+template <class D, typename FromV>
+HWY_API VFromD<D> ResizeBitCast(D /*d*/, FromV v) {
+  // C-style casts are not sufficient when compiling with
+  // -fno-lax-vector-conversions, which will be the future default in Clang,
+  // but reinterpret_cast is.
+  return VFromD<D>{
+      reinterpret_cast<typename detail::Raw128<TFromD<D>>::type>(v.raw)};
+}
+
 // ------------------------------ Set
 
 // Returns a vector/part with all lanes set to "t".

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -2868,35 +2868,43 @@ HWY_API V Shuffle0123(const V v) {
 // Extends or truncates a vector to match the given d.
 namespace detail {
 
-template <class D, HWY_IF_POW2_GT_D(D, -1)>
-HWY_INLINE VFromD<D> ChangeLMUL(D d, VFromD<Half<Half<Half<D>>>> v) {
-  return Ext(d, Ext(Half<D>(), Ext(Half<Half<D>>(), v)));
-}
-template <class D, HWY_IF_POW2_GT_D(D, -2)>
-HWY_INLINE VFromD<D> ChangeLMUL(D d, VFromD<Half<Half<D>>> v) {
-  return Ext(d, Ext(Half<D>(), v));
-}
-template <class D, HWY_IF_POW2_GT_D(D, -3)>
-HWY_INLINE VFromD<D> ChangeLMUL(D d, VFromD<Half<D>> v) {
-  return Ext(d, v);
-}
-
 template <class D>
 HWY_INLINE VFromD<D> ChangeLMUL(D /* d */, VFromD<D> v) {
   return v;
 }
 
-template <class D, HWY_IF_POW2_LE_D(D, 2)>
-HWY_INLINE VFromD<D> ChangeLMUL(D /* d */, VFromD<Twice<D>> v) {
-  return Trunc(v);
+// LMUL of VFromD<D> < LMUL of V: need to truncate v
+template <class D, class V,
+          hwy::EnableIf<IsSame<TFromD<D>, TFromV<V>>()>* = nullptr,
+          HWY_IF_POW2_LE_D(DFromV<VFromD<D>>, DFromV<V>().Pow2() - 1)>
+HWY_INLINE VFromD<D> ChangeLMUL(D d, V v) {
+  const DFromV<decltype(v)> d_from;
+  const Half<decltype(d_from)> dh_from;
+  static_assert(
+      DFromV<VFromD<decltype(dh_from)>>().Pow2() < DFromV<V>().Pow2(),
+      "The LMUL of VFromD<decltype(dh_from)> must be less than the LMUL of V");
+  static_assert(
+      DFromV<VFromD<D>>().Pow2() <= DFromV<VFromD<decltype(dh_from)>>().Pow2(),
+      "The LMUL of VFromD<D> must be less than or equal to the LMUL of "
+      "VFromD<decltype(dh_from)>");
+  return ChangeLMUL(d, Trunc(v));
 }
-template <class D, HWY_IF_POW2_LE_D(D, 1)>
-HWY_INLINE VFromD<D> ChangeLMUL(D /* d */, VFromD<Twice<Twice<D>>> v) {
-  return Trunc(Trunc(v));
-}
-template <class D, HWY_IF_POW2_LE_D(D, 0)>
-HWY_INLINE VFromD<D> ChangeLMUL(D /* d */, VFromD<Twice<Twice<Twice<D>>>> v) {
-  return Trunc(Trunc(Trunc(v)));
+
+// LMUL of VFromD<D> > LMUL of V: need to extend v
+template <class D, class V,
+          hwy::EnableIf<IsSame<TFromD<D>, TFromV<V>>()>* = nullptr,
+          HWY_IF_POW2_GT_D(DFromV<VFromD<D>>, DFromV<V>().Pow2())>
+HWY_INLINE VFromD<D> ChangeLMUL(D d, V v) {
+  const DFromV<decltype(v)> d_from;
+  const Twice<decltype(d_from)> dt_from;
+  static_assert(DFromV<VFromD<decltype(dt_from)>>().Pow2() > DFromV<V>().Pow2(),
+                "The LMUL of VFromD<decltype(dt_from)> must be greater than "
+                "the LMUL of V");
+  static_assert(
+      DFromV<VFromD<D>>().Pow2() >= DFromV<VFromD<decltype(dt_from)>>().Pow2(),
+      "The LMUL of VFromD<D> must be greater than or equal to the LMUL of "
+      "VFromD<decltype(dt_from)>");
+  return ChangeLMUL(d, Ext(dt_from, v));
 }
 
 }  // namespace detail
@@ -3387,6 +3395,17 @@ HWY_API void StoreInterleaved4(VFromD<D> v0, VFromD<D> v1, VFromD<D> v2,
 }
 
 #endif  // HWY_HAVE_TUPLE
+
+// ------------------------------ ResizeBitCast
+
+template <class D, class FromV>
+HWY_API VFromD<D> ResizeBitCast(D /*d*/, FromV v) {
+  const DFromV<decltype(v)> d_from;
+  const Repartition<uint8_t, decltype(d_from)> du8_from;
+  const DFromV<VFromD<D>> d_to;
+  const Repartition<uint8_t, decltype(d_to)> du8_to;
+  return BitCast(d_to, detail::ChangeLMUL(du8_to, BitCast(du8_from, v)));
+}
 
 // ------------------------------ PopulationCount (ShiftRight)
 

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -128,6 +128,32 @@ HWY_API Vec1<T> Iota(const D /* tag */, const T2 first) {
   return Vec1<T>(static_cast<T>(first));
 }
 
+// ------------------------------ ResizeBitCast
+
+template <class D, typename FromV>
+HWY_API VFromD<D> ResizeBitCast(D /* tag */, FromV v) {
+  using TFrom = TFromV<FromV>;
+  using TTo = TFromD<D>;
+  constexpr size_t kCopyLen = HWY_MIN(sizeof(TFrom), sizeof(TTo));
+  TTo to = TTo{0};
+  CopyBytes<kCopyLen>(&v.raw, &to);
+  return VFromD<D>(to);
+}
+
+namespace detail {
+
+// ResizeBitCast on the HWY_SCALAR target has zero-extending semantics if
+// sizeof(TFromD<DTo>) is greater than sizeof(TFromV<FromV>)
+template <class FromSizeTag, class ToSizeTag, class DTo, class DFrom>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    FromSizeTag /* from_size_tag */, ToSizeTag /* to_size_tag */, DTo d_to, DFrom /*d_from*/,
+    VFromD<DFrom> v) {
+  return ResizeBitCast(d_to, v);
+}
+
+}  // namespace scalar
+
+
 // ================================================== LOGICAL
 
 // ------------------------------ Not

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -185,6 +185,15 @@ HWY_API VFromD<D> BitCast(D d,
   return detail::BitCastFromByte(d, detail::BitCastToByte(v));
 }
 
+// ------------------------------ ResizeBitCast
+
+template <class D, typename FromV, HWY_IF_V_SIZE_LE_V(FromV, 16),
+          HWY_IF_V_SIZE_LE_D(D, 16)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  const Repartition<uint8_t, decltype(d)> du8_to;
+  return BitCast(d, VFromD<decltype(du8_to)>{detail::BitCastToInteger(v.raw)});
+}
+
 // ------------------------------ Set
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_T_SIZE_D(D, 1)>

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -84,6 +84,33 @@ HWY_API VFromD<D> BitCast(D d, Vec256<TFrom> v) {
   return ret;
 }
 
+// ------------------------------ ResizeBitCast
+
+// 32-byte vector to 32-byte vector: Same as BitCast
+template <class D, typename FromV, HWY_IF_V_SIZE_V(FromV, 32),
+          HWY_IF_V_SIZE_D(D, 32)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, v);
+}
+
+// <= 16-byte vector to 32-byte vector
+template <class D, typename FromV, HWY_IF_V_SIZE_LE_V(FromV, 16),
+          HWY_IF_V_SIZE_D(D, 32)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  const Half<decltype(d)> dh;
+  VFromD<D> ret;
+  ret.v0 = ResizeBitCast(dh, v);
+  ret.v1 = Zero(dh);
+  return ret;
+}
+
+// 32-byte vector to <= 16-byte vector
+template <class D, typename FromV, HWY_IF_V_SIZE_V(FromV, 32),
+          HWY_IF_V_SIZE_LE_D(D, 16)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return ResizeBitCast(d, v.v0);
+}
+
 // ------------------------------ Set
 template <class D, HWY_IF_V_SIZE_D(D, 32), typename T2>
 HWY_API VFromD<D> Set(D d, const T2 t) {
@@ -1114,6 +1141,22 @@ HWY_API Vec256<T> ZeroExtendVector(D d, Vec128<T> lo) {
   const Half<decltype(d)> dh;
   return Combine(d, Zero(dh), lo);
 }
+
+// ------------------------------ ZeroExtendResizeBitCast
+
+namespace detail {
+
+template <size_t kFromVectSize, class DTo, class DFrom,
+          HWY_IF_LANES_LE(kFromVectSize, 8)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<kFromVectSize> /* from_size_tag */,
+    hwy::SizeTag<32> /* to_size_tag */, DTo d_to, DFrom d_from,
+    VFromD<DFrom> v) {
+  const Half<decltype(d_to)> dh_to;
+  return ZeroExtendVector(d_to, ZeroExtendResizeBitCast(dh_to, d_from, v));
+}
+
+}  // namespace detail
 
 // ------------------------------ ConcatLowerLower
 template <class D, typename T = TFromD<D>>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -330,6 +330,15 @@ HWY_API double GetLane(const Vec128<double, N> v) {
   return _mm_cvtsd_f64(v.raw);
 }
 
+// ------------------------------ ResizeBitCast
+
+template <class D, class FromV, HWY_IF_V_SIZE_LE_V(FromV, 16),
+          HWY_IF_V_SIZE_LE_D(D, 16)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  const Repartition<uint8_t, decltype(d)> du8;
+  return BitCast(d, VFromD<decltype(du8)>{detail::BitCastToInteger(v.raw)});
+}
+
 // ================================================== LOGICAL
 
 // ------------------------------ And

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -275,6 +275,42 @@ HWY_API Vec256<double> Undefined(D /* tag */) {
 
 HWY_DIAGNOSTICS(pop)
 
+// ------------------------------ ResizeBitCast
+
+// 32-byte vector to 32-byte vector (or 64-byte vector to 64-byte vector on
+// AVX3)
+template <class D, class FromV, HWY_IF_V_SIZE_GT_V(FromV, 16),
+          HWY_IF_V_SIZE_D(D, HWY_MAX_LANES_V(FromV) * sizeof(TFromV<FromV>))>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, v);
+}
+
+// 32-byte vector to 16-byte vector (or 64-byte vector to 32-byte vector on
+// AVX3)
+template <class D, class FromV, HWY_IF_V_SIZE_GT_V(FromV, 16),
+          HWY_IF_V_SIZE_D(D,
+                          (HWY_MAX_LANES_V(FromV) * sizeof(TFromV<FromV>)) / 2)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  const DFromV<decltype(v)> d_from;
+  const Half<decltype(d_from)> dh_from;
+  return BitCast(d, LowerHalf(dh_from, v));
+}
+
+// 32-byte vector (or 64-byte vector on AVX3) to <= 8-byte vector
+template <class D, class FromV, HWY_IF_V_SIZE_GT_V(FromV, 16),
+          HWY_IF_V_SIZE_LE_D(D, 8)>
+HWY_API VFromD<D> ResizeBitCast(D /*d*/, FromV v) {
+  return VFromD<D>{ResizeBitCast(Full128<TFromD<D>>(), v).raw};
+}
+
+// <= 16-byte vector to 32-byte vector
+template <class D, class FromV, HWY_IF_V_SIZE_LE_V(FromV, 16),
+          HWY_IF_V_SIZE_D(D, 32)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, Vec256<uint8_t>{_mm256_castsi128_si256(
+                        ResizeBitCast(Full128<uint8_t>(), v).raw)});
+}
+
 // ================================================== LOGICAL
 
 // ------------------------------ And
@@ -2896,6 +2932,21 @@ HWY_API Vec256<double> ZeroExtendVector(D /* tag */, Vec128<double> lo) {
   return Vec256<double>{_mm256_insertf128_pd(_mm256_setzero_pd(), lo.raw, 0)};
 #endif
 }
+
+// ------------------------------ ZeroExtendResizeBitCast
+
+namespace detail {
+
+template <class DTo, class DFrom>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<8> /* from_size_tag */, hwy::SizeTag<32> /* to_size_tag */,
+    DTo d_to, DFrom d_from, VFromD<DFrom> v) {
+  const Twice<decltype(d_from)> dt_from;
+  const Twice<decltype(dt_from)> dq_from;
+  return BitCast(d_to, ZeroExtendVector(dq_from, ZeroExtendVector(dt_from, v)));
+}
+
+}  // namespace detail
 
 // ------------------------------ Combine
 

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -261,6 +261,32 @@ HWY_API Vec512<double> Undefined(D /* tag */) {
 
 HWY_DIAGNOSTICS(pop)
 
+// ------------------------------ ResizeBitCast
+
+// 64-byte vector to 16-byte vector
+template <class D, class FromV, HWY_IF_V_SIZE_V(FromV, 64),
+          HWY_IF_V_SIZE_D(D, 16)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, Vec128<uint8_t>{_mm512_castsi512_si128(
+                        BitCast(Full512<uint8_t>(), v).raw)});
+}
+
+// <= 16-byte vector to 64-byte vector
+template <class D, class FromV, HWY_IF_V_SIZE_LE_V(FromV, 16),
+          HWY_IF_V_SIZE_D(D, 64)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, Vec512<uint8_t>{_mm512_castsi128_si512(
+                        ResizeBitCast(Full128<uint8_t>(), v).raw)});
+}
+
+// 32-byte vector to 64-byte vector
+template <class D, class FromV, HWY_IF_V_SIZE_V(FromV, 32),
+          HWY_IF_V_SIZE_D(D, 64)>
+HWY_API VFromD<D> ResizeBitCast(D d, FromV v) {
+  return BitCast(d, Vec512<uint8_t>{_mm512_castsi256_si512(
+                        BitCast(Full256<uint8_t>(), v).raw)});
+}
+
 // ================================================== LOGICAL
 
 // ------------------------------ Not
@@ -2419,6 +2445,60 @@ HWY_API Vec512<double> ZeroExtendVector(D /* tag */, Vec256<double> lo) {
   return Vec512<double>{_mm512_insertf64x4(_mm512_setzero_pd(), lo.raw, 0)};
 #endif
 }
+
+// ------------------------------ ZeroExtendResizeBitCast
+
+namespace detail {
+
+template <class DTo, class DFrom, HWY_IF_NOT_FLOAT_D(DTo)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<16> /* from_size_tag */, hwy::SizeTag<64> /* to_size_tag */,
+    DTo /*d_to*/, DFrom d_from, VFromD<DFrom> v) {
+  const Repartition<uint8_t, decltype(d_from)> du8_from;
+  const auto vu8 = BitCast(du8_from, v);
+#if HWY_HAVE_ZEXT
+  return VFromD<DTo>{_mm512_zextsi128_si512(vu8.raw)};
+#else
+  return VFromD<DTo>{_mm512_inserti32x4(_mm512_setzero_si512(), vu8.raw, 0)};
+#endif
+}
+
+template <class DTo, class DFrom, HWY_IF_F32_D(DTo)>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<16> /* from_size_tag */, hwy::SizeTag<64> /* to_size_tag */,
+    DTo /* d_to */, DFrom d_from, VFromD<DFrom> v) {
+  const Repartition<float, decltype(d_from)> df32_from;
+  const auto vf32 = BitCast(df32_from, v);
+#if HWY_HAVE_ZEXT
+  return Vec512<float>{_mm512_zextps128_ps512(vf32.raw)};
+#else
+  return Vec512<float>{_mm512_insertf32x4(_mm512_setzero_ps(), vf32.raw, 0)};
+#endif
+}
+
+template <class DTo, class DFrom, HWY_IF_F64_D(DTo)>
+HWY_INLINE Vec512<double> ZeroExtendResizeBitCast(
+    hwy::SizeTag<16> /* from_size_tag */, hwy::SizeTag<64> /* to_size_tag */,
+    DTo /* d_to */, DFrom d_from, VFromD<DFrom> v) {
+  const Repartition<double, decltype(d_from)> df64_from;
+  const auto vf64 = BitCast(df64_from, v);
+#if HWY_HAVE_ZEXT
+  return Vec512<double>{_mm512_zextpd128_pd512(vf64.raw)};
+#else
+  return Vec512<double>{_mm512_insertf64x2(_mm512_setzero_pd(), vf64.raw, 0)};
+#endif
+}
+
+template <class DTo, class DFrom>
+HWY_INLINE VFromD<DTo> ZeroExtendResizeBitCast(
+    hwy::SizeTag<8> /* from_size_tag */, hwy::SizeTag<64> /* to_size_tag */,
+    DTo d_to, DFrom d_from, VFromD<DFrom> v) {
+  const Twice<decltype(d_from)> dt_from;
+  return ZeroExtendResizeBitCast(hwy::SizeTag<16>(), hwy::SizeTag<64>(), d_to,
+                                 dt_from, ZeroExtendVector(dt_from, v));
+}
+
+}  // namespace detail
 
 // ------------------------------ Combine
 

--- a/hwy/tests/combine_test.cc
+++ b/hwy/tests/combine_test.cc
@@ -284,6 +284,170 @@ HWY_NOINLINE void TestAllConcatOddEven() {
   ForAllTypes(ForShrinkableVectors<TestConcatOddEven>());
 }
 
+class TestTruncatingResizeBitCast {
+#if HWY_TARGET != HWY_SCALAR
+ private:
+  template <class DTo, class DFrom>
+  static HWY_INLINE void DoTruncResizeBitCastTest(DTo d_to, DFrom d_from) {
+    const VFromD<DFrom> v = Iota(d_from, 1);
+    const VFromD<DTo> expected = Iota(d_to, 1);
+
+    const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_1);
+
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
+
+    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
+  }
+#endif  // HWY_TARGET != HWY_SCALAR
+ public:
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Half<D> dh;
+    DoTruncResizeBitCastTest(dh, d);
+
+    const auto v_full = Iota(d, 1);
+    const VFromD<decltype(dh)> expected_full_to_half = LowerHalf(dh, v_full);
+    HWY_ASSERT_VEC_EQ(dh, expected_full_to_half, ResizeBitCast(dh, v_full));
+    HWY_ASSERT_VEC_EQ(dh, expected_full_to_half,
+                      ZeroExtendResizeBitCast(dh, v_full));
+    HWY_ASSERT_VEC_EQ(dh, expected_full_to_half,
+                      ZeroExtendResizeBitCast(dh, d, v_full));
+
+    constexpr size_t kMaxLanes = MaxLanes(d);
+#if HWY_TARGET == HWY_RVV
+    constexpr int kFromVectPow2 = DFromV<VFromD<D>>().Pow2();
+    static_assert(kFromVectPow2 >= -3 && kFromVectPow2 <= 3,
+                  "kFromVectPow2 must be between -3 and 3");
+
+    constexpr size_t kScaledMaxLanes =
+        HWY_MAX((kMaxLanes << 3) >> (kFromVectPow2 + 3), 1);
+    constexpr int kMinPow2 = -3 + static_cast<int>(FloorLog2(sizeof(T)));
+    static_assert(kMinPow2 >= -3 && kMinPow2 <= 0,
+                  "kMinPow2 must be between -3 and 0");
+
+    constexpr size_t kQuarterScaledMaxLanes = kScaledMaxLanes;
+    constexpr size_t kEighthScaledMaxLanes = kScaledMaxLanes;
+    constexpr int kQuarterPow2 = HWY_MAX(kFromVectPow2 - 2, kMinPow2);
+    constexpr int kEighthPow2 = HWY_MAX(kFromVectPow2 - 3, kMinPow2);
+#else
+    constexpr size_t kQuarterScaledMaxLanes = HWY_MAX(kMaxLanes / 4, 1);
+    constexpr size_t kEighthScaledMaxLanes = HWY_MAX(kMaxLanes / 8, 1);
+    constexpr int kQuarterPow2 = 0;
+    constexpr int kEighthPow2 = 0;
+#endif
+
+    const CappedTag<T, kQuarterScaledMaxLanes, kQuarterPow2> d_quarter;
+    const CappedTag<T, kEighthScaledMaxLanes, kEighthPow2> d_eighth;
+    if (MaxLanes(d_quarter) == kMaxLanes / 4) {
+      DoTruncResizeBitCastTest(d_quarter, d);
+      if (MaxLanes(d_eighth) == kMaxLanes / 8) {
+        DoTruncResizeBitCastTest(d_eighth, d);
+      }
+    }
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllTruncatingResizeBitCast() {
+  ForAllTypes(ForShrinkableVectors<TestTruncatingResizeBitCast>());
+}
+
+class TestExtendingResizeBitCast {
+#if HWY_TARGET != HWY_SCALAR
+ private:
+  template <class DTo, class DFrom>
+  static HWY_INLINE void DoExtResizeBitCastTest(DTo d_to, DFrom d_from) {
+    const size_t N = Lanes(d_from);
+    const auto active_elements_mask = FirstN(d_to, N);
+
+    const VFromD<DTo> expected =
+        IfThenElseZero(active_elements_mask, Iota(d_to, 1));
+    const VFromD<DFrom> v = Iota(d_from, 1);
+
+    const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+    const VFromD<DTo> actual_2 =
+        IfThenElseZero(active_elements_mask, ZeroExtendResizeBitCast(d_to, v));
+#else
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
+#endif
+    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
+
+    HWY_ASSERT_VEC_EQ(d_to, expected,
+                      IfThenElseZero(active_elements_mask, actual_1));
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
+  }
+  template <class DFrom>
+  static HWY_INLINE void DoExtResizeBitCastToTwiceDTest(DFrom d_from) {
+    using DTo = Twice<DFrom>;
+    const DTo d_to;
+    DoExtResizeBitCastTest(d_to, d_from);
+
+    const VFromD<DFrom> v = Iota(d_from, 1);
+    const VFromD<DTo> expected = ZeroExtendVector(d_to, v);
+
+    const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
+    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
+
+    HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_1));
+    HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_2));
+    HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_3));
+
+#if !HWY_HAVE_SCALABLE && HWY_TARGET != HWY_SVE_256 && \
+    HWY_TARGET != HWY_SVE2_128
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
+#endif
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
+  }
+#endif  // HWY_TARGET != HWY_SCALAR
+ public:
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    DoExtResizeBitCastToTwiceDTest(d);
+
+    constexpr size_t kMaxLanes = MaxLanes(d);
+#if HWY_TARGET == HWY_RVV
+    constexpr int kFromVectPow2 = DFromV<VFromD<D>>().Pow2();
+    static_assert(kFromVectPow2 >= -3 && kFromVectPow2 <= 3,
+                  "kFromVectPow2 must be between -3 and 3");
+
+    constexpr size_t kScaledMaxLanes =
+        HWY_MAX((kMaxLanes << 3) >> (kFromVectPow2 + 3), 1);
+    constexpr size_t kQuadrupleScaledLimit = kScaledMaxLanes;
+    constexpr size_t kOctupleScaledLimit = kScaledMaxLanes;
+    constexpr int kQuadruplePow2 = HWY_MIN(kFromVectPow2 + 2, 3);
+    constexpr int kOctuplePow2 = HWY_MIN(kFromVectPow2 + 3, 3);
+#else
+    constexpr size_t kQuadrupleScaledLimit = kMaxLanes * 4;
+    constexpr size_t kOctupleScaledLimit = kMaxLanes * 8;
+    constexpr int kQuadruplePow2 = 0;
+    constexpr int kOctuplePow2 = 0;
+#endif
+
+    const CappedTag<T, kQuadrupleScaledLimit, kQuadruplePow2> d_quadruple;
+    const CappedTag<T, kOctupleScaledLimit, kOctuplePow2> d_octuple;
+
+    if (MaxLanes(d_quadruple) == kMaxLanes * 4) {
+      DoExtResizeBitCastTest(d_quadruple, d);
+      if (MaxLanes(d_octuple) == kMaxLanes * 8) {
+        DoExtResizeBitCastTest(d_octuple, d);
+      }
+    }
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllExtendingResizeBitCast() {
+  ForAllTypes(ForExtendableVectors<TestExtendingResizeBitCast>());
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -299,6 +463,8 @@ HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllZeroExtendVector);
 HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllCombine);
 HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllConcat);
 HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllConcatOddEven);
+HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllTruncatingResizeBitCast);
+HWY_EXPORT_AND_TEST_P(HwyCombineTest, TestAllExtendingResizeBitCast);
 }  // namespace hwy
 
 #endif  // HWY_ONCE

--- a/hwy/tests/combine_test.cc
+++ b/hwy/tests/combine_test.cc
@@ -276,7 +276,7 @@ struct TestConcatOddEven {
     HWY_ASSERT_VEC_EQ(d, min, ConcatEven(d, min, min));
 #else
     (void)d;
-#endif
+#endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
@@ -343,6 +343,8 @@ class TestTruncatingResizeBitCast {
         DoTruncResizeBitCastTest(d_eighth, d);
       }
     }
+#else
+    (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
@@ -421,6 +423,8 @@ class TestExtendingResizeBitCast {
         DoExtResizeBitCastTest(d_octuple, d);
       }
     }
+#else
+    (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };

--- a/hwy/tests/combine_test.cc
+++ b/hwy/tests/combine_test.cc
@@ -295,11 +295,8 @@ class TestTruncatingResizeBitCast {
     const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_1);
 
-    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, d_from, v);
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
-
-    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
-    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
   }
 #endif  // HWY_TARGET != HWY_SCALAR
  public:
@@ -312,8 +309,6 @@ class TestTruncatingResizeBitCast {
     const auto v_full = Iota(d, 1);
     const VFromD<decltype(dh)> expected_full_to_half = LowerHalf(dh, v_full);
     HWY_ASSERT_VEC_EQ(dh, expected_full_to_half, ResizeBitCast(dh, v_full));
-    HWY_ASSERT_VEC_EQ(dh, expected_full_to_half,
-                      ZeroExtendResizeBitCast(dh, v_full));
     HWY_ASSERT_VEC_EQ(dh, expected_full_to_half,
                       ZeroExtendResizeBitCast(dh, d, v_full));
 
@@ -369,18 +364,11 @@ class TestExtendingResizeBitCast {
     const VFromD<DFrom> v = Iota(d_from, 1);
 
     const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
-#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
-    const VFromD<DTo> actual_2 =
-        IfThenElseZero(active_elements_mask, ZeroExtendResizeBitCast(d_to, v));
-#else
-    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
-#endif
-    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, d_from, v);
 
     HWY_ASSERT_VEC_EQ(d_to, expected,
                       IfThenElseZero(active_elements_mask, actual_1));
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
-    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
   }
   template <class DFrom>
   static HWY_INLINE void DoExtResizeBitCastToTwiceDTest(DFrom d_from) {
@@ -392,18 +380,11 @@ class TestExtendingResizeBitCast {
     const VFromD<DTo> expected = ZeroExtendVector(d_to, v);
 
     const VFromD<DTo> actual_1 = ResizeBitCast(d_to, v);
-    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, v);
-    const VFromD<DTo> actual_3 = ZeroExtendResizeBitCast(d_to, d_from, v);
+    const VFromD<DTo> actual_2 = ZeroExtendResizeBitCast(d_to, d_from, v);
 
     HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_1));
     HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_2));
-    HWY_ASSERT_VEC_EQ(d_from, v, LowerHalf(d_from, actual_3));
-
-#if !HWY_HAVE_SCALABLE && HWY_TARGET != HWY_SVE_256 && \
-    HWY_TARGET != HWY_SVE2_128
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
-#endif
-    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
   }
 #endif  // HWY_TARGET != HWY_SCALAR
  public:

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -186,6 +186,7 @@ struct TestResizeBitCastToOneLaneVect {
     }
 
     auto from_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(from_lanes);
     auto v = Iota(d, 1);
     Store(v, d, from_lanes.get());
 

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -176,6 +176,167 @@ HWY_NOINLINE void TestAllBitCast() {
 #endif
 }
 
+template <class TTo>
+struct TestResizeBitCastToOneLaneVect {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    if (N == 0) {
+      return;
+    }
+
+    auto from_lanes = AllocateAligned<T>(N);
+    auto v = Iota(d, 1);
+    Store(v, d, from_lanes.get());
+
+    const size_t num_of_bytes_to_copy = HWY_MIN(N * sizeof(T), sizeof(TTo));
+
+    int8_t active_bits_mask_i8_arr[sizeof(TTo)] = {};
+    for (size_t i = 0; i < num_of_bytes_to_copy; i++) {
+      active_bits_mask_i8_arr[i] = int8_t{-1};
+    }
+
+    TTo active_bits_int_mask;
+    CopyBytes<sizeof(TTo)>(active_bits_mask_i8_arr, &active_bits_int_mask);
+
+    const FixedTag<TTo, 1> d_to;
+    TTo expected_bits = 0;
+    memcpy(&expected_bits, from_lanes.get(), num_of_bytes_to_copy);
+
+    const auto expected = Set(d_to, expected_bits);
+    const auto v_active_bits_mask = Set(d_to, active_bits_int_mask);
+
+    const auto actual_1 = And(v_active_bits_mask, ResizeBitCast(d_to, v));
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+    const auto actual_2 =
+        And(v_active_bits_mask, ZeroExtendResizeBitCast(d_to, v));
+#else
+    const auto actual_2 = ZeroExtendResizeBitCast(d_to, v);
+#endif
+    const auto actual_3 = ZeroExtendResizeBitCast(d_to, d, v);
+
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_1);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
+    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
+  }
+};
+
+HWY_NOINLINE void TestAllResizeBitCastToOneLaneVect() {
+  ForAllTypes(ForPartialVectors<TestResizeBitCastToOneLaneVect<uint32_t>>());
+#if HWY_HAVE_INTEGER64
+  ForAllTypes(ForPartialVectors<TestResizeBitCastToOneLaneVect<uint64_t>>());
+#endif
+}
+
+// Cast and ensure bytes are the same. Called directly from
+// TestAllSameSizeResizeBitCast or via TestSameSizeResizeBitCastFrom.
+template <typename ToT>
+struct TestSameSizeResizeBitCast {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Repartition<ToT, D> dto;
+    const auto v = Iota(d, 1);
+    const auto expected = BitCast(dto, v);
+
+    const VFromD<decltype(dto)> actual_1 = ResizeBitCast(dto, v);
+    const VFromD<decltype(dto)> actual_2 = ZeroExtendResizeBitCast(dto, v);
+    const VFromD<decltype(dto)> actual_3 = ZeroExtendResizeBitCast(dto, d, v);
+
+    HWY_ASSERT_VEC_EQ(dto, expected, actual_1);
+    HWY_ASSERT_VEC_EQ(dto, expected, actual_2);
+    HWY_ASSERT_VEC_EQ(dto, expected, actual_3);
+  }
+};
+
+// From D to all types.
+struct TestSameSizeResizeBitCastFrom {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T t, D d) {
+    TestSameSizeResizeBitCast<uint8_t>()(t, d);
+    TestSameSizeResizeBitCast<uint16_t>()(t, d);
+    TestSameSizeResizeBitCast<uint32_t>()(t, d);
+#if HWY_HAVE_INTEGER64
+    TestSameSizeResizeBitCast<uint64_t>()(t, d);
+#endif
+    TestSameSizeResizeBitCast<int8_t>()(t, d);
+    TestSameSizeResizeBitCast<int16_t>()(t, d);
+    TestSameSizeResizeBitCast<int32_t>()(t, d);
+#if HWY_HAVE_INTEGER64
+    TestSameSizeResizeBitCast<int64_t>()(t, d);
+#endif
+    TestSameSizeResizeBitCast<float>()(t, d);
+#if HWY_HAVE_FLOAT64
+    TestSameSizeResizeBitCast<double>()(t, d);
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllSameSizeResizeBitCast() {
+  // For HWY_SCALAR and partial vectors, we can only cast to same-sized types:
+  // the former can't partition its single lane, and the latter can be smaller
+  // than a destination type.
+  const ForPartialVectors<TestSameSizeResizeBitCast<uint8_t>> to_u8;
+  to_u8(uint8_t());
+  to_u8(int8_t());
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<int8_t>> to_i8;
+  to_i8(uint8_t());
+  to_i8(int8_t());
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<uint16_t>> to_u16;
+  to_u16(uint16_t());
+  to_u16(int16_t());
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<int16_t>> to_i16;
+  to_i16(uint16_t());
+  to_i16(int16_t());
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<uint32_t>> to_u32;
+  to_u32(uint32_t());
+  to_u32(int32_t());
+  to_u32(float());
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<int32_t>> to_i32;
+  to_i32(uint32_t());
+  to_i32(int32_t());
+  to_i32(float());
+
+#if HWY_HAVE_INTEGER64
+  const ForPartialVectors<TestSameSizeResizeBitCast<uint64_t>> to_u64;
+  to_u64(uint64_t());
+  to_u64(int64_t());
+#if HWY_HAVE_FLOAT64
+  to_u64(double());
+#endif
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<int64_t>> to_i64;
+  to_i64(uint64_t());
+  to_i64(int64_t());
+#if HWY_HAVE_FLOAT64
+  to_i64(double());
+#endif
+#endif  // HWY_HAVE_INTEGER64
+
+  const ForPartialVectors<TestSameSizeResizeBitCast<float>> to_float;
+  to_float(uint32_t());
+  to_float(int32_t());
+  to_float(float());
+
+#if HWY_HAVE_FLOAT64
+  const ForPartialVectors<TestSameSizeResizeBitCast<double>> to_double;
+  to_double(double());
+#if HWY_HAVE_INTEGER64
+  to_double(uint64_t());
+  to_double(int64_t());
+#endif  // HWY_HAVE_INTEGER64
+#endif  // HWY_HAVE_FLOAT64
+
+#if HWY_TARGET != HWY_SCALAR
+  // For non-scalar vectors, we can cast all types to all.
+  ForAllTypes(ForGEVectors<64, TestSameSizeResizeBitCastFrom>());
+#endif
+}
+
 template <typename ToT>
 struct TestPromoteTo {
   template <typename T, class D>
@@ -709,6 +870,8 @@ namespace hwy {
 HWY_BEFORE_TEST(HwyConvertTest);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllRebind);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllBitCast);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllResizeBitCastToOneLaneVect);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllSameSizeResizeBitCast);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllPromoteTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllF16);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllBF16);

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -208,17 +208,10 @@ struct TestResizeBitCastToOneLaneVect {
     const auto v_active_bits_mask = Set(d_to, active_bits_int_mask);
 
     const auto actual_1 = And(v_active_bits_mask, ResizeBitCast(d_to, v));
-#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
-    const auto actual_2 =
-        And(v_active_bits_mask, ZeroExtendResizeBitCast(d_to, v));
-#else
-    const auto actual_2 = ZeroExtendResizeBitCast(d_to, v);
-#endif
-    const auto actual_3 = ZeroExtendResizeBitCast(d_to, d, v);
+    const auto actual_2 = ZeroExtendResizeBitCast(d_to, d, v);
 
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_1);
     HWY_ASSERT_VEC_EQ(d_to, expected, actual_2);
-    HWY_ASSERT_VEC_EQ(d_to, expected, actual_3);
   }
 };
 
@@ -240,12 +233,10 @@ struct TestSameSizeResizeBitCast {
     const auto expected = BitCast(dto, v);
 
     const VFromD<decltype(dto)> actual_1 = ResizeBitCast(dto, v);
-    const VFromD<decltype(dto)> actual_2 = ZeroExtendResizeBitCast(dto, v);
-    const VFromD<decltype(dto)> actual_3 = ZeroExtendResizeBitCast(dto, d, v);
+    const VFromD<decltype(dto)> actual_2 = ZeroExtendResizeBitCast(dto, d, v);
 
     HWY_ASSERT_VEC_EQ(dto, expected, actual_1);
     HWY_ASSERT_VEC_EQ(dto, expected, actual_2);
-    HWY_ASSERT_VEC_EQ(dto, expected, actual_3);
   }
 };
 


### PR DESCRIPTION
Added the ResizeBitCast and ZeroExtendResizeBitCast operations, which allows a vector to be bit-casted to a smaller or larger vector type.

The ResizeBitCast operation is also usually more efficient than doing a BitCast followed by 2 or more LowerHalf operations in the case where `Lanes(D()) * sizeof(TFromD<D>) <= (Lanes(DFromV<V>()) * sizeof(TFromV<V>)) / 4`.

The ResizeBitCast operation is also usually more efficient than a BitCast operation followed by a ZeroExtendVector operation in the case where `Lanes(D()) * sizeof(TFromD<D>) > Lanes(DFromV<V>()) * sizeof(TFromV<V>)`.

In the case of a ResizeBitCast from a smaller vector type to a larger vector type, the contents of any bytes of the result vector past the past the first `Lanes(DFromV<V>()) * sizeof(TFromV<V>)` bytes of the result vector is unspecified, which avoids unnecessary overhead in the case where you do not care about the contents of any bytes past the first `Lanes(DFromV<V>()) * sizeof(TFromV<V>)`  bytes.

The ZeroExtendResizeBitCast operation is equivalent to a ResizeBitCast operation followed by a zero-out of the upper lanes of the result in the case where  `Lanes(D()) * sizeof(TFromD<D>) > Lanes(DFromV<V>()) * sizeof(TFromV<V>)`.

A ZeroExtendResizeBitCast(DTo, DFrom, VFromD<DFrom>) overload is also added since it is possible for `Lanes(DFromV<VFromD<DFrom>>())` to be greater than `Lanes(DFrom())` on RVV/SVE.

The ResizeBitCast operation also avoids unnecessary zero-out on many targets, including SSE2/SSSE3/SSE4/AVX2/AVX3/NEON/SVE/PPC8/PPC9/PPC10/WASM.

There are also use cases for ResizeBitCast in the implementations of StoreInterleaved3, StoreInterleaved4, and UI8ReverseBitsStep in hwy/ops/generic_ops.h.

Code such as `const VFromD<decltype(d_full)> v0{part0.raw};` can be replaced with `const auto v0 = ResizeBitCast(d_full, part0);` with the addition of the ResizeBitCast operation.