### PR TITLE
WidenMulPairwiseAdd compilation fixes and reformatting

### DIFF
--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -2593,7 +2593,8 @@ HWY_API VFromD<D> WidenMulPairwiseAdd(D df32, VBF16 a, VBF16 b) {
   const VU32 ao = And(BitCast(du32, a), odd);
   const VU32 be = ShiftLeft<16>(BitCast(du32, b));
   const VU32 bo = And(BitCast(du32, b), odd);
-  return Mul(BitCast(df32, ae), BitCast(df32, be)) + Mul(BitCast(df32, ao), BitCast(df32, bo));
+  return Mul(BitCast(df32, ae), BitCast(df32, be)) +
+         Mul(BitCast(df32, ao), BitCast(df32, bo));
 }
 
 template <class D, HWY_IF_I32_D(D), class VI16>

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2597,14 +2597,15 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 df32, V16 a, V16 b) {
   const VU32 ao = And(BitCast(du32, a), odd);
   const VU32 be = ShiftLeft<16>(BitCast(du32, b));
   const VU32 bo = And(BitCast(du32, b), odd);
-  return Mul(BitCast(df32, ae), BitCast(df32, be)) + Mul(BitCast(df32, ao), BitCast(df32, bo));
+  return Mul(BitCast(df32, ae), BitCast(df32, be)) +
+         Mul(BitCast(df32, ao), BitCast(df32, bo));
 }
 
 // Even if N=1, the input is always at least 2 lanes, hence vec_msum is safe.
 template <class D32, HWY_IF_I32_D(D32),
           class V16 = VFromD<RepartitionToNarrow<D32>>>
-HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 /* tag */, V16 a, V16 b) {
-  return VFromD<D32>{a * b};
+HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 d32, V16 a, V16 b) {
+  return VFromD<D32>{vec_msum(a.raw, b.raw, Zero(d32).raw)};
 }
 
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1877,12 +1877,12 @@ HWY_API void StoreTransposedBlocks4(Vec256<T> i, Vec256<T> j, Vec256<T> k,
 
 // ------------------------------ WidenMulPairwiseAdd
 template <class D32, typename T16, typename T32 = TFromD<D32>>
-HWY_API Vec256<T32> WidenMulPairwiseAdd(D32 d32, Vec256<T16> a,
-                                             Vec256<T16> b) {
+HWY_API Vec256<T32> WidenMulPairwiseAdd(D32 d32, Vec256<T16> a, Vec256<T16> b) {
   const Half<decltype(d32)> d32h;
-  a.v0 = WidenMulPairwiseAdd(d32h, a.v0, b.v0);
-  a.v1 = WidenMulPairwiseAdd(d32h, a.v1, b.v1);
-  return a;
+  Vec256<T32> result;
+  result.v0 = WidenMulPairwiseAdd(d32h, a.v0, b.v0);
+  result.v1 = WidenMulPairwiseAdd(d32h, a.v1, b.v1);
+  return result;
 }
 
 // ------------------------------ ReorderWidenMulAccumulate

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -6043,7 +6043,7 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 df32, V16 a, V16 b) {
   const VU32 be = ShiftLeft<16>(BitCast(du32, b));
   const VU32 bo = And(BitCast(du32, b), odd);
   return MulAdd(BitCast(df32, ae), BitCast(df32, be),
-            Mul(BitCast(df32, ao), BitCast(df32, bo)));
+                Mul(BitCast(df32, ao), BitCast(df32, bo)));
 }
 
 // Even if N=1, the input is always at least 2 lanes, hence madd_epi16 is safe.

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4389,7 +4389,7 @@ HWY_INLINE Vec256<uint64_t> MulOdd(const Vec256<uint64_t> a,
 // ------------------------------ WidenMulPairwiseAdd
 template <class D, HWY_IF_SIGNED_D(D)>
 HWY_API Vec256<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec256<int16_t> a,
-                                                  Vec256<int16_t> b) {
+                                            Vec256<int16_t> b) {
   return Vec256<int32_t>{_mm256_madd_epi16(a.raw, b.raw)};
 }
 

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5414,7 +5414,7 @@ HWY_INLINE Vec512<uint64_t> MulOdd(const Vec512<uint64_t> a,
 // ------------------------------ WidenMulPairwiseAdd
 template <class D, HWY_IF_I32_D(D)>
 HWY_API Vec512<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec512<int16_t> a,
-                                                  Vec512<int16_t> b) {
+                                            Vec512<int16_t> b) {
   return Vec512<int32_t>{_mm512_madd_epi16(a.raw, b.raw)};
 }
 


### PR DESCRIPTION
Fixed compilation errors with WidenMulPairwiseAdd on PPC and WASM_EMU256 targets.

Also reformatted WidenMulPairwiseAdd on x86 and EMU128.