### PR TITLE
Added SetBeforeFirst, SetAtOrBeforeFirst, SetOnlyFirst, and SetAtOrAfterFirst mask ops

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -857,21 +857,22 @@ false is zero, true has all bits set:
     these operations. This op is for situations where the inputs are known to be
     mutually exclusive.
 
-*   <code>M **SetOnlyFirst**(M m)</code>: returns mask that has only lane `k`
-    set to true if any lanes are set in `m` and all other lanes set to false,
-    where `k` is the index of the first (i.e. lowest index) `m[i]` that is
-    true or the number of lanes in `m` if none of `m[i]` are true.
+*   <code>M **SetOnlyFirst**(M m)</code>: If none of `m[i]` are true, returns
+    all-false. Otherwise, only lane `k` is true, where `k` is equal to
+    `FindKnownFirstTrue(m)`. In other words, sets to false any lanes with index
+    greater than the first true lane, if it exists.
 
-*   <code>M **SetBeforeFirst**(M m)</code>: returns mask with the first `N`
-    lanes set to true and any remaining lanes set to false, where `N` is equal
-    to the index of the first `m[i]` that is true or the number of lanes in `m`
-    if none of `m[i]` are true.
+*   <code>M **SetBeforeFirst**(M m)</code>: If none of `m[i]` are true, returns
+    all-true. Otherwise, returns mask with the first `k` lanes true and all
+    remaining lanes false, where `k` is equal to `FindKnownFirstTrue(m)`. In
+    other words, if at least one of `m[i]` is true, sets to true any lanes with
+    index less than the first true lane and all remaining lanes to false.
 
-**  <code>M **SetAtOrBeforeFirst**(M m)</code>: equivalent to
+*   <code>M **SetAtOrBeforeFirst**(M m)</code>: equivalent to
     `Or(SetBeforeFirst(m), SetOnlyFirst(m))`, but `SetAtOrBeforeFirst(m)` is
     usually more efficient than `Or(SetBeforeFirst(m), SetOnlyFirst(m))`.
 
-**  <code>M **SetAtOrAfterFirst**(M m)</code>: equivalent to
+*   <code>M **SetAtOrAfterFirst**(M m)</code>: equivalent to
     `Not(SetBeforeFirst(m))`.
 
 #### Compress

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -857,6 +857,23 @@ false is zero, true has all bits set:
     these operations. This op is for situations where the inputs are known to be
     mutually exclusive.
 
