### PR TITLE
Made enhancements to PPC10 operations

### DIFF
--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -102,14 +102,14 @@
 #else  // Anything older than 7.0 is not recommended for Highway.
 #define HWY_COMPILER_CLANG 600
 #endif  // __has_warning chain
-#define HWY_COMPILER_CLANG_PATCHLEVEL 0
+#define HWY_COMPILER3_CLANG (HWY_COMPILER_CLANG * 100)
 #else   // use normal version
 #define HWY_COMPILER_CLANG (__clang_major__ * 100 + __clang_minor__)
-#define HWY_COMPILER_CLANG_PATCHLEVEL __clang_patchlevel__
+#define HWY_COMPILER3_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #endif
 #else  // Not clang
 #define HWY_COMPILER_CLANG 0
-#define HWY_COMPILER_CLANG_PATCHLEVEL 0
+#define HWY_COMPILER3_CLANG 0
 #endif
 
 #if HWY_COMPILER_GCC && !HWY_COMPILER_CLANG

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -102,11 +102,14 @@
 #else  // Anything older than 7.0 is not recommended for Highway.
 #define HWY_COMPILER_CLANG 600
 #endif  // __has_warning chain
+#define HWY_COMPILER_CLANG_PATCHLEVEL 0
 #else   // use normal version
 #define HWY_COMPILER_CLANG (__clang_major__ * 100 + __clang_minor__)
+#define HWY_COMPILER_CLANG_PATCHLEVEL __clang_patchlevel__
 #endif
 #else  // Not clang
 #define HWY_COMPILER_CLANG 0
+#define HWY_COMPILER_CLANG_PATCHLEVEL 0
 #endif
 
 #if HWY_COMPILER_GCC && !HWY_COMPILER_CLANG

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -103,9 +103,10 @@
 #define HWY_COMPILER_CLANG 600
 #endif  // __has_warning chain
 #define HWY_COMPILER3_CLANG (HWY_COMPILER_CLANG * 100)
-#else   // use normal version
+#else  // use normal version
 #define HWY_COMPILER_CLANG (__clang_major__ * 100 + __clang_minor__)
-#define HWY_COMPILER3_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#define HWY_COMPILER3_CLANG \
+  (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #endif
 #else  // Not clang
 #define HWY_COMPILER_CLANG 0

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -208,12 +208,11 @@
        (HWY_COMPILER_CLANG == 1600 && HWY_COMPILER_CLANG_PATCHLEVEL < 1))) || \
      (HWY_COMPILER_GCC_ACTUAL >= 1200 && HWY_COMPILER_GCC_ACTUAL <= 1203) ||  \
      (HWY_COMPILER_GCC_ACTUAL >= 1300 && HWY_COMPILER_GCC_ACTUAL <= 1301))
-// GCC 12.0.0 through 12.0.3 and GCC 13.0.0 through 13.0.1 have a compiler bug
-// where the vsldoi instruction is incorrectly optimized out (and this causes
-// some of the Highway unit tests to fail on big-endian PPC10). Details about
-// this compiler bug can be found at
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109069, and this bug will be
-// fixed in the upcoming GCC 12.0.4 and 13.0.2 releases.
+// GCC 12.0 through 12.3 and GCC 13.0 through 13.1 have a compiler bug where the
+// vsldoi instruction is incorrectly optimized out (and this causes some of the
+// Highway unit tests to fail on big-endian PPC10). Details about this compiler
+// bug can be found at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109069, and
+// this bug will be fixed in the upcoming GCC 12.4 and 13.2 releases.
 
 // Clang 16.0.0 and earlier (but not Clang 16.0.1 and later) have a compiler
 // bug in the LLVM DAGCombiner that causes a zero-extend followed by an

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -198,9 +198,31 @@
 #define HWY_BROKEN_SVE 0
 #endif
 
