### PR TITLE
Added U8/U16->U64, U8/U16/U32->I64, and I8/I16->I64 PromoteTo operations

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -3162,6 +3162,10 @@ template <class D, HWY_IF_I32_D(D)>
 HWY_API Vec128<int32_t> PromoteTo(D d, Vec64<uint16_t> v) {
   return BitCast(d, Vec128<uint32_t>(vmovl_u16(v.raw)));
 }
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec128<int64_t> PromoteTo(D d, Vec64<uint32_t> v) {
+  return BitCast(d, Vec128<uint64_t>(vmovl_u32(v.raw)));
+}
 
 // Unsigned: zero-extend to half vector.
 template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U16_D(D)>
@@ -3193,6 +3197,21 @@ HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint8_t, D>> v) {
 template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint16_t, D>> v) {
   return VFromD<D>(vget_low_s32(vreinterpretq_s32_u32(vmovl_u16(v.raw))));
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I64_D(D)>
+HWY_API VFromD<D> PromoteTo(D d, VFromD<Rebind<uint32_t, D>> v) {
+  using DU = RebindToUnsigned<D>;
+  return BitCast(d, VFromD<DU>(vget_low_u64(vmovl_u32(v.raw))));
+}
+
+// U8/U16 to U64/I64: First, zero-extend to U32, and then zero-extend to
+// TFromD<D>
+template <class D, class V, HWY_IF_UI64_D(D),
+          HWY_IF_LANES_D(D, HWY_MAX_LANES_V(V)), HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> PromoteTo(D d, V v) {
+  const Rebind<uint32_t, decltype(d)> du32;
+  return PromoteTo(d, PromoteTo(du32, v));
 }
 
 // Signed: replicate sign bit to full vector.
@@ -3230,6 +3249,15 @@ HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<int16_t, D>> v) {
 template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I64_D(D)>
 HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<int32_t, D>> v) {
   return VFromD<D>(vget_low_s64(vmovl_s32(v.raw)));
+}
+
+// I8/I16 to I64: First, promote to I32, and then promote to I64
+template <class D, class V, HWY_IF_I64_D(D),
+          HWY_IF_LANES_D(D, HWY_MAX_LANES_V(V)), HWY_IF_SIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> PromoteTo(D d, V v) {
+  const Rebind<int32_t, decltype(d)> di32;
+  return PromoteTo(d, PromoteTo(di32, v));
 }
 
 #if __ARM_FP & 2

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -1354,31 +1354,37 @@ HWY_API svint32_t PromoteTo(Simd<int32_t, N, kPow2> dto, svint8_t vfrom) {
   const RepartitionToWide<DFromV<decltype(vfrom)>> d2;
   return PromoteTo(dto, PromoteTo(d2, vfrom));
 }
+template <size_t N, int kPow2>
+HWY_API svuint64_t PromoteTo(Simd<uint64_t, N, kPow2> dto, svuint16_t vfrom) {
+  const RepartitionToWide<DFromV<decltype(vfrom)>> d2;
+  return PromoteTo(dto, PromoteTo(d2, vfrom));
+}
+template <size_t N, int kPow2>
+HWY_API svint64_t PromoteTo(Simd<int64_t, N, kPow2> dto, svint16_t vfrom) {
+  const RepartitionToWide<DFromV<decltype(vfrom)>> d2;
+  return PromoteTo(dto, PromoteTo(d2, vfrom));
+}
 
-// 3x for LaneIndicesFromByteIndices u64
+// 3x
 template <size_t N, int kPow2>
 HWY_API svuint64_t PromoteTo(Simd<uint64_t, N, kPow2> dto, svuint8_t vfrom) {
   const RepartitionToNarrow<decltype(dto)> d4;
   const RepartitionToNarrow<decltype(d4)> d2;
   return PromoteTo(dto, PromoteTo(d4, PromoteTo(d2, vfrom)));
 }
