### PR TITLE
Added AESKeyGenAssist operation

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1471,6 +1471,24 @@ Ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     step of the AES Equivalent Inverse Cipher algorithm. The latency is
     independent of the input values.
 
+*   `V`: `u8` \
+    <code>V **AESKeyGenAssist**&lt;uint8_t&gt;(V v)</code>: AES key generation
+    assist operation
+
+    The AESKeyGenAssist operation is equivalent to doing the following, which
+    matches the behavior of the x86 AES-NI AESKEYGENASSIST instruction:
+    *  Applying the AES SubBytes operation to each byte of `v`.
+    *  Doing a TableLookupBytes operation on each 128-bit block of the
+       result of the `SubBytes(v)` operation with the following indices
+       (which is broadcast to each 128-bit block in the case of vectors with 32
+       or more lanes):
+       `{4, 5, 6, 7, 5, 6, 7, 4, 12, 13, 14, 15, 13, 14, 15, 12}`
+    *  Doing a bitwise XOR operation with the following vector (where `kRcon`
+       is the rounding constant that is the first template argument of the
+       AESKeyGenAssist function and where the below vector is broadcasted to
+       each 128-bit block in the case of vectors with 32 or more lanes):
+       `{0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0}`
+
 *   `V`: `u64` \
     <code>V **CLMulLower**(V a, V b)</code>: carryless multiplication of the
     lower 64 bits of each 128-bit block into a 128-bit product. The latency is

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1472,8 +1472,8 @@ Ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     independent of the input values.
 
 *   `V`: `u8` \
-    <code>V **AESKeyGenAssist**&lt;uint8_t&gt;(V v)</code>: AES key generation
-    assist operation
+    <code>V **AESKeyGenAssist**&lt;uint8_t kRcon&gt;(V v)</code>: AES key
+    generation assist operation
 
     The AESKeyGenAssist operation is equivalent to doing the following, which
     matches the behavior of the x86 AES-NI AESKEYGENASSIST instruction:

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -5560,10 +5560,10 @@ HWY_API VI TableLookupBytesOr0(V bytes, VI from) {
 // ---------------------------- AESKeyGenAssist (AESLastRound, TableLookupBytes)
 
 #if HWY_TARGET == HWY_NEON
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API Vec128<uint8_t> AESKeyGenAssist(Vec128<uint8_t> v) {
   alignas(16) static constexpr uint8_t kRconXorMask[16] = {
-      0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0};
+      0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0};
   alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
       0, 13, 10, 7, 1, 14, 11, 4, 8, 5, 2, 15, 9, 6, 3, 12};
   const DFromV<decltype(v)> d;

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4206,10 +4206,10 @@ HWY_API svuint8_t AESLastRoundInv(svuint8_t state, svuint8_t round_key) {
   return Xor(svaesd_u8(state, svdup_n_u8(0)), round_key);
 }
 
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API svuint8_t AESKeyGenAssist(svuint8_t v) {
   alignas(16) static constexpr uint8_t kRconXorMask[16] = {
-      0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0};
+      0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0};
   alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
       0, 13, 10, 7, 1, 14, 11, 4, 8, 5, 2, 15, 9, 6, 3, 12};
   const DFromV<decltype(v)> d;

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1615,10 +1615,10 @@ HWY_API V AESLastRoundInv(V state, const V round_key) {
   return state;
 }
 
-template <uint8_t kRoundConstant, class V>  // u8
+template <uint8_t kRcon, class V, HWY_IF_U8_D(DFromV<V>)>
 HWY_API V AESKeyGenAssist(V v) {
   alignas(16) static constexpr uint8_t kRconXorMask[16] = {
-      0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0};
+      0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0};
   alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
       4, 5, 6, 7, 5, 6, 7, 4, 12, 13, 14, 15, 13, 14, 15, 12};
   const DFromV<decltype(v)> d;

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1615,6 +1615,19 @@ HWY_API V AESLastRoundInv(V state, const V round_key) {
   return state;
 }
 