+*   <code>M **SetOnlyFirst**(M m)</code>: returns mask that has only lane `k`
+    set to true if any lanes are set in `m` and all other lanes set to false,
+    where `k` is the index of the first (i.e. lowest index) `m[i]` that is
+    true or the number of lanes in `m` if none of `m[i]` are true.
+
+*   <code>M **SetBeforeFirst**(M m)</code>: returns mask with the first `N`
+    lanes set to true and any remaining lanes set to false, where `N` is equal
+    to the index of the first `m[i]` that is true or the number of lanes in `m`
+    if none of `m[i]` are true.
+
+**  <code>M **SetAtOrBeforeFirst**(M m)</code>: equivalent to
+    `Or(SetBeforeFirst(m), SetOnlyFirst(m))`, but `SetAtOrBeforeFirst(m)` is
+    usually more efficient than `Or(SetBeforeFirst(m), SetOnlyFirst(m))`.
+
+**  <code>M **SetAtOrAfterFirst**(M m)</code>: equivalent to
+    `Not(SetBeforeFirst(m))`.
+
 #### Compress
 
 *   <code>V **Compress**(V v, M m)</code>: returns `r` such that `r[n]` is

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -7490,6 +7490,94 @@ HWY_API void StoreInterleaved4(Vec128<T> v0, Vec128<T> v1, Vec128<T> v2,
 
 #undef HWY_IF_STORE_INT
 
+// ------------------------------ Additional mask logical operations
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrAfterFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetAtOrAfterFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const auto vmask = VecFromMask(d, mask);
+  return MaskFromVec(Or(vmask, InterleaveLower(vmask, vmask)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetAtOrAfterFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const auto vmask = VecFromMask(d, mask);
+  const auto neg_vmask =
+      ResizeBitCast(d, Neg(ResizeBitCast(Full64<int64_t>(), vmask)));
+  return MaskFromVec(Or(vmask, neg_vmask));
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetAtOrAfterFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  const Repartition<int64_t, decltype(d)> di64;
+
+  auto vmask = BitCast(di64, VecFromMask(d, mask));
+  vmask = Or(vmask, Neg(vmask));
+
+  // Copy the sign bit of the first int64_t lane to the second int64_t lane
+  const auto vmask2 = BroadcastSignBit(InterleaveLower(Zero(di64), vmask));
+  return MaskFromVec(BitCast(d, Or(vmask, vmask2)));
+}
+
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetBeforeFirst(Mask128<T, N> mask) {
+  return Not(SetAtOrAfterFirst(mask));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetOnlyFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetOnlyFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = BitCast(di, VecFromMask(d, mask));
+  const auto zero = Zero(di);
+  const auto vmask2 = VecFromMask(di, InterleaveLower(zero, vmask) == zero);
+  return MaskFromVec(BitCast(d, And(vmask, vmask2)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetOnlyFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = ResizeBitCast(Full64<int64_t>(), VecFromMask(d, mask));
+  const auto only_first_vmask =
+      BitCast(d, Neg(ResizeBitCast(di, And(vmask, Neg(vmask)))));
+  return MaskFromVec(only_first_vmask);
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetOnlyFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  const RebindToSigned<decltype(d)> di;
+  const Repartition<int64_t, decltype(d)> di64;
+
+  const auto zero = Zero(di64);
+  const auto vmask = BitCast(di64, VecFromMask(d, mask));
+  const auto vmask2 = VecFromMask(di64, InterleaveLower(zero, vmask) == zero);
+  const auto only_first_vmask = Neg(BitCast(di, And(vmask, Neg(vmask))));
+  return MaskFromVec(BitCast(d, And(only_first_vmask, BitCast(di, vmask2))));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrBeforeFirst(Mask128<T, 1> /*mask*/) {
+  const FixedTag<T, 1> d;
+  const RebindToSigned<decltype(d)> di;
+  using TI = MakeSigned<T>;
+
+  return RebindMask(d, MaskFromVec(Set(di, TI(-1))));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 1)>
+HWY_API Mask128<T, N> SetAtOrBeforeFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  return SetBeforeFirst(MaskFromVec(ShiftLeftLanes<1>(VecFromMask(d, mask))));
+}
+
 // ------------------------------ Lt128
 
 template <class D, HWY_IF_V_SIZE_LE_D(D, 16)>

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -920,6 +920,27 @@ HWY_API V IfThenZeroElse(const svbool_t mask, const V no) {
   return IfThenElse(mask, Zero(DFromV<V>()), no);
 }
 
+// ------------------------------ Additional mask logical operations
+HWY_API svbool_t SetBeforeFirst(svbool_t m) {
+  // We don't know the lane type, so assume 8-bit. For larger types, this will
+  // de-canonicalize the predicate, i.e. set bits to 1 even though they do not
+  // correspond to the lowest byte in the lane. Arm says such bits are ignored.
+  return svbrkb_b_z(HWY_SVE_PTRUE(8), m);
+}
+
+HWY_API svbool_t SetAtOrBeforeFirst(svbool_t m) {
+  // We don't know the lane type, so assume 8-bit. For larger types, this will
+  // de-canonicalize the predicate, i.e. set bits to 1 even though they do not
+  // correspond to the lowest byte in the lane. Arm says such bits are ignored.
+  return svbrka_b_z(HWY_SVE_PTRUE(8), m);
+}
+
+HWY_API svbool_t SetOnlyFirst(svbool_t m) { return svbrka_b_z(m, m); }
+
+HWY_API svbool_t SetAtOrAfterFirst(svbool_t m) {
+  return Not(SetBeforeFirst(m));
+}
+
 // ================================================== COMPARE
 
 // mask = f(vector, vector)

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -4224,6 +4224,177 @@ HWY_API size_t CompressBitsStore(VFromD<D> v, const uint8_t* HWY_RESTRICT bits,
 // HWY_NATIVE_LOAD_STORE_INTERLEAVED not set, hence defined in
 // generic_ops-inl.h.
 
+// ------------------------------ Additional mask logical operations
+namespace detail {
+
+#if HWY_IS_LITTLE_ENDIAN
+template <class V>
+HWY_INLINE V Per64BitBlkRevLanesOnBe(V v) {
+  return v;
+}
+template <class V>
+HWY_INLINE V Per128BitBlkRevLanesOnBe(V v) {
+  return v;
+}
+#else
+template <class V, HWY_IF_T_SIZE_V(V, 1)>
+HWY_INLINE V Per64BitBlkRevLanesOnBe(V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse8(d, v);
+}
+template <class V, HWY_IF_T_SIZE_V(V, 2)>
+HWY_INLINE V Per64BitBlkRevLanesOnBe(V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse4(d, v);
+}
+template <class V, HWY_IF_T_SIZE_V(V, 4)>
+HWY_INLINE V Per64BitBlkRevLanesOnBe(V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse2(d, v);
+}
+template <class V, HWY_IF_T_SIZE_V(V, 8)>
+HWY_INLINE V Per64BitBlkRevLanesOnBe(V v) {
+  return v;
+}
+template <class V>
+HWY_INLINE V Per128BitBlkRevLanesOnBe(V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse(d, v);
+}
+#endif
+
+template <class V>
+HWY_INLINE V I128Subtract(V a, V b) {
+#if defined(__SIZEOF_INT128__)
+  using VU128 = __vector unsigned __int128;
+  const V diff_i128{
+      reinterpret_cast<typename detail::Raw128<TFromV<V>>::type>(
+          vec_sub(reinterpret_cast<VU128>(a.raw),
+                  reinterpret_cast<VU128>(b.raw)))};
+#else
+  const DFromV<decltype(a)> d;
+  const Repartition<uint64_t, decltype(d)> du64;
+
+  const auto u64_a = BitCast(du64, a);
+  const auto u64_b = BitCast(du64, b);
+
+  const auto diff_u64 = u64_a - u64_b;
+  const auto borrow_u64 = VecFromMask(du64, u64_a < u64_b);
+
+#if HWY_IS_LITTLE_ENDIAN
+  const auto borrow_u64_shifted = ShiftLeftBytes<8>(du64, borrow_u64);
+#else
+  const auto borrow_u64_shifted = ShiftRightBytes<8>(du64, borrow_u64);
+#endif
+
+  const auto diff_i128 = BitCast(d, diff_u64 + borrow_u64_shifted);
+#endif
+
+  return diff_i128;
+}
+
+}  // namespace detail
+
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrAfterFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetAtOrAfterFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const auto vmask = VecFromMask(d, mask);
+  return MaskFromVec(Or(vmask, InterleaveLower(vmask, vmask)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetAtOrAfterFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const Full64<T> d_full64;
+
+  const auto vmask = VecFromMask(d, mask);
+  const auto vmask_le64 =
+      BitCast(Full64<int64_t>(),
+              detail::Per64BitBlkRevLanesOnBe(ResizeBitCast(d_full64, vmask)));
+  const auto neg_vmask_le64 = Neg(vmask_le64);
+  const auto neg_vmask = ResizeBitCast(
+      d, detail::Per64BitBlkRevLanesOnBe(BitCast(d_full64, neg_vmask_le64)));
+
+  return MaskFromVec(Or(vmask, neg_vmask));
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetAtOrAfterFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  auto vmask = VecFromMask(d, mask);
+
+  const auto vmask_le128 = detail::Per128BitBlkRevLanesOnBe(vmask);
+  const auto neg_vmask_le128 = detail::I128Subtract(Zero(d), vmask_le128);
+  const auto neg_vmask = detail::Per128BitBlkRevLanesOnBe(neg_vmask_le128);
+
+  return MaskFromVec(BitCast(d, Or(vmask, neg_vmask)));
+}
+
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetBeforeFirst(Mask128<T, N> mask) {
+  return Not(SetAtOrAfterFirst(mask));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetOnlyFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetOnlyFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = BitCast(di, VecFromMask(d, mask));
+  const auto zero = Zero(di);
+  const auto vmask2 = VecFromMask(di, InterleaveLower(zero, vmask) == zero);
+  return MaskFromVec(BitCast(d, And(vmask, vmask2)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetOnlyFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const Full64<T> d_full64;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = VecFromMask(d, mask);
+  const auto vmask_le64 =
+      BitCast(Full64<int64_t>(),
+              detail::Per64BitBlkRevLanesOnBe(ResizeBitCast(d_full64, vmask)));
+  const auto neg_vmask_le64 = Neg(vmask_le64);
+  const auto neg_vmask = ResizeBitCast(
+      d, detail::Per64BitBlkRevLanesOnBe(BitCast(d_full64, neg_vmask_le64)));
+
+  const auto first_vmask = BitCast(di, And(vmask, neg_vmask));
+  return MaskFromVec(BitCast(d, Or(first_vmask, Neg(first_vmask))));
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetOnlyFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = VecFromMask(d, mask);
+  const auto vmask_le128 = detail::Per128BitBlkRevLanesOnBe(vmask);
+  const auto neg_vmask_le128 = detail::I128Subtract(Zero(d), vmask_le128);
+  const auto neg_vmask = detail::Per128BitBlkRevLanesOnBe(neg_vmask_le128);
+
+  return MaskFromVec(BitCast(d, Neg(BitCast(di, And(vmask, neg_vmask)))));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrBeforeFirst(Mask128<T, 1> /*mask*/) {
+  const FixedTag<T, 1> d;
+  const RebindToSigned<decltype(d)> di;
+  using TI = MakeSigned<T>;
+
+  return RebindMask(d, MaskFromVec(Set(di, TI(-1))));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 1)>
+HWY_API Mask128<T, N> SetAtOrBeforeFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  return SetBeforeFirst(MaskFromVec(ShiftLeftLanes<1>(VecFromMask(d, mask))));
+}
+
 // ------------------------------ Reductions
 
 namespace detail {

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -2350,6 +2350,20 @@ HWY_API TFromV<V> ExtractLane(const V v, size_t i) {
   return GetLane(detail::SlideDown(v, i));
 }
 
+// ------------------------------ Additional mask logical operations
+
+HWY_RVV_FOREACH_B(HWY_RVV_RETM_ARGM, SetOnlyFirst, sof)
+HWY_RVV_FOREACH_B(HWY_RVV_RETM_ARGM, SetBeforeFirst, sbf)
+HWY_RVV_FOREACH_B(HWY_RVV_RETM_ARGM, SetAtOrBeforeFirst, sif)
+
+#define HWY_RVV_SET_AT_OR_AFTER_FIRST(SEW, SHIFT, MLEN, NAME, OP) \
+  HWY_API HWY_RVV_M(MLEN) SetAtOrAfterFirst(HWY_RVV_M(MLEN) m) {  \
+    return Not(SetBeforeFirst(m));                                \
+  }
+
+HWY_RVV_FOREACH_B(HWY_RVV_SET_AT_OR_AFTER_FIRST, _, _)
+#undef HWY_RVV_SET_AT_OR_AFTER_FIRST
+
 // ------------------------------ InsertLane
 
 template <class V, HWY_IF_NOT_T_SIZE_V(V, 1)>
@@ -2361,10 +2375,6 @@ HWY_API V InsertLane(const V v, size_t i, TFromV<V> t) {
   return IfThenElse(RebindMask(d, is_i), Set(d, t), v);
 }
 
-namespace detail {
-HWY_RVV_FOREACH_B(HWY_RVV_RETM_ARGM, SetOnlyFirst, sof)
-}  // namespace detail
-
 // For 8-bit lanes, Iota0 might overflow.
 template <class V, HWY_IF_T_SIZE_V(V, 1)>
 HWY_API V InsertLane(const V v, size_t i, TFromV<V> t) {
@@ -2372,7 +2382,7 @@ HWY_API V InsertLane(const V v, size_t i, TFromV<V> t) {
   const auto zero = Zero(d);
   const auto one = Set(d, 1);
   const auto ge_i = Eq(detail::SlideUp(zero, one, i), one);
-  const auto is_i = detail::SetOnlyFirst(ge_i);
+  const auto is_i = SetOnlyFirst(ge_i);
   return IfThenElse(RebindMask(d, is_i), Set(d, t), v);
 }
 

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -381,6 +381,26 @@ HWY_API Mask1<T> ExclusiveNeither(const Mask1<T> a, Mask1<T> b) {
   return MaskFromVec(AndNot(VecFromMask(d, a), Not(VecFromMask(d, b))));
 }
 
+template <class T>
+HWY_API Mask1<T> SetAtOrAfterFirst(Mask1<T> mask) {
+  return mask;
+}
+
+template <class T>
+HWY_API Mask1<T> SetBeforeFirst(Mask1<T> mask) {
+  return Not(mask);
+}
+
+template <class T>
+HWY_API Mask1<T> SetOnlyFirst(Mask1<T> mask) {
+  return mask;
+}
+
+template <class T>
+HWY_API Mask1<T> SetAtOrBeforeFirst(Mask1<T> /*mask*/) {
+  return Mask1<T>::FromBool(true);
+}
+
 // ================================================== SHIFTS
 
 // ------------------------------ ShiftLeft/ShiftRight (BroadcastSignBit)

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -8572,6 +8572,126 @@ HWY_API VFromD<D> LoadExpand(MFromD<D> mask, D d,
 // HWY_NATIVE_LOAD_STORE_INTERLEAVED not set, hence defined in
 // generic_ops-inl.h.
 
+// ------------------------------ Additional mask logical operations
+
+#if HWY_TARGET <= HWY_AVX3
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetAtOrAfterFirst(Mask128<T, N> mask) {
+  constexpr uint32_t kActiveElemMask = (uint32_t{1} << N) - 1;
+  return Mask128<T, N>{static_cast<typename Mask128<T, N>::Raw>(
+      (0u - _blsi_u32(mask.raw)) & kActiveElemMask)};
+}
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetBeforeFirst(Mask128<T, N> mask) {
+  constexpr uint32_t kActiveElemMask = (uint32_t{1} << N) - 1;
+  return Mask128<T, N>{static_cast<typename Mask128<T, N>::Raw>(
+      (_blsi_u32(mask.raw) - 1) & kActiveElemMask)};
+}
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetAtOrBeforeFirst(Mask128<T, N> mask) {
+  constexpr uint32_t kActiveElemMask = (uint32_t{1} << N) - 1;
+  return Mask128<T, N>{static_cast<typename Mask128<T, N>::Raw>(
+      _blsmsk_u32(mask.raw) & kActiveElemMask)};
+}
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetOnlyFirst(Mask128<T, N> mask) {
+  return Mask128<T, N>{
+      static_cast<typename Mask128<T, N>::Raw>(_blsi_u32(mask.raw))};
+}
+#else   // AVX2 or below
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrAfterFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetAtOrAfterFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const auto vmask = VecFromMask(d, mask);
+  return MaskFromVec(Or(vmask, InterleaveLower(vmask, vmask)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetAtOrAfterFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const auto vmask = VecFromMask(d, mask);
+  const auto neg_vmask =
+      ResizeBitCast(d, Neg(ResizeBitCast(Full64<int64_t>(), vmask)));
+  return MaskFromVec(Or(vmask, neg_vmask));
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetAtOrAfterFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  const Repartition<int64_t, decltype(d)> di64;
+  const Repartition<float, decltype(d)> df32;
+  const Repartition<int32_t, decltype(d)> di32;
+  using VF = VFromD<decltype(df32)>;
+
+  auto vmask = BitCast(di64, VecFromMask(d, mask));
+  vmask = Or(vmask, Neg(vmask));
+
+  // Copy the sign bit of the first int64_t lane to the second int64_t lane
+  const auto vmask2 = BroadcastSignBit(
+      BitCast(di32, VF{_mm_shuffle_ps(Zero(df32).raw, BitCast(df32, vmask).raw,
+                                      _MM_SHUFFLE(1, 1, 0, 0))}));
+  return MaskFromVec(BitCast(d, Or(vmask, BitCast(di64, vmask2))));
+}
+
+template <class T, size_t N>
+HWY_API Mask128<T, N> SetBeforeFirst(Mask128<T, N> mask) {
+  return Not(SetAtOrAfterFirst(mask));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetOnlyFirst(Mask128<T, 1> mask) {
+  return mask;
+}
+template <class T>
+HWY_API Mask128<T, 2> SetOnlyFirst(Mask128<T, 2> mask) {
+  const FixedTag<T, 2> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = BitCast(di, VecFromMask(d, mask));
+  const auto zero = Zero(di);
+  const auto vmask2 = VecFromMask(di, InterleaveLower(zero, vmask) == zero);
+  return MaskFromVec(BitCast(d, And(vmask, vmask2)));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 2), HWY_IF_V_SIZE_LE(T, N, 8)>
+HWY_API Mask128<T, N> SetOnlyFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  const RebindToSigned<decltype(d)> di;
+
+  const auto vmask = ResizeBitCast(Full64<int64_t>(), VecFromMask(d, mask));
+  const auto only_first_vmask =
+      BitCast(d, Neg(ResizeBitCast(di, And(vmask, Neg(vmask)))));
+  return MaskFromVec(only_first_vmask);
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 8)>
+HWY_API Mask128<T> SetOnlyFirst(Mask128<T> mask) {
+  const Full128<T> d;
+  const RebindToSigned<decltype(d)> di;
+  const Repartition<int64_t, decltype(d)> di64;
+
+  const auto zero = Zero(di64);
+  const auto vmask = BitCast(di64, VecFromMask(d, mask));
+  const auto vmask2 = VecFromMask(di64, InterleaveLower(zero, vmask) == zero);
+  const auto only_first_vmask = Neg(BitCast(di, And(vmask, Neg(vmask))));
+  return MaskFromVec(BitCast(d, And(only_first_vmask, BitCast(di, vmask2))));
+}
+
+template <class T>
+HWY_API Mask128<T, 1> SetAtOrBeforeFirst(Mask128<T, 1> /*mask*/) {
+  const FixedTag<T, 1> d;
+  const RebindToSigned<decltype(d)> di;
+  using TI = MakeSigned<T>;
+
+  return RebindMask(d, MaskFromVec(Set(di, TI(-1))));
+}
+template <class T, size_t N, HWY_IF_LANES_GT(N, 1)>
+HWY_API Mask128<T, N> SetAtOrBeforeFirst(Mask128<T, N> mask) {
+  const Simd<T, N, 0> d;
+  return SetBeforeFirst(MaskFromVec(ShiftLeftLanes<1>(VecFromMask(d, mask))));
+}
+#endif  // HWY_TARGET <= HWY_AVX3
+
 // ------------------------------ Reductions
 
 namespace detail {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -42,6 +42,7 @@ HWY_DIAGNOSTICS_OFF(disable : 4701 4703 6001 26494,
 #include <avxintrin.h>
 // avxintrin defines __m256i and must come before avx2intrin.
 #include <avx2intrin.h>
+#include <bmiintrin.h>
 #include <bmi2intrin.h>  // _pext_u64
 #include <f16cintrin.h>
 #include <fmaintrin.h>

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -42,7 +42,6 @@ HWY_DIAGNOSTICS_OFF(disable : 4701 4703 6001 26494,
 #include <avxintrin.h>
 // avxintrin defines __m256i and must come before avx2intrin.
 #include <avx2intrin.h>
-#include <bmiintrin.h>
 #include <bmi2intrin.h>  // _pext_u64
 #include <f16cintrin.h>
 #include <fmaintrin.h>
@@ -4456,7 +4455,6 @@ HWY_API Vec256<uint64_t> PromoteTo(D /* tag */, Vec32<uint8_t> v) {
   return Vec256<uint64_t>{_mm256_cvtepu8_epi64(v.raw)};
 }
 
-
 // Signed: replicate sign bit.
 // Note: these have 3 cycle latency; if inputs are already split across the
 // 128 bit blocks (in their upper/lower halves), then ZipUpper/lo followed by
@@ -6260,7 +6258,7 @@ HWY_API Mask256<T> SetAtOrAfterFirst(Mask256<T> mask) {
   constexpr uint32_t kActiveElemMask =
       static_cast<uint32_t>((uint64_t{1} << N) - 1);
   return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
-      (0u - _blsi_u32(mask.raw)) & kActiveElemMask)};
+      (0u - detail::AVX3Blsi(mask.raw)) & kActiveElemMask)};
 }
 template <class T>
 HWY_API Mask256<T> SetBeforeFirst(Mask256<T> mask) {
@@ -6268,7 +6266,7 @@ HWY_API Mask256<T> SetBeforeFirst(Mask256<T> mask) {
   constexpr uint32_t kActiveElemMask =
       static_cast<uint32_t>((uint64_t{1} << N) - 1);
   return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
-      (_blsi_u32(mask.raw) - 1) & kActiveElemMask)};
+      (detail::AVX3Blsi(mask.raw) - 1u) & kActiveElemMask)};
 }
 template <class T>
 HWY_API Mask256<T> SetAtOrBeforeFirst(Mask256<T> mask) {
@@ -6276,11 +6274,12 @@ HWY_API Mask256<T> SetAtOrBeforeFirst(Mask256<T> mask) {
   constexpr uint32_t kActiveElemMask =
       static_cast<uint32_t>((uint64_t{1} << N) - 1);
   return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
-      _blsmsk_u32(mask.raw) & kActiveElemMask)};
+      detail::AVX3Blsmsk(mask.raw) & kActiveElemMask)};
 }
 template <class T>
 HWY_API Mask256<T> SetOnlyFirst(Mask256<T> mask) {
-  return Mask256<T>{static_cast<typename Mask256<T>::Raw>(_blsi_u32(mask.raw))};
+  return Mask256<T>{
+      static_cast<typename Mask256<T>::Raw>(detail::AVX3Blsi(mask.raw))};
 }
 #else   // AVX2
 template <class T>

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -6250,6 +6250,106 @@ HWY_API void StoreTransposedBlocks4(Vec256<T> i, Vec256<T> j, Vec256<T> k,
 }
 }  // namespace detail
 
+// ------------------------------ Additional mask logical operations
+
+#if HWY_TARGET <= HWY_AVX3
+template <class T>
+HWY_API Mask256<T> SetAtOrAfterFirst(Mask256<T> mask) {
+  constexpr size_t N = 32 / sizeof(T);
+  constexpr uint32_t kActiveElemMask =
+      static_cast<uint32_t>((uint64_t{1} << N) - 1);
+  return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
+      (0u - _blsi_u32(mask.raw)) & kActiveElemMask)};
+}
+template <class T>
+HWY_API Mask256<T> SetBeforeFirst(Mask256<T> mask) {
+  constexpr size_t N = 32 / sizeof(T);
+  constexpr uint32_t kActiveElemMask =
+      static_cast<uint32_t>((uint64_t{1} << N) - 1);
+  return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
+      (_blsi_u32(mask.raw) - 1) & kActiveElemMask)};
+}
+template <class T>
+HWY_API Mask256<T> SetAtOrBeforeFirst(Mask256<T> mask) {
+  constexpr size_t N = 32 / sizeof(T);
+  constexpr uint32_t kActiveElemMask =
+      static_cast<uint32_t>((uint64_t{1} << N) - 1);
+  return Mask256<T>{static_cast<typename Mask256<T>::Raw>(
+      _blsmsk_u32(mask.raw) & kActiveElemMask)};
+}
+template <class T>
+HWY_API Mask256<T> SetOnlyFirst(Mask256<T> mask) {
+  return Mask256<T>{static_cast<typename Mask256<T>::Raw>(_blsi_u32(mask.raw))};
+}
+#else   // AVX2
+template <class T>
+HWY_API Mask256<T> SetAtOrAfterFirst(Mask256<T> mask) {
+  const Full256<T> d;
+  const Repartition<int64_t, decltype(d)> di64;
+  const Repartition<float, decltype(d)> df32;
+  const Repartition<int32_t, decltype(d)> di32;
+  const Half<decltype(di64)> dh_i64;
+  const Half<decltype(di32)> dh_i32;
+  using VF32 = VFromD<decltype(df32)>;
+
+  auto vmask = BitCast(di64, VecFromMask(d, mask));
+  vmask = Or(vmask, Neg(vmask));
+
+  // Copy the sign bit of the even int64_t lanes to the odd int64_t lanes
+  const auto vmask2 = BitCast(
+      di32, VF32{_mm256_shuffle_ps(Zero(df32).raw, BitCast(df32, vmask).raw,
+                                   _MM_SHUFFLE(1, 1, 0, 0))});
+  vmask = Or(vmask, BitCast(di64, BroadcastSignBit(vmask2)));
+
+  // Copy the sign bit of the lower 128-bit half to the upper 128-bit half
+  const auto vmask3 =
+      BroadcastSignBit(Broadcast<3>(BitCast(dh_i32, LowerHalf(dh_i64, vmask))));
+  vmask = Or(vmask, BitCast(di64, Combine(di32, vmask3, Zero(dh_i32))));
+  return MaskFromVec(BitCast(d, vmask));
+}
+
+template <class T>
+HWY_API Mask256<T> SetBeforeFirst(Mask256<T> mask) {
+  return Not(SetAtOrAfterFirst(mask));
+}
+
+template <class T>
+HWY_API Mask256<T> SetOnlyFirst(Mask256<T> mask) {
+  const Full256<T> d;
+  const RebindToSigned<decltype(d)> di;
+  const Repartition<int64_t, decltype(d)> di64;
+  const Half<decltype(di64)> dh_i64;
+
+  const auto zero = Zero(di64);
+  const auto vmask = BitCast(di64, VecFromMask(d, mask));
+
+  const auto vmask_eq_0 = VecFromMask(di64, vmask == zero);
+  auto vmask2_lo = LowerHalf(dh_i64, vmask_eq_0);
+  auto vmask2_hi = UpperHalf(dh_i64, vmask_eq_0);
+
+  vmask2_lo = And(vmask2_lo, InterleaveLower(vmask2_lo, vmask2_lo));
+  vmask2_hi = And(ConcatLowerUpper(dh_i64, vmask2_hi, vmask2_lo),
+                  InterleaveUpper(dh_i64, vmask2_lo, vmask2_lo));
+  vmask2_lo = InterleaveLower(Set(dh_i64, int64_t{-1}), vmask2_lo);
+
+  const auto vmask2 = Combine(di64, vmask2_hi, vmask2_lo);
+  const auto only_first_vmask = Neg(BitCast(di, And(vmask, Neg(vmask))));
+  return MaskFromVec(BitCast(d, And(only_first_vmask, BitCast(di, vmask2))));
+}
+
+template <class T>
+HWY_API Mask256<T> SetAtOrBeforeFirst(Mask256<T> mask) {
+  const Full256<T> d;
+  constexpr size_t kLanesPerBlock = MaxLanes(d) / 2;
+
+  const auto vmask = VecFromMask(d, mask);
+  const auto vmask_lo = ConcatLowerLower(d, vmask, Zero(d));
+  return SetBeforeFirst(
+      MaskFromVec(CombineShiftRightBytes<(kLanesPerBlock - 1) * sizeof(T)>(
+          d, vmask, vmask_lo)));
+}
+#endif  // HWY_TARGET <= HWY_AVX3
+
 // ------------------------------ Reductions
 
 namespace detail {

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5281,7 +5281,7 @@ HWY_API Mask512<T> SetBeforeFirst(Mask512<T> mask) {
 #if HWY_ARCH_X86_64
   return Mask512<T>{static_cast<__mmask64>(_blsi_u64(mask.raw) - 1)};
 #else
-  return Mask512<T>{static_cast<__mmask64>(~(mask.raw | (-mask.raw)))};
+  return Mask512<T>{static_cast<__mmask64>(~(mask.raw | (0ULL - mask.raw)))};
 #endif
 }
 template <class T, HWY_IF_NOT_T_SIZE(T, 1)>

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5258,56 +5258,25 @@ HWY_API void StoreTransposedBlocks4(const Vec512<T> i, const Vec512<T> j,
 
 // ------------------------------ Additional mask logical operations
 
-template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+template <class T>
 HWY_API Mask512<T> SetAtOrAfterFirst(Mask512<T> mask) {
   return Mask512<T>{
-      static_cast<typename Mask512<T>::Raw>(0u - _blsi_u32(mask.raw))};
+      static_cast<typename Mask512<T>::Raw>(0u - detail::AVX3Blsi(mask.raw))};
 }
-template <class T, HWY_IF_T_SIZE(T, 1)>
-HWY_API Mask512<T> SetAtOrAfterFirst(Mask512<T> mask) {
-#if HWY_ARCH_X86_64
-  return Mask512<T>{static_cast<__mmask64>(0ULL - _blsi_u64(mask.raw))};
-#else
-  return Mask512<T>{static_cast<__mmask64>(mask.raw | (0ULL - mask.raw))};
-#endif
-}
-template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+template <class T>
 HWY_API Mask512<T> SetBeforeFirst(Mask512<T> mask) {
   return Mask512<T>{
-      static_cast<typename Mask512<T>::Raw>(_blsi_u32(mask.raw) - 1)};
+      static_cast<typename Mask512<T>::Raw>(detail::AVX3Blsi(mask.raw) - 1u)};
 }
