### PR TITLE
Added BitwiseIfThenElse operation

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -655,6 +655,12 @@ them from 2-argument functions:
 *   <code>V **Or3**(V o1, V o2, V o3)</code>: returns `o1[i] | o2[i] | o3[i]`.
     This is less efficient than `Xor3` on some targets; use that where possible.
 *   <code>V **OrAnd**(V o, V a1, V a2)</code>: returns `o[i] | (a1[i] & a2[i])`.
+*   <code>V **BitwiseIfThenElse**(V mask, V yes, V no)</code>: returns
+    `((mask[i] & yes[i]) | (~mask[i] & no[i]))`. `BitwiseIfThenElse` is more
+    efficient than `Or(And(mask, yes), AndNot(mask, no))` on some targets.
+
+    `BitwiseIfThenElse(mask, yes, no)` is guaranteed to return the same result
+    as `Or(And(mask, yes), AndNot(mask, no))` on all targets
 
 Special functions for signed types:
 

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -2131,6 +2131,19 @@ HWY_API Vec128<T, N> IfVecThenElse(Vec128<T, N> mask, Vec128<T, N> yes,
   return IfThenElse(MaskFromVec(mask), yes, no);
 }
 
+// ------------------------------ BitwiseIfThenElse
+
+#ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#undef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#else
+#define HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#endif
+
+template <class V>
+HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
+  return IfVecThenElse(mask, yes, no);
+}
+
 // ------------------------------ Operator overloads (internal-only if float)
 
 template <typename T, size_t N>

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -1031,6 +1031,19 @@ HWY_API V IfVecThenElse(const V mask, const V yes, const V no) {
 
 #endif  // HWY_SVE_HAVE_2
 
+// ------------------------------ BitwiseIfThenElse
+
+#ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#undef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#else
+#define HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#endif
+
+template <class V>
+HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
+  return IfVecThenElse(mask, yes, no);
+}
+
 // ------------------------------ Floating-point classification (Ne)
 
 template <class V>

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -122,6 +122,21 @@ HWY_API void SafeCopyN(const size_t num, D d, const T* HWY_RESTRICT from,
 #endif
 }
 
+// ------------------------------ BitwiseIfThenElse
+#if (defined(HWY_NATIVE_BITWISE_IF_THEN_ELSE) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#undef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#else
+#define HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#endif
+
+template <class V>
+HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
+  return Or(And(mask, yes), AndNot(mask, no));
+}
+
+#endif  // HWY_NATIVE_BITWISE_IF_THEN_ELSE
+
 // "Include guard": skip if native instructions are available. The generic
 // implementation is currently shared between x86_* and wasm_*, and is too large
 // to duplicate.

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -306,6 +306,19 @@ HWY_API Vec128<T, N> IfVecThenElse(Vec128<T, N> mask, Vec128<T, N> yes,
                                       BitCast(du, mask).raw)});
 }
 
+// ------------------------------ BitwiseIfThenElse
+
+#ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#undef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#else
+#define HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#endif
+
+template <class V>
+HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
+  return IfVecThenElse(mask, yes, no);
+}
+
 // ------------------------------ Operator overloads (internal-only if float)
 
 template <typename T, size_t N>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -478,6 +478,22 @@ HWY_API Vec128<T, N> IfVecThenElse(Vec128<T, N> mask, Vec128<T, N> yes,
 #endif
 }
 
+// ------------------------------ BitwiseIfThenElse
+#if HWY_TARGET <= HWY_AVX3
+
+#ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#undef HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#else
+#define HWY_NATIVE_BITWISE_IF_THEN_ELSE
+#endif
+
+template <class V>
+HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
+  return IfVecThenElse(mask, yes, no);
+}
+
+#endif
+
 // ------------------------------ Operator overloads (internal-only if float)
 
 template <typename T, size_t N>

--- a/hwy/tests/logical_test.cc
+++ b/hwy/tests/logical_test.cc
@@ -199,6 +199,80 @@ HWY_NOINLINE void TestAllTestBit() {
   ForIntegerTypes(ForPartialVectors<TestTestBit>());
 }
 