+template <uint8_t kRoundConstant, class V>  // u8
+HWY_API V AESKeyGenAssist(V v) {
+  alignas(16) static constexpr uint8_t kRconXorMask[16] = {
+      0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0};
+  alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
+      4, 5, 6, 7, 5, 6, 7, 4, 12, 13, 14, 15, 13, 14, 15, 12};
+  const DFromV<decltype(v)> d;
+  const auto sub_word_result = detail::SubBytes(v);
+  const auto rot_word_result =
+      TableLookupBytes(sub_word_result, LoadDup128(d, kRotWordShuffle));
+  return Xor(rot_word_result, LoadDup128(d, kRconXorMask));
+}
+
 // Constant-time implementation inspired by
 // https://www.bearssl.org/constanttime.html, but about half the cost because we
 // use 64x64 multiplies and 128-bit XORs.

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2976,10 +2976,10 @@ HWY_API Vec128<uint8_t> AESInvMixColumns(Vec128<uint8_t> state) {
   return AESRoundInv(AESLastRound(state, zero), zero);
 }
 
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API Vec128<uint8_t> AESKeyGenAssist(Vec128<uint8_t> v) {
   constexpr __vector unsigned char kRconXorMask = {
-      0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0};
+      0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0};
   constexpr __vector unsigned char kRotWordShuffle = {
       4, 5, 6, 7, 5, 6, 7, 4, 12, 13, 14, 15, 13, 14, 15, 12};
   const detail::CipherTag dc;

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2976,6 +2976,21 @@ HWY_API Vec128<uint8_t> AESInvMixColumns(Vec128<uint8_t> state) {
   return AESRoundInv(AESLastRound(state, zero), zero);
 }
 
