### PR TITLE
Fix vqsort compilation errors

### DIFF
--- a/hwy/contrib/sort/algo-inl.h
+++ b/hwy/contrib/sort/algo-inl.h
@@ -421,9 +421,13 @@ void CallHeapSort(K64V64* HWY_RESTRICT keys, const size_t num_keys) {
 
 template <class Order, typename KeyType>
 void Run(Algo algo, KeyType* HWY_RESTRICT inout, size_t num,
-         SharedState& shared, size_t thread) {
+         SharedState& shared, size_t /*thread*/) {
   const std::less<KeyType> less;
   const std::greater<KeyType> greater;
+
+#if !HAVE_PARALLEL_IPS4O
+  (void)shared;
+#endif
 
   switch (algo) {
 #if HAVE_AVX2SORT

--- a/hwy/contrib/sort/bench_parallel.cc
+++ b/hwy/contrib/sort/bench_parallel.cc
@@ -205,7 +205,6 @@ void BenchParallel() {
   const Dist dist = Dist::kUniform32;
 
   SharedState shared;
-  shared.tls.resize(NT);
 
   std::vector<Result> results;
   for (size_t nt = 1; nt < NT; nt += HWY_MAX(1, NT / 16)) {

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -403,8 +403,10 @@ static HWY_NOINLINE void TestRandomGenerator() {
     sum_hi += bits >> 32;
   }
   const double expected = 1000 * (1ULL << 31);
-  HWY_ASSERT(0.9 * expected <= sum_lo && sum_lo <= 1.1 * expected);
-  HWY_ASSERT(0.9 * expected <= sum_hi && sum_hi <= 1.1 * expected);
+  HWY_ASSERT(0.9 * expected <= static_cast<double>(sum_lo) &&
+             static_cast<double>(sum_lo) <= 1.1 * expected);
+  HWY_ASSERT(0.9 * expected <= static_cast<double>(sum_hi) &&
+             static_cast<double>(sum_hi) <= 1.1 * expected);
 
   const size_t lanes_per_block = HWY_MAX(64 / sizeof(TU), N);  // power of two
 

--- a/hwy/contrib/sort/vqsort.cc
+++ b/hwy/contrib/sort/vqsort.cc
@@ -111,7 +111,7 @@ void Fill16Bytes(void* bytes) {
 
 }  // namespace
 
-uint64_t* HWY_RESTRICT GetGeneratorState() {
+uint64_t* GetGeneratorState() {
   thread_local uint64_t state[3] = {0};
   // This is a counter; zero indicates not yet initialized.
   if (HWY_UNLIKELY(state[2] == 0)) {

--- a/hwy/contrib/sort/vqsort.h
+++ b/hwy/contrib/sort/vqsort.h
@@ -95,8 +95,8 @@ class HWY_CONTRIB_DLLEXPORT Sorter {
   // Move-only
   Sorter(const Sorter&) = delete;
   Sorter& operator=(const Sorter&) = delete;
-  Sorter(Sorter&& other) {}
-  Sorter& operator=(Sorter&& other) { return *this; }
+  Sorter(Sorter&& /*other*/) {}
+  Sorter& operator=(Sorter&& /*other*/) { return *this; }
 
   void operator()(uint16_t* HWY_RESTRICT keys, size_t n,
                   SortAscending tag) const {
@@ -203,11 +203,18 @@ class HWY_CONTRIB_DLLEXPORT Sorter {
     return nullptr;
   }
 
+#if HWY_COMPILER_CLANG
+  HWY_DIAGNOSTICS(push)
+  HWY_DIAGNOSTICS_OFF(disable : 4700, ignored "-Wunused-private-field")
+#endif
   void* unused_ = nullptr;
+#if HWY_COMPILER_CLANG
+  HWY_DIAGNOSTICS(pop)
+#endif
 };
 
 // Internal use only
-HWY_CONTRIB_DLLEXPORT uint64_t* HWY_RESTRICT GetGeneratorState();
+HWY_CONTRIB_DLLEXPORT uint64_t* GetGeneratorState();
 
 }  // namespace hwy
 


### PR DESCRIPTION
Changes were made to hwy/contrib/sort/algo-inl.h, hwy/contrib/sort/bench_parallel.cc, hwy/contrib/sort/sort_test.cc, hwy/contrib/sort/vqsort.cc, and hwy/contrib/sort/vqsort.h to fix compilation errors in the GitHub workflow.