+template <size_t N, int kPow2>
+HWY_API svint64_t PromoteTo(Simd<int64_t, N, kPow2> dto, svint8_t vfrom) {
+  const RepartitionToNarrow<decltype(dto)> d4;
+  const RepartitionToNarrow<decltype(d4)> d2;
+  return PromoteTo(dto, PromoteTo(d4, PromoteTo(d2, vfrom)));
+}
 
 // Sign change
-template <size_t N, int kPow2>
-HWY_API svint16_t PromoteTo(Simd<int16_t, N, kPow2> dto, svuint8_t vfrom) {
-  const RebindToUnsigned<decltype(dto)> du;
-  return BitCast(dto, PromoteTo(du, vfrom));
-}
-template <size_t N, int kPow2>
-HWY_API svint32_t PromoteTo(Simd<int32_t, N, kPow2> dto, svuint16_t vfrom) {
-  const RebindToUnsigned<decltype(dto)> du;
-  return BitCast(dto, PromoteTo(du, vfrom));
-}
-template <size_t N, int kPow2>
-HWY_API svint32_t PromoteTo(Simd<int32_t, N, kPow2> dto, svuint8_t vfrom) {
-  const Repartition<uint16_t, DFromV<decltype(vfrom)>> du16;
-  const Repartition<int16_t, decltype(du16)> di16;
-  return PromoteTo(dto, BitCast(di16, PromoteTo(du16, vfrom)));
+template <class D, class V, HWY_IF_SIGNED_D(D), HWY_IF_UNSIGNED_V(V),
+          HWY_IF_LANES_GT(sizeof(TFromD<D>), sizeof(TFromV<V>))>
+HWY_API VFromD<D> PromoteTo(D di, V v) {
+  const RebindToUnsigned<decltype(di)> du;
+  return BitCast(di, PromoteTo(du, v));
 }
 
 // ------------------------------ PromoteTo F

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2476,6 +2476,17 @@ HWY_API VFromD<D> PromoteTo(D d32,
   return PromoteTo(d32, PromoteTo(d16, v));
 }
 
+// 8-bit or 16-bit to 64-bit: First, promote to MakeWide<FromT>, and then
+// convert to 64-bit.
+template <class D, typename FromT, HWY_IF_T_SIZE_D(D, 8), HWY_IF_NOT_FLOAT_D(D),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(FromT),
+          HWY_IF_T_SIZE_ONE_OF(FromT, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> PromoteTo(D d64,
+                            Vec128<FromT, Rebind<FromT, D>().MaxLanes()> v) {
+  const Rebind<MakeWide<FromT>, decltype(d64)> dw;
+  return PromoteTo(d64, PromoteTo(dw, v));
+}
+
 // Workaround for origin tracking bug in Clang msan prior to 11.0
 // (spurious "uninitialized memory" for TestF16 with "ORIGIN: invalid")
 #if HWY_IS_MSAN && (HWY_COMPILER_CLANG != 0 && HWY_COMPILER_CLANG < 1100)

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -3283,11 +3283,25 @@ template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint16_t, D>> v) {
   return VFromD<D>{wasm_u32x4_extend_low_u16x8(v.raw)};
 }
+template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_I64_D(D)>
+HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint32_t, D>> v) {
+  return VFromD<D>{wasm_u64x2_extend_low_u32x4(v.raw)};
+}
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint8_t, D>> v) {
   return VFromD<D>{
       wasm_u32x4_extend_low_u16x8(wasm_u16x8_extend_low_u8x16(v.raw))};
+}
+
+// U8/U16 to U64/I64: First, zero-extend to U32, and then zero-extend to
+// TFromD<D>
+template <class D, class V, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_UI64_D(D),
+          HWY_IF_LANES_D(D, HWY_MAX_LANES_V(V)), HWY_IF_UNSIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> PromoteTo(D d, V v) {
+  const Rebind<uint32_t, decltype(d)> du32;
+  return PromoteTo(d, PromoteTo(du32, v));
 }
 
 // Signed: replicate sign bit.