-template <class T, HWY_IF_T_SIZE(T, 1)>
-HWY_API Mask512<T> SetBeforeFirst(Mask512<T> mask) {
-#if HWY_ARCH_X86_64
-  return Mask512<T>{static_cast<__mmask64>(_blsi_u64(mask.raw) - 1)};
-#else
-  return Mask512<T>{static_cast<__mmask64>(~(mask.raw | (0ULL - mask.raw)))};
-#endif
-}
-template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+template <class T>
 HWY_API Mask512<T> SetAtOrBeforeFirst(Mask512<T> mask) {
   return Mask512<T>{
-      static_cast<typename Mask512<T>::Raw>(_blsmsk_u32(mask.raw))};
+      static_cast<typename Mask512<T>::Raw>(detail::AVX3Blsmsk(mask.raw))};
 }
-template <class T, HWY_IF_T_SIZE(T, 1)>
-HWY_API Mask512<T> SetAtOrBeforeFirst(Mask512<T> mask) {
-#if HWY_ARCH_X86_64
-  return Mask512<T>{static_cast<__mmask64>(_blsmsk_u64(mask.raw))};
-#else
-  return Mask512<T>{static_cast<__mmask64>(mask.raw ^ (mask.raw - 1))};
-#endif
-}
-template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+template <class T>
 HWY_API Mask512<T> SetOnlyFirst(Mask512<T> mask) {
-  return Mask512<T>{static_cast<typename Mask512<T>::Raw>(_blsi_u32(mask.raw))};
-}
-template <class T, HWY_IF_T_SIZE(T, 1)>
-HWY_API Mask512<T> SetOnlyFirst(Mask512<T> mask) {
-#if HWY_ARCH_X86_64
-  return Mask512<T>{static_cast<__mmask64>(_blsi_u64(mask.raw))};
-#else
-  return Mask512<T>{static_cast<__mmask64>(mask.raw & (0ULL - mask.raw))};
-#endif
+  return Mask512<T>{
+      static_cast<typename Mask512<T>::Raw>(detail::AVX3Blsi(mask.raw))};
 }
 
 // ------------------------------ Shl (LoadDup128)

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5256,6 +5256,60 @@ HWY_API void StoreTransposedBlocks4(const Vec512<T> i, const Vec512<T> j,
 
 }  // namespace detail
 
