### PR TITLE
Fixes to WASM/X86 Shl/Shr and Shl/Shr unit tests

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -629,11 +629,11 @@ Shift all lanes by the same (not necessarily compile-time constant) amount:
 
 Per-lane variable shifts (slow if SSSE3/SSE4, or 16-bit, or Shr i64 on AVX2):
 
-*   `V`: `{u}, {i}{16,32,64}` \
+*   `V`: `{u,i}` \
     <code>V **operator<<**(V a, V b)</code> returns `a[i] << b[i]`. Currently
     unavailable on SVE/RVV; use the equivalent `Shl` instead.
 
-*   `V`: `{u}, {i}{16,32,64}` \
+*   `V`: `{u,i}` \
     <code>V **operator>>**(V a, V b)</code> returns `a[i] >> b[i]`. Currently
     unavailable on SVE/RVV; use the equivalent `Shr` instead.
 

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -667,7 +667,7 @@ HWY_API Mask256<T> ExclusiveNeither(const Mask256<T> a, Mask256<T> b) {
 }
 
 // ------------------------------ Shl (BroadcastSignBit, IfThenElse)
-template <typename T>
+template <typename T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
 HWY_API Vec256<T> operator<<(Vec256<T> v, const Vec256<T> bits) {
   v.v0 = operator<<(v.v0, bits.v0);
   v.v1 = operator<<(v.v1, bits.v1);
@@ -675,7 +675,7 @@ HWY_API Vec256<T> operator<<(Vec256<T> v, const Vec256<T> bits) {
 }
 
 // ------------------------------ Shr (BroadcastSignBit, IfThenElse)
-template <typename T>
+template <typename T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
 HWY_API Vec256<T> operator>>(Vec256<T> v, const Vec256<T> bits) {
   v.v0 = operator>>(v.v0, bits.v0);
   v.v1 = operator>>(v.v1, bits.v1);

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -5716,11 +5716,17 @@ HWY_API Vec128<T, N> SwapAdjacentBlocks(Vec128<T, N> v) {
 // to LLVM-MCA) than scalar or testing bits: https://gcc.godbolt.org/z/9G7Y9v.
 
 namespace detail {
-#if HWY_TARGET > HWY_AVX3  // Unused for AVX3 - we use sllv directly
-
+#if HWY_TARGET == HWY_AVX2  // Unused for AVX3 - we use sllv directly
+template <class V>
+HWY_API V AVX2ShlU16Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint32_t, decltype(d)> du32;
+  return TruncateTo(d, PromoteTo(du32, v) << PromoteTo(du32, bits));
+}
+#elif HWY_TARGET > HWY_AVX2
 // Returns 2^v for use as per-lane multipliers to emulate 16-bit shifts.
-template <typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
-HWY_INLINE Vec128<MakeUnsigned<T>, N> Pow2(const Vec128<T, N> v) {
+template <typename T, HWY_IF_T_SIZE(T, 2)>
+HWY_INLINE Vec128<MakeUnsigned<T>> Pow2(const Vec128<T> v) {
   const DFromV<decltype(v)> d;
   const RebindToUnsigned<decltype(d)> du;
   const RepartitionToWide<decltype(d)> dw;
@@ -5742,6 +5748,33 @@ HWY_INLINE Vec128<MakeUnsigned<T>, N> Pow2(const Vec128<T, N> v) {
 #endif
 }
 
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 2), HWY_IF_LANES_LE(N, 4)>
+HWY_INLINE Vec128<MakeUnsigned<T>, N> Pow2(const Vec128<T, N> v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const Twice<decltype(du)> dt_u;
+  const RepartitionToWide<decltype(dt_u)> dt_w;
+  const RebindToFloat<decltype(dt_w)> dt_f;
+  // Move into exponent (this u16 will become the upper half of an f32)
+  const auto exp = ShiftLeft<23 - 16>(v);
+  const auto upper = exp + Set(d, 0x3F80);  // upper half of 1.0f
+  // Insert 0 into lower halves for reinterpreting as binary32.
+  const auto f0 = ZipLower(dt_w, Zero(dt_u), ResizeBitCast(dt_u, upper));
+  // See cvtps comment below.
+  const VFromD<decltype(dt_w)> bits0{_mm_cvtps_epi32(BitCast(dt_f, f0).raw)};
+#if HWY_TARGET <= HWY_SSE4
+  return VFromD<decltype(du)>{_mm_packus_epi32(bits0.raw, bits0.raw)};
+#elif HWY_TARGET == HWY_SSSE3
+  alignas(16)
+      const uint16_t kCompactEvenU16[8] = {0x0100, 0x0504, 0x0908, 0x0D0C};
+  return TableLookupBytes(bits0, Load(du, kCompactEvenU16));
+#else
+  const RebindToSigned<decltype(dt_w)> dt_i32;
+  const auto bits0_i32 = ShiftRight<16>(BitCast(dt_i32, ShiftLeft<16>(bits0)));
+  return VFromD<decltype(du)>{_mm_packs_epi32(bits0_i32.raw, bits0_i32.raw)};
+#endif
+}
+
 // Same, for 32-bit shifts.
 template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_INLINE Vec128<MakeUnsigned<T>, N> Pow2(const Vec128<T, N> v) {
@@ -5753,21 +5786,62 @@ HWY_INLINE Vec128<MakeUnsigned<T>, N> Pow2(const Vec128<T, N> v) {
   return Vec128<MakeUnsigned<T>, N>{_mm_cvtps_epi32(_mm_castsi128_ps(f.raw))};
 }
 
-#endif  // HWY_TARGET > HWY_AVX3
+#endif  // HWY_TARGET > HWY_AVX2
 
 template <size_t N>
 HWY_API Vec128<uint16_t, N> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint16_t, N> v,
                                 Vec128<uint16_t, N> bits) {
 #if HWY_TARGET <= HWY_AVX3
   return Vec128<uint16_t, N>{_mm_sllv_epi16(v.raw, bits.raw)};
+#elif HWY_TARGET == HWY_AVX2
+  return AVX2ShlU16Vec128(v, bits);
 #else
   return v * Pow2(bits);
 #endif
 }
-HWY_API Vec128<uint16_t, 1> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint16_t, 1> v,
-                                Vec128<uint16_t, 1> bits) {
-  return Vec128<uint16_t, 1>{_mm_sll_epi16(v.raw, bits.raw)};
+
+#if HWY_TARGET > HWY_AVX3
+HWY_API Vec16<uint16_t> Shl(hwy::UnsignedTag /*tag*/, Vec16<uint16_t> v,
+                            Vec16<uint16_t> bits) {
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<uint16_t> bits16{_mm_cvtepu16_epi64(bits.raw)};
+#else
+  const auto bits16 = And(bits, Vec16<uint16_t>{_mm_set_epi64x(0, 0xFFFF)});
+#endif
+  return Vec16<uint16_t>{_mm_sll_epi16(v.raw, bits16.raw)};
 }
+#endif
+
+#if HWY_TARGET <= HWY_AVX3
+template <class V>
+HWY_INLINE V AVX2ShlU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint16_t, decltype(d)> du16;
+  return TruncateTo(d, PromoteTo(du16, v) << PromoteTo(du16, bits));
+}
+#elif HWY_TARGET <= HWY_AVX2
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE V AVX2ShlU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint32_t, decltype(d)> du32;
+  return TruncateTo(d, PromoteTo(du32, v) << PromoteTo(du32, bits));
+}
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE V AVX2ShlU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  const Rebind<uint16_t, decltype(d)> du16;
+  const Rebind<uint32_t, decltype(dh)> dh_u32;
+
+  const auto lo_shl_result = PromoteTo(dh_u32, LowerHalf(dh, v))
+                             << PromoteTo(dh_u32, LowerHalf(dh, bits));
+  const auto hi_shl_result = PromoteTo(dh_u32, UpperHalf(dh, v))
+                             << PromoteTo(dh_u32, UpperHalf(dh, bits));
+  const auto u16_shl_result = ConcatEven(du16, BitCast(du16, hi_shl_result),
+                                         BitCast(du16, lo_shl_result));
+  return TruncateTo(dh, u16_shl_result);
+}
+#endif
 
 // 8-bit: may use the Shl overload for uint16_t.
 template <size_t N>
@@ -5782,26 +5856,35 @@ HWY_API Vec128<uint8_t, N> Shl(hwy::UnsignedTag tag, Vec128<uint8_t, N> v,
   // kShl[i] = 1 << i
   alignas(16) static constexpr uint8_t kShl[16] = {1,    2,    4,    8,   0x10,
                                                    0x20, 0x40, 0x80, 0x00};
-  v = And(v, TableLookupBytes(Load(d, kMasks), bits));
-  const VFromD<decltype(d)> mul = TableLookupBytes(Load(d, kShl), bits);
+  v = And(v, TableLookupBytes(Load(Full64<uint8_t>(), kMasks), bits));
+  const VFromD<decltype(d)> mul =
+      TableLookupBytes(Load(Full64<uint8_t>(), kShl), bits);
   return VFromD<decltype(d)>{_mm_gf2p8mul_epi8(v.raw, mul.raw)};
+#elif HWY_TARGET <= HWY_AVX2
+  (void)tag;
+  (void)d;
+  return AVX2ShlU8Vec128(v, bits);
 #else
   const Repartition<uint16_t, decltype(d)> dw;
   using VW = VFromD<decltype(dw)>;
-  const VW mask = Set(dw, 0x00FF);
+  const VW even_mask = Set(dw, 0x00FF);
+  const VW odd_mask = Set(dw, 0xFF00);
   const VW vw = BitCast(dw, v);
   const VW bits16 = BitCast(dw, bits);
-  const VW evens = Shl(tag, And(vw, mask), And(bits16, mask));
-  // Shift odd lanes in-place
-  const VW odds = Shl(tag, vw, ShiftRight<8>(bits16));
-  return BitCast(d, IfVecThenElse(Set(dw, 0xFF00), odds, evens));
+  // Shift even lanes in-place
+  const VW evens = Shl(tag, vw, And(bits16, even_mask));
+  const VW odds = Shl(tag, And(vw, odd_mask), ShiftRight<8>(bits16));
+  return BitCast(d, IfVecThenElse(odd_mask, odds, evens));
 #endif
 }
 HWY_API Vec128<uint8_t, 1> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint8_t, 1> v,
                                Vec128<uint8_t, 1> bits) {
-  const Full16<uint16_t> d16;
-  const Vec16<uint16_t> bits16{bits.raw};
-  const Vec16<uint16_t> bits8 = And(bits16, Set(d16, 0xFF));
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<uint16_t> bits8{_mm_cvtepu8_epi64(bits.raw)};
+#else
+  const Vec16<uint16_t> bits8 =
+      And(Vec16<uint16_t>{bits.raw}, Vec16<uint16_t>{_mm_set_epi64x(0, 0xFF)});
+#endif
   return Vec128<uint8_t, 1>{_mm_sll_epi16(v.raw, bits8.raw)};
 }
 