@@ -3308,6 +3322,15 @@ template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<int8_t, D>> v) {
   return VFromD<D>{
       wasm_i32x4_extend_low_i16x8(wasm_i16x8_extend_low_i8x16(v.raw))};
+}
+
+// I8/I16 to I64: First, promote to I32, and then promote to I64
+template <class D, class V, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_I64_D(D),
+          HWY_IF_LANES_D(D, HWY_MAX_LANES_V(V)), HWY_IF_SIGNED_V(V),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_API VFromD<D> PromoteTo(D d, V v) {
+  const Rebind<int32_t, decltype(d)> di32;
+  return PromoteTo(d, PromoteTo(di32, v));
 }
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16), HWY_IF_F32_D(D)>

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1260,6 +1260,10 @@ template <class D, HWY_IF_I32_D(D)>
 HWY_API Vec128<int32_t> PromoteUpperTo(D /* tag */, Vec128<uint16_t> v) {
   return Vec128<int32_t>{wasm_u32x4_extend_high_u16x8(v.raw)};
 }
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec128<int64_t> PromoteUpperTo(D /* tag */, Vec128<uint32_t> v) {
+  return Vec128<int64_t>{wasm_u64x2_extend_high_u32x4(v.raw)};
+}
 
 // Signed: replicate sign bit.
 template <class D, HWY_IF_I16_D(D)>
@@ -1316,7 +1320,8 @@ HWY_API Vec128<float> PromoteUpperTo(D df32, Vec128<bfloat16_t> v) {
 
 }  // namespace detail
 