+// ------------------------------ Additional mask logical operations
+
+template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetAtOrAfterFirst(Mask512<T> mask) {
+  return Mask512<T>{
+      static_cast<typename Mask512<T>::Raw>(0u - _blsi_u32(mask.raw))};
+}
+template <class T, HWY_IF_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetAtOrAfterFirst(Mask512<T> mask) {
+#if HWY_ARCH_X86_64
+  return Mask512<T>{static_cast<__mmask64>(0ULL - _blsi_u64(mask.raw))};
+#else
+  return Mask512<T>{static_cast<__mmask64>(mask.raw | (0ULL - mask.raw))};
+#endif
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetBeforeFirst(Mask512<T> mask) {
+  return Mask512<T>{
+      static_cast<typename Mask512<T>::Raw>(_blsi_u32(mask.raw) - 1)};
+}
+template <class T, HWY_IF_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetBeforeFirst(Mask512<T> mask) {
+#if HWY_ARCH_X86_64
+  return Mask512<T>{static_cast<__mmask64>(_blsi_u64(mask.raw) - 1)};
+#else
+  return Mask512<T>{static_cast<__mmask64>(~(mask.raw | (-mask.raw)))};
+#endif
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetAtOrBeforeFirst(Mask512<T> mask) {
+  return Mask512<T>{
+      static_cast<typename Mask512<T>::Raw>(_blsmsk_u32(mask.raw))};
+}
+template <class T, HWY_IF_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetAtOrBeforeFirst(Mask512<T> mask) {
+#if HWY_ARCH_X86_64
+  return Mask512<T>{static_cast<__mmask64>(_blsmsk_u64(mask.raw))};
+#else
+  return Mask512<T>{static_cast<__mmask64>(mask.raw ^ (mask.raw - 1))};
+#endif
+}
+template <class T, HWY_IF_NOT_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetOnlyFirst(Mask512<T> mask) {
+  return Mask512<T>{static_cast<typename Mask512<T>::Raw>(_blsi_u32(mask.raw))};
+}
+template <class T, HWY_IF_T_SIZE(T, 1)>
+HWY_API Mask512<T> SetOnlyFirst(Mask512<T> mask) {
+#if HWY_ARCH_X86_64
+  return Mask512<T>{static_cast<__mmask64>(_blsi_u64(mask.raw))};
+#else
+  return Mask512<T>{static_cast<__mmask64>(mask.raw & (0ULL - mask.raw))};
+#endif
+}
+
 // ------------------------------ Shl (LoadDup128)
 
 HWY_API Vec512<uint16_t> operator<<(Vec512<uint16_t> v, Vec512<uint16_t> bits) {


### PR DESCRIPTION
The SetBeforeFirst, SetAtOrBeforeFirst, SetOnlyFirst, and SetAtOrAfterFirst mask operations were implemented as:
- `SetOnlyFirst(m)` is more efficient than `RebindMask(d, Eq(Iota(du, 0), static_cast<TU>(FindFirstTrue(d, m))))` on some targets
- `SetBeforeFirst(m)` is more efficient than `FirstN(d, HWY_MIN(static_cast<size_t>(FindFirstTrue(d, m)), MaxLanes(d)))` on some targets
- `SetAtOrBeforeFirst(m)` is usually more efficient than `Or(SetBeforeFirst(m), SetOnlyFirst(m))`
- RVV has instructions for the SetBeforeFirst, SetAtOrBeforeFirst, and SetOnlyFirst operations
- The implementations of SetBeforeFirst, SetAtOrBeforeFirst, SetOnlyFirst, and SetAtOrAfterFirst in hwy/ops/rvv-inl.h can correctly deal with masks that have more than 128 lanes
- SVE can efficiently carry out the SetBeforeFirst, SetAtOrBeforeFirst, and SetOnlyFirst operations using the svbrka_b_z and svbrkb_b_z intrinsics
- SVE can carry out the SetOnlyFirst operation using a single BRKA instruction
- The SetBeforeFirst, SetAtOrBeforeFirst, SetOnlyFirst, and SetAtOrAfterFirst operations can be efficiently implemented on AVX3 using the BMI1 _blsi_u32, _blsi_u64, _blsmsk_i32, and _blsmsk_i64 intrinsics
- PPC8/PPC9/PPC10 has a psubuqm instruction that can do a 128-bit negation, which allows SetBeforeFirst, SetAtOrBeforeFirst, SetOnlyFirst, and SetAtOrAfterFirst to be more efficiently implemented for 128-bit masks on PPC8/PPC9/PPC10