+template <uint8_t kRoundConstant>
+HWY_API Vec128<uint8_t> AESKeyGenAssist(Vec128<uint8_t> v) {
+  constexpr __vector unsigned char kRconXorMask = {
+      0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0};
+  constexpr __vector unsigned char kRotWordShuffle = {
+      4, 5, 6, 7, 5, 6, 7, 4, 12, 13, 14, 15, 13, 14, 15, 12};
+  const detail::CipherTag dc;
+  const Full128<uint8_t> du8;
+  const auto sub_word_result =
+      BitCast(du8, detail::CipherVec{vec_sbox_be(BitCast(dc, v).raw)});
+  const auto rot_word_result =
+      TableLookupBytes(sub_word_result, Vec128<uint8_t>{kRotWordShuffle});
+  return Xor(rot_word_result, Vec128<uint8_t>{kRconXorMask});
+}
+
 template <size_t N>
 HWY_API Vec128<uint64_t, N> CLMulLower(Vec128<uint64_t, N> a,
                                        Vec128<uint64_t, N> b) {

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -7199,9 +7199,9 @@ HWY_API Vec128<uint8_t> AESLastRoundInv(Vec128<uint8_t> state,
   return Vec128<uint8_t>{_mm_aesdeclast_si128(state.raw, round_key.raw)};
 }
 
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API Vec128<uint8_t> AESKeyGenAssist(Vec128<uint8_t> v) {
-  return Vec128<uint8_t>{_mm_aeskeygenassist_si128(v.raw, kRoundConstant)};
+  return Vec128<uint8_t>{_mm_aeskeygenassist_si128(v.raw, kRcon)};
 }
 
 template <size_t N>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -7199,6 +7199,11 @@ HWY_API Vec128<uint8_t> AESLastRoundInv(Vec128<uint8_t> state,
   return Vec128<uint8_t>{_mm_aesdeclast_si128(state.raw, round_key.raw)};
 }
 
+template <uint8_t kRoundConstant>
+HWY_API Vec128<uint8_t> AESKeyGenAssist(Vec128<uint8_t> v) {
+  return Vec128<uint8_t>{_mm_aeskeygenassist_si128(v.raw, kRoundConstant)};
+}
+
 template <size_t N>
 HWY_API Vec128<uint64_t, N> CLMulLower(Vec128<uint64_t, N> a,
                                        Vec128<uint64_t, N> b) {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4894,12 +4894,12 @@ HWY_API V AESInvMixColumns(V state) {
 #endif
 }
 
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API Vec256<uint8_t> AESKeyGenAssist(Vec256<uint8_t> v) {
   const Full256<uint8_t> d;
 #if HWY_TARGET <= HWY_AVX3_DL
   alignas(16) static constexpr uint8_t kRconXorMask[16] = {
-      0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0};
+      0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0};
   alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
       0, 13, 10, 7, 1, 14, 11, 4, 8, 5, 2, 15, 9, 6, 3, 12};
   const Repartition<uint32_t, decltype(d)> du32;
@@ -4908,8 +4908,8 @@ HWY_API Vec256<uint8_t> AESKeyGenAssist(Vec256<uint8_t> v) {
   return TableLookupBytes(sub_word_result, Load(d, kRotWordShuffle));
 #else
   const Half<decltype(d)> d2;
-  return Combine(d, AESKeyGenAssist<kRoundConstant>(UpperHalf(d2, v)),
-                 AESKeyGenAssist<kRoundConstant>(LowerHalf(v)));
+  return Combine(d, AESKeyGenAssist<kRcon>(UpperHalf(d2, v)),
+                 AESKeyGenAssist<kRcon>(LowerHalf(v)));
 #endif
 }
 

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4894,6 +4894,25 @@ HWY_API V AESInvMixColumns(V state) {
 #endif
 }
 
+template <uint8_t kRoundConstant>
+HWY_API Vec256<uint8_t> AESKeyGenAssist(Vec256<uint8_t> v) {
+  const Full256<uint8_t> d;
+#if HWY_TARGET <= HWY_AVX3_DL
+  alignas(16) static constexpr uint8_t kRconXorMask[16] = {
+      0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0};
+  alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
+      0, 13, 10, 7, 1, 14, 11, 4, 8, 5, 2, 15, 9, 6, 3, 12};
+  const Repartition<uint32_t, decltype(d)> du32;
+  const auto w13 = BitCast(d, DupOdd(BitCast(du32, v)));
+  const auto sub_word_result = AESLastRound(w13, Load(d, kRconXorMask));
+  return TableLookupBytes(sub_word_result, Load(d, kRotWordShuffle));
+#else
+  const Half<decltype(d)> d2;
+  return Combine(d, AESKeyGenAssist<kRoundConstant>(UpperHalf(d2, v)),
+                 AESKeyGenAssist<kRoundConstant>(LowerHalf(v)));
+#endif
+}
+
 HWY_API Vec256<uint64_t> CLMulLower(Vec256<uint64_t> a, Vec256<uint64_t> b) {
 #if HWY_TARGET <= HWY_AVX3_DL
   return Vec256<uint64_t>{_mm256_clmulepi64_epi128(a.raw, b.raw, 0x00)};

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -3918,12 +3918,12 @@ HWY_API Vec512<uint8_t> AESLastRoundInv(Vec512<uint8_t> state,
 #endif
 }
 
-template <uint8_t kRoundConstant>
+template <uint8_t kRcon>
 HWY_API Vec512<uint8_t> AESKeyGenAssist(Vec512<uint8_t> v) {
   const Full512<uint8_t> d;
 #if HWY_TARGET <= HWY_AVX3_DL
   alignas(16) static constexpr uint8_t kRconXorMask[16] = {
-      0, kRoundConstant, 0, 0, 0, 0, 0, 0, 0, kRoundConstant, 0, 0, 0, 0, 0, 0};
+      0, kRcon, 0, 0, 0, 0, 0, 0, 0, kRcon, 0, 0, 0, 0, 0, 0};
   alignas(16) static constexpr uint8_t kRotWordShuffle[16] = {
       0, 13, 10, 7, 1, 14, 11, 4, 8, 5, 2, 15, 9, 6, 3, 12};
   const Repartition<uint32_t, decltype(d)> du32;
@@ -3932,8 +3932,8 @@ HWY_API Vec512<uint8_t> AESKeyGenAssist(Vec512<uint8_t> v) {
   return TableLookupBytes(sub_word_result, Load(d, kRotWordShuffle));
 #else
   const Half<decltype(d)> d2;
-  return Combine(d, AESKeyGenAssist<kRoundConstant>(UpperHalf(d2, v)),
-                 AESKeyGenAssist<kRoundConstant>(LowerHalf(v)));
+  return Combine(d, AESKeyGenAssist<kRcon>(UpperHalf(d2, v)),
+                 AESKeyGenAssist<kRcon>(LowerHalf(v)));
 #endif
 }
 

--- a/hwy/tests/crypto_test.cc
+++ b/hwy/tests/crypto_test.cc
@@ -253,6 +253,37 @@ HWY_NOINLINE void TestAllAESInverse() {
   ForGEVectors<128, TestAESInverse>()(uint8_t());
 }
 
+struct TestAESKeyGenAssist {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*t*/, D d) {
+    alignas(16) static constexpr uint8_t kTestVect1[16] = {
+        0x27, 0xCF, 0x73, 0xC3, 0x27, 0xCF, 0x73, 0xC3,
+        0x74, 0x01, 0x90, 0x5A, 0x74, 0x01, 0x90, 0x5A};
+    alignas(16) static constexpr uint8_t kExpectedResult1[16] = {
+        0xCC, 0x8A, 0x8F, 0x2E, 0xAA, 0x8F, 0x2E, 0xCC,
+        0x92, 0x7C, 0x60, 0xBE, 0x5C, 0x60, 0xBE, 0x92};
+
+    const auto expected_1 = LoadDup128(d, kExpectedResult1);
+    const auto actual_1 = AESKeyGenAssist<0x20>(LoadDup128(d, kTestVect1));
+    HWY_ASSERT_VEC_EQ(d, expected_1, actual_1);
+
+    alignas(16) static constexpr uint8_t kTestVect2[16] = {
+        0xD0, 0x14, 0xF9, 0xA8, 0x57, 0x5C, 0x00, 0x6E,
+        0xE1, 0x3F, 0x0C, 0xC8, 0xC9, 0xEE, 0x25, 0x89};
+    alignas(16) static constexpr uint8_t kExpectedResult2[16] = {
+        0x5B, 0x4A, 0x63, 0x9F, 0x7C, 0x63, 0x9F, 0x5B,
+        0xDD, 0x28, 0x3F, 0xA7, 0x1E, 0x3F, 0xA7, 0xDD};
+
+    const auto expected_2 = LoadDup128(d, kExpectedResult2);
+    const auto actual_2 = AESKeyGenAssist<0x36>(LoadDup128(d, kTestVect2));
+    HWY_ASSERT_VEC_EQ(d, expected_2, actual_2);
+  }
+};
+
+HWY_NOINLINE void TestAllAESKeyGenAssist() {
+  ForGEVectors<128, TestAESKeyGenAssist>()(uint8_t());
+}
+
 #else
 HWY_NOINLINE void TestAllAES() {}
 HWY_NOINLINE void TestAllAESInverse() {}


### PR DESCRIPTION
Added the AESKeyGenAssist operation, which can be used to accelerate the AES Key Expansion algorithm, as the AESKeyGenAssist operation for a 128-bit uint8_t vector can be carried out in a single instruction on SSE4/AVX2/AVX3/AVX3_DL targets using the x86 AES-NI AESKEYGENASSIST instruction.

There are two different approaches that can be used to implement the AESKeyGenAssist operation for the other targets.

The first approach, which is used on NEON Crypto/SVE2 Crypto (and for 256-bit/512-bit vectors on AVX3_DL) is to do a U32 DupOdd operation, followed by an AESLastRound operation, followed by a shuffle using the TableLookupBytes operation.

The second approach, which is used by EMU128/PPC8/PPC9/PPC10/NEON_WITHOUT_AES/SSE2/SSSE3/RVV is to do an AES SubBytes operation, followed by a TableLookupBytes operation, followed by a Xor operation. The second approach also avoids the extra shuffle operation that the first approach would require on the EMU128/NEON_WITHOUT_AES/SSE2/SSSE3/RVV targets.