+class TestBitwiseIfThenElse {
+ private:
+  template <class T>
+  static constexpr T ValueFromBitPattern(hwy::FloatTag /* type_tag */,
+                                         T /* unused */, uint64_t bits) {
+    using TI = MakeSigned<T>;
+    return static_cast<T>(static_cast<TI>(bits & MantissaMask<T>())) +
+           MantissaEnd<T>();
+  }
+  template <class T>
+  static constexpr MakeUnsigned<T> ValueFromBitPattern(
+      hwy::NonFloatTag /* type_tag */, T /* unused */, uint64_t bits) {
+    return static_cast<MakeUnsigned<T>>(bits);
+  }
+
+ public:
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    using TU = MakeUnsigned<T>;
+    using TVal = RemoveConst<decltype(ValueFromBitPattern(IsFloatTag<T>(), T(),
+                                                          uint64_t{0}))>;
+    static_assert(!IsFloat<T>() || IsSame<TVal, T>(),
+                  "TVal should be the same as T if T is a floating-point type");
+    static_assert(IsFloat<T>() || IsSame<TVal, TU>(),
+                  "TVal should be the same as TU if T is a integer type");
+
+    static constexpr TVal a0 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0x0FF00FF00FF00FF0u});
+    static constexpr TVal b0 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0x33CC33CC33CC33CCu});
+    static constexpr TVal c0 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0x55AA55AA55AA55AAu});
+    static constexpr TVal a1 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0xF00FF00FF00FF00Fu});
+    static constexpr TVal b1 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0xCC33CC33CC33CC33u});
+    static constexpr TVal c1 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0xAA55AA55AA55AA55u});
+
+    const RebindToUnsigned<decltype(d)> du;
+    const Rebind<TVal, decltype(d)> d_val;
+    const auto v_a0 = BitCast(d, Set(d_val, a0));
+    const auto v_b0 = BitCast(d, Set(d_val, b0));
+    const auto v_c0 = BitCast(d, Set(d_val, c0));
+
+    const auto v_a1 = BitCast(d, Set(d_val, a1));
+    const auto v_b1 = BitCast(d, Set(d_val, b1));
+    const auto v_c1 = BitCast(d, Set(d_val, c1));
+
+    static constexpr TVal expected_1 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0x53CA53CA53CA53CAu});
+    HWY_ASSERT_VEC_EQ(d, BitCast(d, Set(d_val, expected_1)),
+                      BitwiseIfThenElse(v_a0, v_b0, v_c0));
+
+    static constexpr TVal expected_2 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0xCA53CA53CA53CA53u});
+    HWY_ASSERT_VEC_EQ(d, BitCast(d, Set(d_val, expected_2)),
+                      BitwiseIfThenElse(v_a1, v_b1, v_c1));
+
+    static constexpr TVal expected_3 = ValueFromBitPattern(
+        IsFloatTag<T>(), T(), uint64_t{0x1DB81DB81DB81DB8u});
+    HWY_ASSERT_VEC_EQ(d, BitCast(d, Set(d_val, expected_3)),
+                      BitwiseIfThenElse(v_b1, v_a0, v_c0));
+
+    const auto v_all_ones = BitCast(d, Set(du, static_cast<TU>(-1)));
+    HWY_ASSERT_VEC_EQ(d, v_a0, BitwiseIfThenElse(v_all_ones, v_a0, v_b0));
+    HWY_ASSERT_VEC_EQ(d, v_b0, BitwiseIfThenElse(Zero(d), v_a0, v_b0));
+  }
+};
+
+HWY_NOINLINE void TestAllBitwiseIfThenElse() {
+  ForAllTypes(ForPartialVectors<TestBitwiseIfThenElse>());
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -213,6 +287,7 @@ HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllLogical);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllCopySign);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllBroadcastSignBit);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllTestBit);
+HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllBitwiseIfThenElse);
 }  // namespace hwy
 
 #endif


### PR DESCRIPTION
While the BitwiseIfThenElse operation is similar to the IfVecThenElse operation, the BitwiseIfThenElse operation was added to provide guarantees that `BitwiseIfThenElse(mask, yes, no)` produces the same result as `Or(And(mask, yes), AndNot(mask, no))` in the case where `mask[i]` is neither zero nor all bits set.

There are some targets where `IfVecThenElse(mask, yes, no)` does not produce the same result as `BitwiseIfThenElse(mask, yes, no)` for the case where `mask[i]` is neither zero nor all bits set, including SSE4/AVX2.

Here is an example of code where BitwiseIfThenElse and IfVecThenElse generate different results on SSE4/AVX2:
```
alignas(16) static constexpr uint8_t kVectA[16] =
  { 0xB4, 0x9C, 0xC3, 0x97, 0xBA, 0x44, 0xA3, 0xB3, 0xDF, 0x29, 0x7A, 0xA3, 0x14, 0x4D, 0xE2, 0xF6 };
alignas(16) static constexpr uint8_t kVectB[16] =
  { 0x1B, 0x7B, 0x81, 0xF9, 0xBE, 0xF4, 0x42, 0x67, 0x6E, 0xD1, 0xA9, 0xB3, 0x5E, 0x1C, 0x0E, 0x69 };
alignas(16) static constexpr uint8_t kVectC[16] =
  { 0x79, 0x37, 0xE4, 0xAD, 0x01, 0x3E, 0x5C, 0x0E, 0xCE, 0x1E, 0xF4, 0x5B, 0x77, 0x8A, 0xDA, 0x59 };

const FixedTag<uint8_t, 16> d;
const auto a = Load(d, kVectA);
const auto b = Load(d, kVectB);
const auto c = Load(d, kVectC);

const auto r1 = BitwiseIfThenElse(a, b, c);
const auto r2 = IfVecThenElse(a, b, c);
```

Here is the result of `r1` in the example code above (on all targets):
`{0x59, 0x3B, 0xA5, 0xB9, 0xBB, 0x7E, 0x5E, 0x2F, 0x4E, 0x17, 0xAC, 0xFB, 0x77, 0x8E, 0x1A, 0x69}`

Here is the result of `r2` in the example code above on the SSE4/AVX2 targets (where IfVecThenElse is implemented using a `_mm_blendv_epi8` operation):
`{0x1B, 0x7B, 0x81, 0xF9, 0xBE, 0x3E, 0x42, 0x67, 0x6E, 0x1E, 0xF4, 0xB3, 0x77, 0x8A, 0x0E, 0x69}`