-template <class D, HWY_IF_V_SIZE_D(D, 32), typename TN>
+template <class D, HWY_IF_V_SIZE_D(D, 32), typename TN,
+          HWY_IF_T_SIZE_D(D, sizeof(TN) * 2)>
 HWY_API VFromD<D> PromoteTo(D d, Vec128<TN> v) {
   const Half<decltype(d)> dh;
   VFromD<D> ret;
@@ -1325,15 +1330,33 @@ HWY_API VFromD<D> PromoteTo(D d, Vec128<TN> v) {
   return ret;
 }
 
-// This is the only 4x promotion from 8 to 32-bit.
-template <class DW, HWY_IF_T_SIZE_D(DW, 4), typename TN, HWY_IF_T_SIZE(TN, 1)>
+// 4x promotion: 8-bit to 32-bit or 16-bit to 64-bit
+template <class DW, HWY_IF_V_SIZE_D(DW, 32),
+          HWY_IF_T_SIZE_ONE_OF_D(DW, (1 << 4) | (1 << 8)),
+          HWY_IF_NOT_FLOAT_D(DW), typename TN,
+          HWY_IF_T_SIZE_D(DW, sizeof(TN) * 4),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(TN)>
 HWY_API Vec256<TFromD<DW>> PromoteTo(DW d, Vec64<TN> v) {
   const Half<decltype(d)> dh;
-  const Rebind<MakeWide<TN>, decltype(d)> d2;  // 16-bit lanes
-  const auto v16 = PromoteTo(d2, v);
+  // 16-bit lanes for UI8->UI32, 32-bit lanes for UI16->UI64
+  const Rebind<MakeWide<TN>, decltype(d)> d2;
+  const auto v_2x = PromoteTo(d2, v);
   Vec256<TFromD<DW>> ret;
-  ret.v0 = PromoteTo(dh, LowerHalf(v16));
-  ret.v1 = detail::PromoteUpperTo(dh, v16);
+  ret.v0 = PromoteTo(dh, LowerHalf(v_2x));
+  ret.v1 = detail::PromoteUpperTo(dh, v_2x);
+  return ret;
+}
+
+// 8x promotion: 8-bit to 64-bit
+template <class DW, HWY_IF_V_SIZE_D(DW, 32), HWY_IF_T_SIZE_D(DW, 8),
+          HWY_IF_NOT_FLOAT_D(DW), typename TN, HWY_IF_T_SIZE(TN, 1)>
+HWY_API Vec256<TFromD<DW>> PromoteTo(DW d, Vec32<TN> v) {
+  const Half<decltype(d)> dh;
+  const Repartition<MakeWide<MakeWide<TN>>, decltype(dh)> d4;  // 32-bit lanes
+  const auto v32 = PromoteTo(d4, v);
+  Vec256<TFromD<DW>> ret;
+  ret.v0 = PromoteTo(dh, LowerHalf(v32));
+  ret.v1 = detail::PromoteUpperTo(dh, v32);
   return ret;
 }
 

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4360,26 +4360,23 @@ template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec256<uint32_t> PromoteTo(D /* tag */, Vec128<uint8_t, 8> v) {
   return Vec256<uint32_t>{_mm256_cvtepu8_epi32(v.raw)};
 }
-template <class D, HWY_IF_I16_D(D)>
-HWY_API Vec256<int16_t> PromoteTo(D /* tag */, Vec128<uint8_t> v) {
-  return Vec256<int16_t>{_mm256_cvtepu8_epi16(v.raw)};
-}
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec256<int32_t> PromoteTo(D /* tag */, Vec128<uint8_t, 8> v) {
-  return Vec256<int32_t>{_mm256_cvtepu8_epi32(v.raw)};
-}
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec256<uint32_t> PromoteTo(D /* tag */, Vec128<uint16_t> v) {
   return Vec256<uint32_t>{_mm256_cvtepu16_epi32(v.raw)};
-}
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec256<int32_t> PromoteTo(D /* tag */, Vec128<uint16_t> v) {
-  return Vec256<int32_t>{_mm256_cvtepu16_epi32(v.raw)};
 }
 template <class D, HWY_IF_U64_D(D)>
 HWY_API Vec256<uint64_t> PromoteTo(D /* tag */, Vec128<uint32_t> v) {
   return Vec256<uint64_t>{_mm256_cvtepu32_epi64(v.raw)};
 }
+template <class D, HWY_IF_U64_D(D)>
+HWY_API Vec256<uint64_t> PromoteTo(D /* tag */, Vec64<uint16_t> v) {
+  return Vec256<uint64_t>{_mm256_cvtepu16_epi64(v.raw)};
+}
+template <class D, HWY_IF_U64_D(D)>
+HWY_API Vec256<uint64_t> PromoteTo(D /* tag */, Vec32<uint8_t> v) {
+  return Vec256<uint64_t>{_mm256_cvtepu8_epi64(v.raw)};
+}
+
 
 // Signed: replicate sign bit.
 // Note: these have 3 cycle latency; if inputs are already split across the
@@ -4400,6 +4397,14 @@ HWY_API Vec256<int32_t> PromoteTo(D /* tag */, Vec128<int16_t> v) {
 template <class D, HWY_IF_I64_D(D)>
 HWY_API Vec256<int64_t> PromoteTo(D /* tag */, Vec128<int32_t> v) {
   return Vec256<int64_t>{_mm256_cvtepi32_epi64(v.raw)};
+}
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec256<int64_t> PromoteTo(D /* tag */, Vec64<int16_t> v) {
+  return Vec256<int64_t>{_mm256_cvtepi16_epi64(v.raw)};
+}
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec256<int64_t> PromoteTo(D /* tag */, Vec32<int8_t> v) {
+  return Vec256<int64_t>{_mm256_cvtepi8_epi64(v.raw)};
 }
 
 // ------------------------------ Demotions (full -> part w/ narrow lanes)

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -3417,25 +3417,21 @@ template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec512<uint32_t> PromoteTo(D /* tag */, Vec128<uint8_t> v) {
   return Vec512<uint32_t>{_mm512_cvtepu8_epi32(v.raw)};
 }
-template <class D, HWY_IF_I16_D(D)>
-HWY_API Vec512<int16_t> PromoteTo(D /* tag */, Vec256<uint8_t> v) {
-  return Vec512<int16_t>{_mm512_cvtepu8_epi16(v.raw)};
-}
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec512<int32_t> PromoteTo(D /* tag */, Vec128<uint8_t> v) {
-  return Vec512<int32_t>{_mm512_cvtepu8_epi32(v.raw)};
-}
 template <class D, HWY_IF_U32_D(D)>
 HWY_API Vec512<uint32_t> PromoteTo(D /* tag */, Vec256<uint16_t> v) {
   return Vec512<uint32_t>{_mm512_cvtepu16_epi32(v.raw)};
 }
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec512<int32_t> PromoteTo(D /* tag */, Vec256<uint16_t> v) {
-  return Vec512<int32_t>{_mm512_cvtepu16_epi32(v.raw)};
-}
 template <class D, HWY_IF_U64_D(D)>
 HWY_API Vec512<uint64_t> PromoteTo(D /* tag */, Vec256<uint32_t> v) {
   return Vec512<uint64_t>{_mm512_cvtepu32_epi64(v.raw)};
+}
+template <class D, HWY_IF_U64_D(D)>
+HWY_API Vec512<uint64_t> PromoteTo(D /* tag */, Vec128<uint16_t> v) {
+  return Vec512<uint64_t>{_mm512_cvtepu16_epi64(v.raw)};
+}
+template <class D, HWY_IF_U64_D(D)>
+HWY_API Vec512<uint64_t> PromoteTo(D /* tag */, Vec64<uint8_t> v) {
+  return Vec512<uint64_t>{_mm512_cvtepu8_epi64(v.raw)};
 }
 
 // Signed: replicate sign bit.
@@ -3457,6 +3453,14 @@ HWY_API Vec512<int32_t> PromoteTo(D /* tag */, Vec256<int16_t> v) {
 template <class D, HWY_IF_I64_D(D)>
 HWY_API Vec512<int64_t> PromoteTo(D /* tag */, Vec256<int32_t> v) {
   return Vec512<int64_t>{_mm512_cvtepi32_epi64(v.raw)};
+}
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec512<int64_t> PromoteTo(D /* tag */, Vec128<int16_t> v) {
+  return Vec512<int64_t>{_mm512_cvtepi16_epi64(v.raw)};
+}
+template <class D, HWY_IF_I64_D(D)>
+HWY_API Vec512<int64_t> PromoteTo(D /* tag */, Vec64<int8_t> v) {
+  return Vec512<int64_t>{_mm512_cvtepi8_epi64(v.raw)};
 }
 
 // Float

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -231,6 +231,21 @@ HWY_NOINLINE void TestAllPromoteTo() {
 
   const ForPromoteVectors<TestPromoteTo<int64_t>, 1> to_i64div2;
   to_i64div2(int32_t());
+  to_i64div2(uint32_t());
+
+  const ForPromoteVectors<TestPromoteTo<uint64_t>, 2> to_u64div4;
+  to_u64div4(uint16_t());
+
+  const ForPromoteVectors<TestPromoteTo<int64_t>, 2> to_i64div4;
+  to_i64div4(int16_t());
+  to_i64div4(uint16_t());
+
+  const ForPromoteVectors<TestPromoteTo<uint64_t>, 3> to_u64div8;
+  to_u64div8(uint8_t());
+
+  const ForPromoteVectors<TestPromoteTo<int64_t>, 3> to_i64div8;
+  to_i64div8(int8_t());
+  to_i64div8(uint8_t());
 #endif
 
 #if HWY_HAVE_FLOAT64


### PR DESCRIPTION
U8/U16->U64, U8/U16/U32->I64, and I8/I16->I64 PromoteTo operations were added for all targets to ensure consistency across all targets.

SSE4/AVX2/AVX3/RVV can also do I8->I64, I16->I64, U8->U64, and U16->U64 PromoteTo operations using a single instruction.

U8->U64 PromoteTo was also already implemented on the SVE/SCALAR/EMU128 targets.

Also fixed ForPromoteVectors implementation in hwy/tests/test_util-inl.h.