-// There are GCC/Clang compiler bugs on big-endian PPC with the -mcpu=power10
-// option if optimizations are enabled
-#if HWY_ARCH_PPC && HWY_IS_BIG_ENDIAN
+#if (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1100)
+// GCC 10 supports the -mcpu=power10 option but does not support the PPC10
+// vector intrinsics
+#define HWY_BROKEN_PPC10 (HWY_PPC10)
+#elif HWY_ARCH_PPC && HWY_IS_BIG_ENDIAN &&                                    \
+    ((HWY_COMPILER_CLANG &&                                                   \
+      (HWY_COMPILER_CLANG < 1600 ||                                           \
+       (HWY_COMPILER_CLANG == 1600 && HWY_COMPILER_CLANG_PATCHLEVEL < 1))) || \
+     (HWY_COMPILER_GCC_ACTUAL >= 1200 && HWY_COMPILER_GCC_ACTUAL <= 1203) ||  \
+     (HWY_COMPILER_GCC_ACTUAL >= 1300 && HWY_COMPILER_GCC_ACTUAL <= 1301))
+// GCC 12.0.0 through 12.0.3 and GCC 13.0.0 through 13.0.1 have a compiler bug
+// where the vsldoi instruction is incorrectly optimized out (and this causes
+// some of the Highway unit tests to fail on big-endian PPC10). Details about
+// this compiler bug can be found at
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109069, and this bug will be
+// fixed in the upcoming GCC 12.0.4 and 13.0.2 releases.
+
+// Clang 16.0.0 and earlier (but not Clang 16.0.1 and later) have a compiler
+// bug in the LLVM DAGCombiner that causes a zero-extend followed by an
+// element insert into a vector, followed by a vector shuffle to be incorrectly
+// optimized on big-endian PPC (and which caused some of the Highway unit tests
+// to fail on big-endian PPC10).
+
+// Details about this bug, which has already been fixed in Clang 16.0.1 and
+// later, can be found at https://github.com/llvm/llvm-project/issues/61315.
 #define HWY_BROKEN_PPC10 (HWY_PPC10)
 #else
 #define HWY_BROKEN_PPC10 0

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -203,16 +203,15 @@
 // vector intrinsics
 #define HWY_BROKEN_PPC10 (HWY_PPC10)
 #elif HWY_ARCH_PPC && HWY_IS_BIG_ENDIAN &&                                    \
-    ((HWY_COMPILER_CLANG &&                                                   \
-      (HWY_COMPILER_CLANG < 1600 ||                                           \
-       (HWY_COMPILER_CLANG == 1600 && HWY_COMPILER_CLANG_PATCHLEVEL < 1))) || \
+    ((HWY_COMPILER3_CLANG && HWY_COMPILER3_CLANG < 160001) ||                 \
      (HWY_COMPILER_GCC_ACTUAL >= 1200 && HWY_COMPILER_GCC_ACTUAL <= 1203) ||  \
      (HWY_COMPILER_GCC_ACTUAL >= 1300 && HWY_COMPILER_GCC_ACTUAL <= 1301))
 // GCC 12.0 through 12.3 and GCC 13.0 through 13.1 have a compiler bug where the
-// vsldoi instruction is incorrectly optimized out (and this causes some of the
-// Highway unit tests to fail on big-endian PPC10). Details about this compiler
-// bug can be found at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109069, and
-// this bug will be fixed in the upcoming GCC 12.4 and 13.2 releases.
+// vsldoi instruction is sometimes incorrectly optimized out (and this causes
+// some of the Highway unit tests to fail on big-endian PPC10). Details about
+// this compiler bug can be found at
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109069, and this bug will be
+// fixed in the upcoming GCC 12.4 and 13.2 releases.
 
 // Clang 16.0.0 and earlier (but not Clang 16.0.1 and later) have a compiler
 // bug in the LLVM DAGCombiner that causes a zero-extend followed by an


### PR DESCRIPTION
Added the HWY_COMPILER_CLANG_PATCHLEVEL macro, which is set to `__clang_patchlevel__` for Clang and to `0` for non-Clang based compilers (or Clang versions detected using `__has_warning` or `__has_attribute` checks).

Updated HWY_BROKEN_PPC10 to mark HWY_PPC10 as non-broken on big-endian PPC with Clang 16.0.1 or later, GCC 11.x, and GCC 12.4 and later (excluding GCC 13.0 and 13.1).

All of the Highway unit tests pass on big-endian HWY_PPC10 when compiled with GCC 11.3 or Clang 16.0.4.

The __builtin_constant_p check for full vectors on PPC8/PPC9/PPC10 has also been refactored out to a new detail::IsConstantRawAltivecVect function (which is used to facilitate GCC/Clang constant folding optimizations for the Xor3, Or3, OrAnd, SumOfLanes, and SumsOf8 operations on PPC8/PPC9/PPC10).

detail::TernaryLogic (which is a wrapper for the PPC10 vec_ternarylogic intrinsic/xxeval instruction) is also now used to implement the Xor3, Or3, OrAnd, int64_t SaturatedAdd, and int64_t SaturatedSub operations on PPC10.

Also re-implemented detail::LoadMaskBits128 on PPC10 using the vec_genbm/vec_genhm/vec_genwm/vec_gendm intrinsics, which convert an mask back to a vector (similar to the _mm_movm_epi8/_mm_movm_epi16/_mm_movm_epi32/_mm_movm_epi64 operations on AVX512VL).