### PR TITLE
Updated AVX3_DL implementation of I16->I32 ReorderWidenMulAccumulate

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -5889,7 +5889,11 @@ template <class D32, HWY_IF_I32_D(D32), HWY_IF_V_SIZE_LE_D(D32, 16),
 HWY_API VFromD<D32> ReorderWidenMulAccumulate(D32 /* tag */, V16 a, V16 b,
                                               const VFromD<D32> sum0,
                                               VFromD<D32>& /*sum1*/) {
+#if HWY_TARGET <= HWY_AVX3_DL
+  return VFromD<D32>{_mm_dpwssd_epi32(sum0.raw, a.raw, b.raw)};
+#else
   return sum0 + VFromD<D32>{_mm_madd_epi16(a.raw, b.raw)};
+#endif
 }
 
 // ------------------------------ RearrangeToOddPlusEven

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4278,7 +4278,11 @@ HWY_API Vec256<int32_t> ReorderWidenMulAccumulate(D /*d32*/, Vec256<int16_t> a,
                                                   Vec256<int16_t> b,
                                                   const Vec256<int32_t> sum0,
                                                   Vec256<int32_t>& /*sum1*/) {
+#if HWY_TARGET <= HWY_AVX3_DL
+  return Vec256<int32_t>{_mm256_dpwssd_epi32(sum0.raw, a.raw, b.raw)};
+#else
   return sum0 + Vec256<int32_t>{_mm256_madd_epi16(a.raw, b.raw)};
+#endif
 }
 
 // ------------------------------ RearrangeToOddPlusEven

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -51,20 +51,25 @@ HWY_DIAGNOSTICS_OFF(disable : 4703 6001 26494, ignored "-Wmaybe-uninitialized")
 #include <avx512vlbwintrin.h>
 #include <avx512dqintrin.h>
 #include <avx512vldqintrin.h>
-#include <avx512bitalgintrin.h>
-#include <avx512vlbitalgintrin.h>
 #include <avx512cdintrin.h>
 #include <avx512vlcdintrin.h>
+
+#if HWY_TARGET <= HWY_AVX3_DL
+#include <avx512bitalgintrin.h>
+#include <avx512vlbitalgintrin.h>
 #include <avx512vbmiintrin.h>
 #include <avx512vbmivlintrin.h>
 #include <avx512vbmi2intrin.h>
 #include <avx512vlvbmi2intrin.h>
 #include <avx512vpopcntdqintrin.h>
 #include <avx512vpopcntdqvlintrin.h>
+#include <avx512vnniintrin.h>
+#include <avx512vlvnniintrin.h>
 // Must come after avx512fintrin, else will not define 512-bit intrinsics.
 #include <vaesintrin.h>
 #include <vpclmulqdqintrin.h>
 #include <gfniintrin.h>
+#endif  // HWY_TARGET <= HWY_AVX3_DL
 // clang-format on
 #endif  // HWY_COMPILER_CLANGCL
 
@@ -5198,7 +5203,11 @@ HWY_API Vec512<int32_t> ReorderWidenMulAccumulate(D /*d32*/, Vec512<int16_t> a,
                                                   Vec512<int16_t> b,
                                                   const Vec512<int32_t> sum0,
                                                   Vec512<int32_t>& /*sum1*/) {
+#if HWY_TARGET <= HWY_AVX3_DL
+  return Vec512<int32_t>{_mm512_dpwssd_epi32(sum0.raw, a.raw, b.raw)};
+#else
   return sum0 + Vec512<int32_t>{_mm512_madd_epi16(a.raw, b.raw)};
+#endif
 }
 
 HWY_API Vec512<int32_t> RearrangeToOddPlusEven(const Vec512<int32_t> sum0,


### PR DESCRIPTION
The I16->I32 ReorderWidenMulAccumulate implementation for the AVX3_DL/AVX3_ZEN4 targets has been updated to use the `_mm_dpwssd_epi32`, `_mm256_dpwssd_epi32`, and `_mm512_dpwssd_epi32` intrinsics.

`_mm_dpwssd_epi32(sum, a, b)` is equivalent to `_mm_add_epi32(sum, _mm_madd_epi16(a, b))`, but `_mm_dpwssd_epi32(sum, a, b)` can be carried out using a single VPDPWSSD instruction on the AVX3_DL/AVX3_ZEN4 targets.