### PR TITLE
Fix GCC compilation error with BaseCase in vqsort-inl.h

### DIFF
--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -758,9 +758,8 @@ HWY_INLINE void Sort129To256(Traits st, T* HWY_RESTRICT keys, size_t num_lanes,
 //
 // See M. Blacher's thesis: https://github.com/mark-blacher/masterthesis
 template <class D, class Traits, typename T>
-HWY_NOINLINE void BaseCase(D d, Traits st, T* HWY_RESTRICT keys,
-                           T* HWY_RESTRICT keys_end, size_t num_lanes,
-                           T* HWY_RESTRICT buf) {
+HWY_NOINLINE void BaseCase(D d, Traits st, T* HWY_RESTRICT keys, T* keys_end,
+                           size_t num_lanes, T* buf) {
   constexpr size_t kLPK = st.LanesPerKey();
   HWY_DASSERT(num_lanes <= Constants::BaseCaseNumLanes<kLPK>(Lanes(d)));
   // Checking kMaxKeys avoids generating unreachable HWY_ASSERT codepaths.


### PR DESCRIPTION
Removed HWY_RESTRICT from the keys_end and buf parameters in vqsort-inl.h to fix a compiler error when vqsort-inl.h is compiled with GCC.