@@ -5814,10 +5897,19 @@ HWY_API Vec128<uint32_t, N> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint32_t, N> v,
   return Vec128<uint32_t, N>{_mm_sllv_epi32(v.raw, bits.raw)};
 #endif
 }
-HWY_API Vec128<uint32_t, 1> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint32_t, 1> v,
-                                const Vec128<uint32_t, 1> bits) {
-  return Vec128<uint32_t, 1>{_mm_sll_epi32(v.raw, bits.raw)};
+
+#if HWY_TARGET >= HWY_SSE4
+HWY_API Vec32<uint32_t> Shl(hwy::UnsignedTag /*tag*/, Vec32<uint32_t> v,
+                            const Vec32<uint32_t> bits) {
+#if HWY_TARGET == HWY_SSE4
+  const Vec32<uint32_t> bits32{_mm_cvtepu32_epi64(bits.raw)};
+#else
+  const auto bits32 =
+      Combine(Full64<uint32_t>(), Zero(Full32<uint32_t>()), bits);
+#endif
+  return Vec32<uint32_t>{_mm_sll_epi32(v.raw, bits32.raw)};
 }
+#endif
 
 HWY_API Vec128<uint64_t> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint64_t> v,
                              Vec128<uint64_t> bits) {
@@ -5856,16 +5948,71 @@ HWY_API Vec128<T, N> operator<<(Vec128<T, N> v, Vec128<T, N> bits) {
 
 // ------------------------------ Shr (mul, mask, BroadcastSignBit)
 
-// Use AVX2+ variable shifts except for SSSE3/SSE4 or 16-bit. There, we use
+// Use AVX2+ variable shifts except for SSSE3/SSE4. There, we use
 // widening multiplication by powers of two obtained by loading float exponents,
 // followed by a constant right-shift. This is still faster than a scalar or
 // bit-test approach: https://gcc.godbolt.org/z/9G7Y9v.
+
+#if HWY_TARGET <= HWY_AVX2
+namespace detail {
+
+#if HWY_TARGET <= HWY_AVX3
+template <class V>
+HWY_INLINE V AVX2ShrU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint16_t, decltype(d)> du16;
+  const RebindToSigned<decltype(du16)> di16;
+  return DemoteTo(d,
+                  BitCast(di16, PromoteTo(du16, v) >> PromoteTo(du16, bits)));
+}
+#else   // AVX2
+template <class V>
+HWY_INLINE V AVX2ShrU16Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint32_t, decltype(d)> du32;
+  const RebindToSigned<decltype(du32)> di32;
+  return DemoteTo(d,
+                  BitCast(di32, PromoteTo(du32, v) >> PromoteTo(du32, bits)));
+}
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE V AVX2ShrU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<uint32_t, decltype(d)> du32;
+  const RebindToSigned<decltype(du32)> di32;
+  return DemoteTo(d,
+                  BitCast(di32, PromoteTo(du32, v) >> PromoteTo(du32, bits)));
+}
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE V AVX2ShrU8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  const Rebind<int16_t, decltype(d)> di16;
+  const Rebind<uint16_t, decltype(d)> du16;
+  const Rebind<int32_t, decltype(dh)> dh_i32;
+  const Rebind<uint32_t, decltype(dh)> dh_u32;
+
+  const auto lo_shr_result =
+      BitCast(dh_i32, PromoteTo(dh_u32, LowerHalf(dh, v)) >>
+                          PromoteTo(dh_u32, LowerHalf(dh, bits)));
+  const auto hi_shr_result =
+      BitCast(dh_i32, PromoteTo(dh_u32, UpperHalf(dh, v)) >>
+                          PromoteTo(dh_u32, UpperHalf(dh, bits)));
+  const auto i16_shr_result =
+      BitCast(di16, OrderedDemote2To(du16, lo_shr_result, hi_shr_result));
+  return DemoteTo(d, i16_shr_result);
+}
+#endif  // HWY_TARGET <= HWY_AVX3
+
+}  // namespace detail
+#endif  // HWY_TARGET <= HWY_AVX2
 
 template <size_t N>
 HWY_API Vec128<uint16_t, N> operator>>(Vec128<uint16_t, N> in,
                                        const Vec128<uint16_t, N> bits) {
 #if HWY_TARGET <= HWY_AVX3
   return Vec128<uint16_t, N>{_mm_srlv_epi16(in.raw, bits.raw)};
+#elif HWY_TARGET <= HWY_AVX2
+  return detail::AVX2ShrU16Vec128(in, bits);
 #else
   const DFromV<decltype(in)> d;
   // For bits=0, we cannot mul by 2^16, so fix the result later.
@@ -5874,15 +6021,26 @@ HWY_API Vec128<uint16_t, N> operator>>(Vec128<uint16_t, N> in,
   return IfThenElse(bits == Zero(d), in, out);
 #endif
 }
-HWY_API Vec128<uint16_t, 1> operator>>(const Vec128<uint16_t, 1> in,
-                                       const Vec128<uint16_t, 1> bits) {
-  return Vec128<uint16_t, 1>{_mm_srl_epi16(in.raw, bits.raw)};
+
+#if HWY_TARGET > HWY_AVX3
+HWY_API Vec16<uint16_t> operator>>(const Vec16<uint16_t> in,
+                                   const Vec16<uint16_t> bits) {
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<uint16_t> bits16{_mm_cvtepu16_epi64(bits.raw)};
+#else
+  const auto bits16 = And(bits, Vec16<uint16_t>{_mm_set_epi64x(0, 0xFFFF)});
+#endif
+  return Vec16<uint16_t>{_mm_srl_epi16(in.raw, bits16.raw)};
 }
+#endif
 
 // 8-bit uses 16-bit shifts.
 template <size_t N>
 HWY_API Vec128<uint8_t, N> operator>>(Vec128<uint8_t, N> in,
                                       const Vec128<uint8_t, N> bits) {
+#if HWY_TARGET <= HWY_AVX2
+  return detail::AVX2ShrU8Vec128(in, bits);
+#else
   const DFromV<decltype(in)> d;
   const Repartition<uint16_t, decltype(d)> dw;
   using VW = VFromD<decltype(dw)>;
@@ -5893,13 +6051,19 @@ HWY_API Vec128<uint8_t, N> operator>>(Vec128<uint8_t, N> in,
   // Shift odd lanes in-place
   const VW odds = vw >> ShiftRight<8>(bits16);
   return OddEven(BitCast(d, odds), BitCast(d, evens));
+#endif
 }
 HWY_API Vec128<uint8_t, 1> operator>>(const Vec128<uint8_t, 1> in,
                                       const Vec128<uint8_t, 1> bits) {
-  const Full16<uint16_t> d16;
-  const Vec16<uint16_t> bits16{bits.raw};
-  const Vec16<uint16_t> bits8 = And(bits16, Set(d16, 0xFF));
-  return Vec128<uint8_t, 1>{_mm_srl_epi16(in.raw, bits8.raw)};
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<uint16_t> in8{_mm_cvtepu8_epi16(in.raw)};
+  const Vec16<uint16_t> bits8{_mm_cvtepu8_epi64(bits.raw)};
+#else
+  const Vec16<uint16_t> mask{_mm_set_epi64x(0, 0xFF)};
+  const Vec16<uint16_t> in8 = And(Vec16<uint16_t>{in.raw}, mask);
+  const Vec16<uint16_t> bits8 = And(Vec16<uint16_t>{bits.raw}, mask);
+#endif
+  return Vec128<uint8_t, 1>{_mm_srl_epi16(in8.raw, bits8.raw)};
 }
 
 template <size_t N>
@@ -5924,10 +6088,19 @@ HWY_API Vec128<uint32_t, N> operator>>(const Vec128<uint32_t, N> in,
   return Vec128<uint32_t, N>{_mm_srlv_epi32(in.raw, bits.raw)};
 #endif
 }
+
+#if HWY_TARGET >= HWY_SSE4
 HWY_API Vec128<uint32_t, 1> operator>>(const Vec128<uint32_t, 1> in,
                                        const Vec128<uint32_t, 1> bits) {
-  return Vec128<uint32_t, 1>{_mm_srl_epi32(in.raw, bits.raw)};
+#if HWY_TARGET == HWY_SSE4
+  const Vec32<uint32_t> bits32{_mm_cvtepu32_epi64(bits.raw)};
+#else
+  const auto bits32 =
+      Combine(Full64<uint32_t>(), Zero(Full32<uint32_t>()), bits);
+#endif
+  return Vec128<uint32_t, 1>{_mm_srl_epi32(in.raw, bits32.raw)};
 }
+#endif
 
 HWY_API Vec128<uint64_t> operator>>(const Vec128<uint64_t> v,
                                     const Vec128<uint64_t> bits) {
@@ -5947,9 +6120,46 @@ HWY_API Vec64<uint64_t> operator>>(const Vec64<uint64_t> v,
   return Vec64<uint64_t>{_mm_srl_epi64(v.raw, bits.raw)};
 }
 
-#if HWY_TARGET > HWY_AVX3  // AVX2 or older
 namespace detail {
 
+#if HWY_TARGET <= HWY_AVX3
+template <class V>
+HWY_INLINE V AVX2ShrI8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<int16_t, decltype(d)> di16;
+  return DemoteTo(d, PromoteTo(di16, v) >> PromoteTo(di16, bits));
+}
+#elif HWY_TARGET <= HWY_AVX2  // AVX2
+template <class V>
+HWY_INLINE V AVX2ShrI16Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<int32_t, decltype(d)> di32;
+  return DemoteTo(d, PromoteTo(di32, v) >> PromoteTo(di32, bits));
+}
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE V AVX2ShrI8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Rebind<int32_t, decltype(d)> di32;
+  return DemoteTo(d, PromoteTo(di32, v) >> PromoteTo(di32, bits));
+}
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE V AVX2ShrI8Vec128(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  const Rebind<int16_t, decltype(d)> di16;
+  const Rebind<int32_t, decltype(dh)> dh_i32;
+
+  const auto lo_shr_result = PromoteTo(dh_i32, LowerHalf(dh, v)) >>
+                             PromoteTo(dh_i32, LowerHalf(dh, bits));
+  const auto hi_shr_result = PromoteTo(dh_i32, UpperHalf(dh, v)) >>
+                             PromoteTo(dh_i32, UpperHalf(dh, bits));
+  const auto i16_shr_result =
+      OrderedDemote2To(di16, lo_shr_result, hi_shr_result);
+  return DemoteTo(d, i16_shr_result);
+}
+#endif
+
+#if HWY_TARGET > HWY_AVX3
 // Also used in x86_256-inl.h.
 template <class DI, class V>
 HWY_INLINE V SignedShr(const DI di, const V v, const V count_i) {
@@ -5961,23 +6171,59 @@ HWY_INLINE V SignedShr(const DI di, const V v, const V count_i) {
   const auto abs = BitCast(du, v ^ sign);  // off by one, but fixed below
   return BitCast(di, abs >> count) ^ sign;
 }
+#endif
 
 }  // namespace detail
-#endif  // HWY_TARGET > HWY_AVX3
 
 template <size_t N>
 HWY_API Vec128<int16_t, N> operator>>(Vec128<int16_t, N> v,
                                       Vec128<int16_t, N> bits) {
 #if HWY_TARGET <= HWY_AVX3
   return Vec128<int16_t, N>{_mm_srav_epi16(v.raw, bits.raw)};
+#elif HWY_TARGET <= HWY_AVX2
+  return detail::AVX2ShrI16Vec128(v, bits);
 #else
   const DFromV<decltype(v)> d;
   return detail::SignedShr(d, v, bits);
 #endif
 }
-HWY_API Vec128<int16_t, 1> operator>>(Vec128<int16_t, 1> v,
-                                      Vec128<int16_t, 1> bits) {
-  return Vec128<int16_t, 1>{_mm_sra_epi16(v.raw, bits.raw)};
+
+#if HWY_TARGET > HWY_AVX3
+HWY_API Vec16<int16_t> operator>>(Vec16<int16_t> v, Vec16<int16_t> bits) {
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<int16_t> bits16{_mm_cvtepu16_epi64(bits.raw)};
+#else
+  const auto bits16 = And(bits, Vec16<int16_t>{_mm_set_epi64x(0, 0xFFFF)});
+#endif
+  return Vec16<int16_t>{_mm_sra_epi16(v.raw, bits16.raw)};
+}
+#endif
+
+template <size_t N>
+HWY_API Vec128<int8_t, N> operator>>(Vec128<int8_t, N> v,
+                                     Vec128<int8_t, N> bits) {
+#if HWY_TARGET <= HWY_AVX2
+  return detail::AVX2ShrI8Vec128(v, bits);
+#else
+  const DFromV<decltype(v)> d;
+  return detail::SignedShr(d, v, bits);
+#endif
+}
+HWY_API Vec128<int8_t, 1> operator>>(Vec128<int8_t, 1> v,
+                                     Vec128<int8_t, 1> bits) {
+#if HWY_TARGET <= HWY_SSE4
+  const Vec16<int16_t> vi16{_mm_cvtepi8_epi16(v.raw)};
+  const Vec16<uint16_t> bits8{_mm_cvtepu8_epi64(bits.raw)};
+#else
+  const DFromV<decltype(v)> d;
+  const Rebind<int16_t, decltype(d)> di16;
+  const Twice<decltype(d)> dt;
+
+  const auto vi16 = ShiftRight<8>(BitCast(di16, Combine(dt, v, v)));
+  const Vec16<uint16_t> bits8 =
+      And(Vec16<uint16_t>{bits.raw}, Vec16<uint16_t>{_mm_set_epi64x(0, 0xFF)});
+#endif
+  return Vec128<int8_t, 1>{_mm_sra_epi16(vi16.raw, bits8.raw)};
 }
 
 template <size_t N>
@@ -5990,10 +6236,17 @@ HWY_API Vec128<int32_t, N> operator>>(Vec128<int32_t, N> v,
   return detail::SignedShr(d, v, bits);
 #endif
 }
-HWY_API Vec128<int32_t, 1> operator>>(Vec128<int32_t, 1> v,
-                                      Vec128<int32_t, 1> bits) {
-  return Vec128<int32_t, 1>{_mm_sra_epi32(v.raw, bits.raw)};
+
+#if HWY_TARGET > HWY_AVX2
+HWY_API Vec32<int32_t> operator>>(Vec32<int32_t> v, Vec32<int32_t> bits) {
+#if HWY_TARGET == HWY_SSE4
+  const Vec32<uint32_t> bits32{_mm_cvtepu32_epi64(bits.raw)};
+#else
+  const auto bits32 = Combine(Full64<int32_t>(), Zero(Full32<int32_t>()), bits);
+#endif
+  return Vec32<int32_t>{_mm_sra_epi32(v.raw, bits32.raw)};
 }
+#endif
 
 template <size_t N>
 HWY_API Vec128<int64_t, N> operator>>(Vec128<int64_t, N> v,

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -5874,7 +5874,7 @@ HWY_API Vec128<uint8_t, N> Shl(hwy::UnsignedTag tag, Vec128<uint8_t, N> v,
   // Shift even lanes in-place
   const VW evens = Shl(tag, vw, And(bits16, even_mask));
   const VW odds = Shl(tag, And(vw, odd_mask), ShiftRight<8>(bits16));
-  return BitCast(d, IfVecThenElse(odd_mask, odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 #endif
 }
 HWY_API Vec128<uint8_t, 1> Shl(hwy::UnsignedTag /*tag*/, Vec128<uint8_t, 1> v,

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4233,7 +4233,7 @@ HWY_API Vec256<uint8_t> Shl(hwy::UnsignedTag tag, Vec256<uint8_t> v,
   // Shift even lanes in-place
   const VW evens = Shl(tag, vw, And(bits16, even_mask));
   const VW odds = Shl(tag, And(vw, odd_mask), ShiftRight<8>(bits16));
-  return BitCast(d, IfVecThenElse(odd_mask, odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 #endif
 }
 
@@ -4305,7 +4305,7 @@ HWY_API Vec256<uint8_t> operator>>(Vec256<uint8_t> v, Vec256<uint8_t> bits) {
   const VW evens = And(vw, mask) >> And(bits16, mask);
   // Shift odd lanes in-place
   const VW odds = vw >> ShiftRight<8>(bits16);
-  return BitCast(d, IfVecThenElse(Set(dw, 0xFF00), odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 }
 
 HWY_API Vec256<uint32_t> operator>>(Vec256<uint32_t> v, Vec256<uint32_t> bits) {
@@ -4355,8 +4355,7 @@ HWY_API Vec256<int8_t> operator>>(Vec256<int8_t> v, Vec256<int8_t> bits) {
   const VW evens = ShiftRight<8>(ShiftLeft<8>(vw)) >> And(bits16, mask);
   // Shift odd lanes in-place
   const VW odds = vw >> BitCast(dw, ShiftRight<8>(BitCast(dw_u, bits16)));
-  return BitCast(
-      d, IfVecThenElse(Set(dw, static_cast<int16_t>(0xFF00)), odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 }
 
 HWY_API Vec256<int32_t> operator>>(Vec256<int32_t> v, Vec256<int32_t> bits) {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -4185,36 +4185,26 @@ HWY_API Vec256<TI> TableLookupBytes(Vec128<T, N> bytes, Vec256<TI> from) {
 namespace detail {
 
 #if HWY_TARGET > HWY_AVX3 && !HWY_IDE  // AVX2 or older
-
-// Returns 2^v for use as per-lane multipliers to emulate 16-bit shifts.
-template <typename T>
-HWY_INLINE Vec256<MakeUnsigned<T>> Pow2(const Vec256<T> v) {
-  static_assert(sizeof(T) == 2, "Only for 16-bit");
+template <class V>
+HWY_INLINE V AVX2ShlU16Vec256(V v, V bits) {
   const DFromV<decltype(v)> d;
-  const RepartitionToWide<decltype(d)> dw;
-  const Rebind<float, decltype(dw)> df;
-  const auto zero = Zero(d);
-  // Move into exponent (this u16 will become the upper half of an f32)
-  const auto exp = ShiftLeft<23 - 16>(v);
-  const auto upper = exp + Set(d, 0x3F80);  // upper half of 1.0f
-  // Insert 0 into lower halves for reinterpreting as binary32.
-  const auto f0 = ZipLower(dw, zero, upper);
-  const auto f1 = ZipUpper(dw, zero, upper);
-  // Do not use ConvertTo because it checks for overflow, which is redundant
-  // because we only care about v in [0, 16).
-  const Vec256<int32_t> bits0{_mm256_cvttps_epi32(BitCast(df, f0).raw)};
-  const Vec256<int32_t> bits1{_mm256_cvttps_epi32(BitCast(df, f1).raw)};
-  return Vec256<MakeUnsigned<T>>{_mm256_packus_epi32(bits0.raw, bits1.raw)};
-}
+  const Half<decltype(d)> dh;
+  const Rebind<uint32_t, decltype(dh)> du32;
 
-#endif  // HWY_TARGET > HWY_AVX3
+  const auto lo_shl_result = PromoteTo(du32, LowerHalf(dh, v))
+                             << PromoteTo(du32, LowerHalf(dh, bits));
+  const auto hi_shl_result = PromoteTo(du32, UpperHalf(dh, v))
+                             << PromoteTo(du32, UpperHalf(dh, bits));
+  return ConcatEven(d, BitCast(d, hi_shl_result), BitCast(d, lo_shl_result));
+}
+#endif
 
 HWY_INLINE Vec256<uint16_t> Shl(hwy::UnsignedTag /*tag*/, Vec256<uint16_t> v,
                                 Vec256<uint16_t> bits) {
 #if HWY_TARGET <= HWY_AVX3 || HWY_IDE
   return Vec256<uint16_t>{_mm256_sllv_epi16(v.raw, bits.raw)};
 #else
-  return v * Pow2(bits);
+  return AVX2ShlU16Vec256(v, bits);
 #endif
 }
 
@@ -4236,13 +4226,14 @@ HWY_API Vec256<uint8_t> Shl(hwy::UnsignedTag tag, Vec256<uint8_t> v,
 #else
   const Repartition<uint16_t, decltype(d)> dw;
   using VW = VFromD<decltype(dw)>;
-  const VW mask = Set(dw, 0x00FF);
+  const VW even_mask = Set(dw, 0x00FF);
+  const VW odd_mask = Set(dw, 0xFF00);
   const VW vw = BitCast(dw, v);
   const VW bits16 = BitCast(dw, bits);
-  const VW evens = Shl(tag, And(vw, mask), And(bits16, mask));
-  // Shift odd lanes in-place
-  const VW odds = Shl(tag, vw, ShiftRight<8>(bits16));
-  return BitCast(d, IfVecThenElse(Set(dw, 0xFF00), odds, evens));
+  // Shift even lanes in-place
+  const VW evens = Shl(tag, vw, And(bits16, even_mask));
+  const VW odds = Shl(tag, And(vw, odd_mask), ShiftRight<8>(bits16));
+  return BitCast(d, IfVecThenElse(odd_mask, odds, evens));
 #endif
 }
 
@@ -4274,15 +4265,32 @@ HWY_API Vec256<T> operator<<(Vec256<T> v, Vec256<T> bits) {
 
 // ------------------------------ Shr (MulHigh, IfThenElse, Not)
 
+#if HWY_TARGET > HWY_AVX3  // AVX2
+namespace detail {
+
+template <class V>
+HWY_INLINE V AVX2ShrU16Vec256(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  const Rebind<int32_t, decltype(dh)> di32;
+  const Rebind<uint32_t, decltype(dh)> du32;
+
+  const auto lo_shr_result =
+      PromoteTo(du32, LowerHalf(dh, v)) >> PromoteTo(du32, LowerHalf(dh, bits));
+  const auto hi_shr_result =
+      PromoteTo(du32, UpperHalf(dh, v)) >> PromoteTo(du32, UpperHalf(dh, bits));
+  return OrderedDemote2To(d, BitCast(di32, lo_shr_result),
+                          BitCast(di32, hi_shr_result));
+}
+
+}  // namespace detail
+#endif
+
 HWY_API Vec256<uint16_t> operator>>(Vec256<uint16_t> v, Vec256<uint16_t> bits) {
-#if HWY_TARGET <= HWY_AVX3 || HWY_IDE
+#if HWY_TARGET <= HWY_AVX3
   return Vec256<uint16_t>{_mm256_srlv_epi16(v.raw, bits.raw)};
 #else
-  Full256<uint16_t> d;
-  // For bits=0, we cannot mul by 2^16, so fix the result later.
-  auto out = MulHigh(v, detail::Pow2(Set(d, 16) - bits));
-  // Replace output with input where bits == 0.
-  return IfThenElse(bits == Zero(d), v, out);
+  return detail::AVX2ShrU16Vec256(v, bits);
 #endif
 }
 
@@ -4308,13 +4316,47 @@ HWY_API Vec256<uint64_t> operator>>(Vec256<uint64_t> v, Vec256<uint64_t> bits) {
   return Vec256<uint64_t>{_mm256_srlv_epi64(v.raw, bits.raw)};
 }
 
+#if HWY_TARGET > HWY_AVX3  // AVX2
+namespace detail {
+
+template <class V>
+HWY_INLINE V AVX2ShrI16Vec256(V v, V bits) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  const Rebind<int32_t, decltype(dh)> di32;
+
+  const auto lo_shr_result =
+      PromoteTo(di32, LowerHalf(dh, v)) >> PromoteTo(di32, LowerHalf(dh, bits));
+  const auto hi_shr_result =
+      PromoteTo(di32, UpperHalf(dh, v)) >> PromoteTo(di32, UpperHalf(dh, bits));
+  return OrderedDemote2To(d, lo_shr_result, hi_shr_result);
+}
+
+}  // namespace detail
+#endif
+
 HWY_API Vec256<int16_t> operator>>(Vec256<int16_t> v, Vec256<int16_t> bits) {
 #if HWY_TARGET <= HWY_AVX3
   return Vec256<int16_t>{_mm256_srav_epi16(v.raw, bits.raw)};
 #else
-  const DFromV<decltype(v)> d;
-  return detail::SignedShr(d, v, bits);
+  return detail::AVX2ShrI16Vec256(v, bits);
 #endif
+}
+
+// 8-bit uses 16-bit shifts.
+HWY_API Vec256<int8_t> operator>>(Vec256<int8_t> v, Vec256<int8_t> bits) {
+  const DFromV<decltype(v)> d;
+  const RepartitionToWide<decltype(d)> dw;
+  const RebindToUnsigned<decltype(dw)> dw_u;
+  using VW = VFromD<decltype(dw)>;
+  const VW mask = Set(dw, 0x00FF);
+  const VW vw = BitCast(dw, v);
+  const VW bits16 = BitCast(dw, bits);
+  const VW evens = ShiftRight<8>(ShiftLeft<8>(vw)) >> And(bits16, mask);
+  // Shift odd lanes in-place
+  const VW odds = vw >> BitCast(dw, ShiftRight<8>(BitCast(dw_u, bits16)));
+  return BitCast(
+      d, IfVecThenElse(Set(dw, static_cast<int16_t>(0xFF00)), odds, evens));
 }
 
 HWY_API Vec256<int32_t> operator>>(Vec256<int32_t> v, Vec256<int32_t> bits) {

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5285,7 +5285,7 @@ HWY_API Vec512<uint8_t> operator<<(Vec512<uint8_t> v, Vec512<uint8_t> bits) {
   // Shift even lanes in-place
   const VW evens = vw << And(bits16, even_mask);
   const VW odds = And(vw, odd_mask) << ShiftRight<8>(bits16);
-  return BitCast(d, IfVecThenElse(odd_mask, odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 #endif
 }
 
@@ -5325,7 +5325,7 @@ HWY_API Vec512<uint8_t> operator>>(Vec512<uint8_t> v, Vec512<uint8_t> bits) {
   const VW evens = And(vw, mask) >> And(bits16, mask);
   // Shift odd lanes in-place
   const VW odds = vw >> ShiftRight<8>(bits16);
-  return BitCast(d, IfVecThenElse(Set(dw, 0xFF00), odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 }
 
 HWY_API Vec512<uint32_t> operator>>(const Vec512<uint32_t> v,
@@ -5355,8 +5355,7 @@ HWY_API Vec512<int8_t> operator>>(Vec512<int8_t> v, Vec512<int8_t> bits) {
   const VW evens = ShiftRight<8>(ShiftLeft<8>(vw)) >> And(bits16, mask);
   // Shift odd lanes in-place
   const VW odds = vw >> BitCast(dw, ShiftRight<8>(BitCast(dw_u, bits16)));
-  return BitCast(
-      d, IfVecThenElse(Set(dw, static_cast<int16_t>(0xFF00)), odds, evens));
+  return OddEven(BitCast(d, odds), BitCast(d, evens));
 }
 
 HWY_API Vec512<int32_t> operator>>(const Vec512<int32_t> v,

--- a/hwy/tests/shift_test.cc
+++ b/hwy/tests/shift_test.cc
@@ -86,7 +86,7 @@ struct TestVariableLeftShifts {
     constexpr size_t kMaxShift = (sizeof(T) * 8) - 1;
     const auto max_shift = Set(d, kMaxShift);
     const auto small_shifts = And(Iota(d, 0), max_shift);
-    const auto large_shifts = max_shift - small_shifts;
+    const auto large_shifts = Sub(max_shift, small_shifts);
 
     // Same: 0
     HWY_ASSERT_VEC_EQ(d, values, Shl(values, v0));
@@ -210,7 +210,7 @@ struct TestVariableUnsignedRightShifts {
     constexpr size_t kMaxShift = (sizeof(T) * 8) - 1;
     const auto max_shift = Set(d, kMaxShift);
     const auto small_shifts = And(Iota(d, 0), max_shift);
-    const auto large_shifts = max_shift - small_shifts;
+    const auto large_shifts = Sub(max_shift, small_shifts);
 
     // Same: 0
     HWY_ASSERT_VEC_EQ(d, values, Shr(values, v0));
@@ -222,7 +222,10 @@ struct TestVariableUnsignedRightShifts {
     HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(values, v1));
 
     // Same: max
-    HWY_ASSERT_VEC_EQ(d, v0, Shr(values, max_shift));
+    for (size_t i = 0; i < N; ++i) {
+      expected[i] = T(T(i & kMax) >> kMaxShift);
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(values, max_shift));
 
     // Variable: small
     for (size_t i = 0; i < N; ++i) {
@@ -326,7 +329,7 @@ struct TestVariableSignedRightShifts {
 
     // First test positive values, negative are checked below.
     const auto v0 = Zero(d);
-    const auto positive = Iota(d, 0) & Set(d, kMax);
+    const auto positive = And(Iota(d, 0), Set(d, kMax));
 
     // Shift by 0
     HWY_ASSERT_VEC_EQ(d, positive, ShiftRight<0>(positive));
@@ -345,20 +348,21 @@ struct TestVariableSignedRightShifts {
 
     const auto max_shift = Set(d, kMaxShift);
     const auto small_shifts = And(Iota(d, 0), max_shift);
-    const auto large_shifts = max_shift - small_shifts;
+    const auto large_shifts = Sub(max_shift, small_shifts);
 
     const auto negative = Iota(d, kMin);
 
     // Test varying negative to shift
     for (size_t i = 0; i < N; ++i) {
-      expected[i] = RightShiftNegative<1>(static_cast<T>(kMin + i));
+      expected[i] =
+          RightShiftNegative<1>(static_cast<T>(static_cast<TU>(kMin) + i));
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(negative, Set(d, 1)));
 
     // Shift MSB right by small amounts
     for (size_t i = 0; i < N; ++i) {
       const size_t amount = i & kMaxShift;
-      const TU shifted = ~((1ull << (kMaxShift - amount)) - 1);
+      const TU shifted = static_cast<TU>(~((1ull << (kMaxShift - amount)) - 1));
       CopySameSize(&shifted, &expected[i]);
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(Set(d, kMin), small_shifts));
@@ -366,7 +370,7 @@ struct TestVariableSignedRightShifts {
     // Shift MSB right by large amounts
     for (size_t i = 0; i < N; ++i) {
       const size_t amount = kMaxShift - (i & kMaxShift);
-      const TU shifted = ~((1ull << (kMaxShift - amount)) - 1);
+      const TU shifted = static_cast<TU>(~((1ull << (kMaxShift - amount)) - 1));
       CopySameSize(&shifted, &expected[i]);
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(Set(d, kMin), large_shifts));
@@ -381,21 +385,11 @@ HWY_NOINLINE void TestAllShifts() {
 }
 
 HWY_NOINLINE void TestAllVariableShifts() {
-  ForUnsignedTypes(ForPartialVectors<TestLeftShifts</*kSigned=*/false>>());
-  ForUnsignedTypes(ForPartialVectors<TestUnsignedRightShifts>());
-
-  const ForPartialVectors<TestLeftShifts</*kSigned=*/true>> shl_s;
-  const ForPartialVectors<TestSignedRightShifts> shr_s;
-
-  shl_s(int16_t());
-  shr_s(int16_t());
-  shl_s(int32_t());
-  shr_s(int32_t());
-
-#if HWY_HAVE_INTEGER64
-  shl_s(int64_t());
-  shr_s(int64_t());
-#endif
+  ForUnsignedTypes(
+      ForPartialVectors<TestVariableLeftShifts</*kSigned=*/false>>());
+  ForSignedTypes(ForPartialVectors<TestVariableLeftShifts</*kSigned=*/true>>());
+  ForUnsignedTypes(ForPartialVectors<TestVariableUnsignedRightShifts>());
+  ForSignedTypes(ForPartialVectors<TestVariableSignedRightShifts>());
 }
 
 HWY_NOINLINE void TestAllRotateRight() {

--- a/hwy/tests/shift_test.cc
+++ b/hwy/tests/shift_test.cc
@@ -354,8 +354,9 @@ struct TestVariableSignedRightShifts {
 
     // Test varying negative to shift
     for (size_t i = 0; i < N; ++i) {
+      const auto val = static_cast<T>(static_cast<TU>(kMin) + i);
       expected[i] =
-          RightShiftNegative<1>(static_cast<T>(static_cast<TU>(kMin) + i));
+          (val < 0) ? RightShiftNegative<1>(val) : static_cast<T>(val >> 1);
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), Shr(negative, Set(d, 1)));
 


### PR DESCRIPTION
Made the following fixes to `operator<<` and `operator>>` on SSE2/SSSE3/SSE4/AVX2/AVX3/AVX3_DL:
- Implemented `operator>>` for I8 vectors
- Fixed the issue where `operator<<` and `operator>>` generated incorrect results for 1-lane I8/U8/I16/U16/I32/U32 vectors as the  `_mm_sll_epi16`, `_mm_srl_epi16`, `_mm_sra_epi16`, `_mm_sll_epi32`, `_mm_srl_epi32`, and `_mm_sra_epi32` intrinsics (and the SSE2 PSLLW/PSRLW/PSRAW/PSLLD/PSRLD/PSRAD instructions) treat the second argument (shift count) as a uint64_t vector (whose first uint64_t lane is used as the shift count)
- Updated the implementation of `operator<<` and `operator>>` for 1-lane I16/U16 vectors on AVX3 to use the `operator<<(Vec128<uint16_t, N>, Vec128<uint16_t, N>)`, `operator>>(Vec128<int16_t, N>, Vec128<int16_t, N>)`, and `(Vec128<uint16_t, N>, Vec128<uint16_t, N>)` overloads to avoid unnecessary zero-out of the shift amount
- Updated the implementation of `operator<<` and `operator>>` for 1-lane I32/U32 vectors on AVX2/AVX3 to use the `operator<<(Vec128<uint32_t, N>, Vec128<uint32_t, N>)`, `operator>>(Vec128<int32_t, N>, Vec128<int32_t, N>)`, and `(Vec128<uint32_t, N>, Vec128<uint32_t, N>)` overloads to avoid unnecessary zero-out of the shift amount
- Updated U16 implementation of `operator<<` on AVX2 to do a PromoteTo to U32, followed by a U32 Shl, followed by a truncation back to U16 (to avoid the need for Pow2 or F32->I32 conversions on AVX2)
- Updated I16/U16 implementation of `operator>>` on AVX2 to do a PromoteTo to I32/U32, followed by a I32/U32 Shr, followed by a demotion back to I16/U16 (to avoid the need for Pow2, F32->I32 conversions, or fix-up for a zero shift count on AVX2)
- Fixed issue where `operator<<` on AVX3_DL generated incorrect results for I8/U8 vectors that are smaller than 8 bytes by replacing `Load(d, kMasks)` with `Load(Full64<uint8_t>(), kMasks)` and replacing `Load(d, kShl)` with `Load(Full64<uint8_t>(), kShl)`
- Reimplemented `detail::Pow2` for I16/U16 vectors that have fewer than 4 lanes on SSE2/SSSE3/SSE4 to avoid the second float to int32_t conversion
- Fixed bug with `operator<<` for I8/U8 vectors on SSE2/SSSE3/SSE4/AVX2/AVX3 as doing a U16 Shl of the odd lanes need the even lanes zeroed out (to avoid shifting in bits from the even lanes)

Made the following fixes to U64/I64 `operator<<` and `operator>>` on WASM:
- The `lanes` and `bits_lanes` arrays are now zero-initialized in the U64/I64 `operator<<` and `operator>>` implementations to avoid undefined behavior in the case of one-lane U64/I64 vectors
- The `lanes` and `bits_lanes` arrays in the U64/I64 `operator<<` implementation are now uint64_t arrays to avoid undefined behavior in the case where `T` is int64_t
- A bitwise AND of the shift amounts is performed to match the behavior of I8/U8/I16/U16/I32/U32 Shl/Shr and to avoid undefined behavior (and WASM Clang will optimize out the bitwise AND of the shift amounts when optimizations are enabled as the WASM i64.shr_s and i64.shr_u instructions ignore the upper 58 bits of the shift amount)

Made the following fixes in hwy/tests/shift_test.cc:
- Fixed the issue where `TestVariableLeftShifts`, `TestVariableUnsignedRightShifts`, and `TestVariableSignedRightShifts` were not invoked by `TestAllVariableShifts`
- Fixed the issue where `TestVariableUnsignedRightShifts` would fail for uint8_t vectors that have more than 128 lanes as it is possible for `values[i] >> kMaxShift` to be non-zero in the case where `Lanes(d) > hwy::LimitsMax<MakeSigned<T>>()`
- Fixed the issue where `TestVariableSignedRightShifts` would fail for int8_t vectors that have more than 128 lanes as it is possible for `negative[i] >= 0` to be true in the case where `Lanes(d) > hwy::LimitsMax<T>()`
- Fixed issues where `TestVariableLeftShifts`, `TestVariableUnsignedRightShifts`, and `TestVariableSignedRightShifts` would fail to compile on RVV/SVE by replacing `max_shift - small_shifts` with `Sub(max_shift, small_shifts)` and replacing `Iota(d, 0) & Set(d, kMax)` with `And(Iota(d, 0), Set(d, kMax))`
- Fixed compilation warning with `kMin + i` in `TestVariableSignedRightShifts` by casting `kMin` to TU
