### PR TITLE
Added I8/U8/I16/U16 DupEven/DupOdd and Per4LaneBlockShuffle

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1445,8 +1445,7 @@ instead because they are more general:
     blocks are taken from `a` and the even blocks from `b`. Returns `b` if the
     vector has no more than one block (i.e. is 128 bits or scalar).
 
-*   `V`: `{u,i,f}{32,64}` \
-    <code>V **DupEven**(V v)</code>: returns `r`, the result of copying even
+*   <code>V **DupEven**(V v)</code>: returns `r`, the result of copying even
     lanes to the next higher-indexed lane. For each even lane index `i`,
     `r[i] == v[i]` and `r[i + 1] == v[i]`.
 
@@ -1505,6 +1504,28 @@ instead because they are more general:
     <code>V **ReverseBits**(V a)</code> returns a vector where the bits of each
     lane are reversed.
 
+*   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx0, size_t kIdx1,
+    size_t kIdx2, size_t kIdx3&gt;(V v)</code> does a per 4-lane block shuffle
+    of `v` if `Lanes(DFromV<V>())` is greater than or equal to 4 or a shuffle of
+    the full vector if `Lanes(DFromV<V>())` is less than 4.
+
+    `kIdx0`, `kIdx1`, `kIdx2`, and `kIdx3` must all be between 0 and 3.
+
+    Per4LaneBlockShuffle is equivalent to doing a TableLookupLanes with the
+    following indices (but Per4LaneBlockShuffle is usually more efficient than
+    TableLookupLanes):
+    `{kIdx0, kIdx1, kIdx2, kIdx3, kIdx0+4, kIdx1+4, kIdx2+4, kIdx3+4, ...}`
+
+    If `Lanes(DFromV<V>())` is less than 4 and `kIdx0 >= Lanes(DFromV<V>())` is
+    true, Per4LaneBlockShuffle returns an unspecified value in the first lane of
+    the result. Otherwise, Per4LaneBlockShuffle returns `v[kIdx0]` in the first
+    lane of the result.
+
+    If `Lanes(DFromV<V>())` is equal to 2 and `kIdx1 >= 2` is true,
+    Per4LaneBlockShuffle returns an unspecified value in the second lane of the
+    result. Otherwise, Per4LaneBlockShuffle returns `v[kIdx1]` in the first lane
+    of the result.
+
 The following `ReverseN` must not be called if `Lanes(D()) < N`:
 
 *   <code>V **Reverse2**(D, V a)</code> returns a vector with each group of 2
@@ -1518,8 +1539,7 @@ The following `ReverseN` must not be called if `Lanes(D()) < N`:
 
 All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
 
-*   `V`: `{u,i,f}{32,64}` \
-    <code>V **DupOdd**(V v)</code>: returns `r`, the result of copying odd lanes
+*   <code>V **DupOdd**(V v)</code>: returns `r`, the result of copying odd lanes
     to the previous lower-indexed lane. For each odd lane index `i`, `r[i] ==
     v[i]` and `r[i - 1] == v[i]`.
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1504,16 +1504,16 @@ instead because they are more general:
     <code>V **ReverseBits**(V a)</code> returns a vector where the bits of each
     lane are reversed.
 
-*   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx0, size_t kIdx1,
-    size_t kIdx2, size_t kIdx3&gt;(V v)</code> does a per 4-lane block shuffle
+*   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx3, size_t kIdx2,
+    size_t kIdx1, size_t kIdx0&gt;(V v)</code> does a per 4-lane block shuffle
     of `v` if `Lanes(DFromV<V>())` is greater than or equal to 4 or a shuffle of
     the full vector if `Lanes(DFromV<V>())` is less than 4.
 
     `kIdx0`, `kIdx1`, `kIdx2`, and `kIdx3` must all be between 0 and 3.
 
     Per4LaneBlockShuffle is equivalent to doing a TableLookupLanes with the
-    following indices (but Per4LaneBlockShuffle is usually more efficient than
-    TableLookupLanes):
+    following indices (but Per4LaneBlockShuffle is more efficient than
+    TableLookupLanes on some platforms):
     `{kIdx0, kIdx1, kIdx2, kIdx3, kIdx0+4, kIdx1+4, kIdx2+4, kIdx3+4, ...}`
 
     If `Lanes(DFromV<V>())` is less than 4 and `kIdx0 >= Lanes(DFromV<V>())` is

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -5125,6 +5125,34 @@ HWY_INLINE VFromD<D> Per4LaneBlkShufDupSet4xU32(D d, const uint32_t x3,
 }
 #endif  // HWY_COMPILER_GCC || HWY_COMPILER_CLANG
 
+template <size_t kLaneSize, size_t kVectSize, class V,
+          HWY_IF_LANES_GT_D(DFromV<V>, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x88> /*idx_3210_tag*/,
+                                  hwy::SizeTag<kLaneSize> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RepartitionToWide<decltype(du)> dw;
+
+  const auto evens = BitCast(dw, ConcatEven(d, v, v));
+  return BitCast(d, InterleaveLower(dw, evens, evens));
+}
+
+template <size_t kLaneSize, size_t kVectSize, class V,
+          HWY_IF_LANES_GT_D(DFromV<V>, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xDD> /*idx_3210_tag*/,
+                                  hwy::SizeTag<kLaneSize> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RepartitionToWide<decltype(du)> dw;
+
+  const auto odds = BitCast(dw, ConcatOdd(d, v, v));
+  return BitCast(d, InterleaveLower(dw, odds, odds));
+}
+
 template <class V>
 HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xFA> /*idx_3210_tag*/,
                                   hwy::SizeTag<2> /*lane_size_tag*/,

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -5047,6 +5047,22 @@ HWY_API VFromD<DW> ZipUpper(DW dw, V a, V b) {
   return BitCast(dw, InterleaveUpper(D(), a, b));
 }
 
+// ------------------------------ Per4LaneBlockShuffle
+namespace detail {
+
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<2> /*idx_0_tag*/,
+                                  hwy::SizeTag<2> /*idx_1_tag*/,
+                                  hwy::SizeTag<3> /*idx_2_tag*/,
+                                  hwy::SizeTag<3> /*idx_3_tag*/,
+                                  hwy::SizeTag<2> /*lane_size_tag*/,
+                                  hwy::SizeTag<8> /*vect_size_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return InterleaveUpper(d, v, v);
+}
+
+}  // namespace detail
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)
 
 template <class D32, HWY_IF_F32_D(D32),
@@ -5392,7 +5408,8 @@ HWY_API Vec128<T, 2> ConcatEven(D d, Vec128<T, 2> hi, Vec128<T, 2> lo) {
 
 // ------------------------------ DupEven (InterleaveLower)
 
-template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
+template <typename T, size_t N,
+          HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4))>
 HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
 #if HWY_ARCH_ARM_A64
   return detail::InterleaveEven(v, v);
@@ -5408,7 +5425,8 @@ HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
 
 // ------------------------------ DupOdd (InterleaveUpper)
 
-template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
+template <typename T, size_t N,
+          HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4))>
 HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {
 #if HWY_ARCH_ARM_A64
   return detail::InterleaveOdd(v, v);

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2015,6 +2015,40 @@ HWY_API V InterleaveUpper(D d, const V a, const V b) {
   return InterleaveUpper(DFromV<V>(), a, b);
 }
 
+// ------------------------------ Per4LaneBlockShuffle
+
+namespace detail {
+
+template <size_t kLaneSize, size_t kVectSize, class V,
+          HWY_IF_NOT_T_SIZE_V(V, 8)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x88> /*idx_3210_tag*/,
+                                  hwy::SizeTag<kLaneSize> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RepartitionToWide<decltype(du)> dw;
+
+  const auto evens = BitCast(dw, ConcatEvenFull(v, v));
+  return BitCast(d, ZipLowerSame(evens, evens));
+}
+
+template <size_t kLaneSize, size_t kVectSize, class V,
+          HWY_IF_NOT_T_SIZE_V(V, 8)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xDD> /*idx_3210_tag*/,
+                                  hwy::SizeTag<kLaneSize> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  const DFromV<decltype(v)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RepartitionToWide<decltype(du)> dw;
+
+  const auto odds = BitCast(dw, ConcatOddFull(v, v));
+  return BitCast(d, ZipLowerSame(odds, odds));
+}
+
+}  // namespace detail
+
 // ================================================== COMBINE
 
 namespace detail {

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3119,179 +3119,288 @@ HWY_API V ReverseBits(V v) {
 
 // ------------------------------ Per4LaneBlockShuffle
 
+#if (defined(HWY_NATIVE_PER4LANEBLKSHUF_DUP32) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#undef HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#else
+#define HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#endif
+
 #if HWY_TARGET != HWY_SCALAR
 namespace detail {
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 1)>
-HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<0> /*idx_0_tag*/,
-                                  hwy::SizeTag<0> /*idx_1_tag*/, V v) {
+template <class D>
+HWY_INLINE Vec<D> Per4LaneBlkShufDupSet4xU32(D d, const uint32_t x3,
+                                             const uint32_t x2,
+                                             const uint32_t x1,
+                                             const uint32_t x0) {
+  alignas(16) const uint32_t lanes[4] = {x0, x1, x2, x3};
+
+#if HWY_TARGET == HWY_RVV
+  constexpr int kPow2 = d.Pow2();
+  constexpr int kLoadPow2 = HWY_MAX(kPow2, -1);
+  const ScalableTag<uint32_t, kLoadPow2> d_load;
+#else
+  constexpr size_t kMaxBytes = d.MaxBytes();
+#if HWY_TARGET == HWY_NEON || HWY_TARGET == HWY_NEON_WITHOUT_AES
+  constexpr size_t kMinLanesToLoad = 2;
+#else
+  constexpr size_t kMinLanesToLoad = 4;
+#endif
+  constexpr size_t kNumToLoad =
+      HWY_MAX(kMaxBytes / sizeof(uint32_t), kMinLanesToLoad);
+  const CappedTag<uint32_t, kNumToLoad> d_load;
+#endif
+
+  return ResizeBitCast(d, LoadDup128(d_load, lanes));
+}
+
+}  // namespace detail
+#endif
+
+#endif  // HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+
+#if HWY_TARGET != HWY_SCALAR
+namespace detail {
+
+template <class V>
+HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<0> /*idx_10_tag*/, V v) {
   return DupEven(v);
 }
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 1)>
-HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<1> /*idx_0_tag*/,
-                                  hwy::SizeTag<1> /*idx_1_tag*/, V v) {
-  return DupOdd(v);
-}
-
-template <size_t kIdx0, class V, HWY_IF_LANES_GT_D(DFromV<V>, 1)>
-HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<0> /*idx_1_tag*/, V v) {
-  static_assert(kIdx0 != 0, "kIdx0 != 0 should be true");
+template <class V>
+HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<1> /*idx_10_tag*/, V v) {
   const DFromV<decltype(v)> d;
   return Reverse2(d, v);
 }
 
-template <size_t kIdx0, size_t kIdx1, class V>
-HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/, V v) {
-  static_assert(
-      HWY_MAX_LANES_V(V) <= 1 || kIdx1 != 0,
-      "kIdx1 != 0 should be true if HWY_MAX_LANES_V(V) is greater than 1");
-  static_assert(HWY_MAX_LANES_V(V) <= 1 || kIdx0 != 1 || kIdx1 != 1,
-                "kIdx0 != 1 or kIdx1 != 1 should be true if HWY_MAX_LANES_V(V) "
-                "is greater than 1");
+template <class V>
+HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<2> /*idx_10_tag*/, V v) {
   return v;
 }
 
-template <size_t kLaneSize, class VT, class VI>
-HWY_INLINE VT Per4LaneBlockShufTblLookup(
-    hwy::SizeTag<kLaneSize> /* lane_size_tag */, VT vt, VI vi) {
-  return TableLookupBytes(vt, vi);
+template <class V>
+HWY_INLINE V Per2LaneBlockShuffle(hwy::SizeTag<3> /*idx_10_tag*/, V v) {
+  return DupOdd(v);
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class D>
-HWY_INLINE VFromD<D> Per4LaneBlockShufIdx(hwy::SizeTag<1> /* lane_size_tag */,
-                                          D d,
-                                          hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                          hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                          hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                          hwy::SizeTag<kIdx3> /*idx_3_tag*/) {
-  const Repartition<uint8_t, decltype(d)> du8;
-  alignas(16) static constexpr uint8_t kShuffle[16] = {
-      static_cast<uint8_t>(kIdx0),      static_cast<uint8_t>(kIdx1),
-      static_cast<uint8_t>(kIdx2),      static_cast<uint8_t>(kIdx3),
-      static_cast<uint8_t>(kIdx0 + 4),  static_cast<uint8_t>(kIdx1 + 4),
-      static_cast<uint8_t>(kIdx2 + 4),  static_cast<uint8_t>(kIdx3 + 4),
-      static_cast<uint8_t>(kIdx0 + 8),  static_cast<uint8_t>(kIdx1 + 8),
-      static_cast<uint8_t>(kIdx2 + 8),  static_cast<uint8_t>(kIdx3 + 8),
-      static_cast<uint8_t>(kIdx0 + 12), static_cast<uint8_t>(kIdx1 + 12),
-      static_cast<uint8_t>(kIdx2 + 12), static_cast<uint8_t>(kIdx3 + 12)};
-  return BitCast(d, LoadDup128(du8, kShuffle));
-}
-
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class D>
-HWY_INLINE VFromD<D> Per4LaneBlockShufIdx(hwy::SizeTag<2> /* lane_size_tag */,
-                                          D d,
-                                          hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                          hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                          hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                          hwy::SizeTag<kIdx3> /*idx_3_tag*/) {
-  const Repartition<uint8_t, decltype(d)> du8;
-  alignas(16) static constexpr uint8_t kShuffle[16] = {
-      static_cast<uint8_t>(kIdx0 * 2),     static_cast<uint8_t>(kIdx0 * 2 + 1),
-      static_cast<uint8_t>(kIdx1 * 2),     static_cast<uint8_t>(kIdx1 * 2 + 1),
-      static_cast<uint8_t>(kIdx2 * 2),     static_cast<uint8_t>(kIdx2 * 2 + 1),
-      static_cast<uint8_t>(kIdx3 * 2),     static_cast<uint8_t>(kIdx3 * 2 + 1),
-      static_cast<uint8_t>(kIdx0 * 2 + 8), static_cast<uint8_t>(kIdx0 * 2 + 9),
-      static_cast<uint8_t>(kIdx1 * 2 + 8), static_cast<uint8_t>(kIdx1 * 2 + 9),
-      static_cast<uint8_t>(kIdx2 * 2 + 8), static_cast<uint8_t>(kIdx2 * 2 + 9),
-      static_cast<uint8_t>(kIdx3 * 2 + 8), static_cast<uint8_t>(kIdx3 * 2 + 9)};
-  return BitCast(d, LoadDup128(du8, kShuffle));
-}
-
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class D>
-HWY_INLINE VFromD<D> Per4LaneBlockShufIdx(hwy::SizeTag<4> /* lane_size_tag */,
-                                          D d,
-                                          hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                          hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                          hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                          hwy::SizeTag<kIdx3> /*idx_3_tag*/) {
-  const Repartition<uint8_t, decltype(d)> du8;
-  alignas(16) static constexpr uint8_t kShuffle[16] = {
-      static_cast<uint8_t>(kIdx0 * 4),     static_cast<uint8_t>(kIdx0 * 4 + 1),
-      static_cast<uint8_t>(kIdx0 * 4 + 2), static_cast<uint8_t>(kIdx0 * 4 + 3),
-      static_cast<uint8_t>(kIdx1 * 4),     static_cast<uint8_t>(kIdx1 * 4 + 1),
-      static_cast<uint8_t>(kIdx1 * 4 + 2), static_cast<uint8_t>(kIdx1 * 4 + 3),
-      static_cast<uint8_t>(kIdx2 * 4),     static_cast<uint8_t>(kIdx2 * 4 + 1),
-      static_cast<uint8_t>(kIdx2 * 4 + 2), static_cast<uint8_t>(kIdx2 * 4 + 3),
-      static_cast<uint8_t>(kIdx3 * 4),     static_cast<uint8_t>(kIdx3 * 4 + 1),
-      static_cast<uint8_t>(kIdx3 * 4 + 2), static_cast<uint8_t>(kIdx3 * 4 + 3)};
-  return BitCast(d, LoadDup128(du8, kShuffle));
-}
-
-#if HWY_HAVE_INTEGER64 && HWY_MAX_BYTES >= 32
-template <class VT, class VI>
-HWY_INLINE VT Per4LaneBlockShufTblLookup(hwy::SizeTag<8> /* lane_size_tag */,
-                                         VT vt, VI vi) {
-  return TableLookupLanes(vt, vi);
-}
-
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class D>
-HWY_INLINE IndicesFromD<D> Per4LaneBlockShufIdx(
-    hwy::SizeTag<8> /* lane_size_tag */, D d, hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-    hwy::SizeTag<kIdx1> /*idx_1_tag*/, hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-    hwy::SizeTag<kIdx3> /*idx_3_tag*/) {
-  const RebindToUnsigned<decltype(d)> du;
-
-  alignas(32) static constexpr uint64_t kShuffle[4] = {
-      static_cast<uint64_t>(kIdx0), static_cast<uint64_t>(kIdx1),
-      static_cast<uint64_t>(kIdx2), static_cast<uint64_t>(kIdx3)};
-
-  constexpr int kLoadPow2 = d.Pow2();
-  constexpr size_t kMaxLanesToLoad = HWY_MIN(HWY_MAX_LANES_D(D), 4);
-  constexpr size_t kLoadN = D::template NewN<kLoadPow2, kMaxLanesToLoad>();
-  const Simd<uint64_t, kLoadN, kLoadPow2> d_load;
-  static_assert(d_load.MaxLanes() <= 4, "MaxLanes(d_load) <= 4 must be true");
-
-  const auto loaded_idx_vect = ResizeBitCast(du, Load(d_load, kShuffle));
-#if HWY_MAX_BYTES == 32
-  return IndicesFromVec(d, loaded_idx_vect);
+HWY_INLINE uint32_t U8x4Per4LaneBlkIndices(const uint32_t idx3,
+                                           const uint32_t idx2,
+                                           const uint32_t idx1,
+                                           const uint32_t idx0) {
+#if HWY_IS_LITTLE_ENDIAN
+  return static_cast<uint32_t>((idx3 << 24) | (idx2 << 16) | (idx1 << 8) |
+                               idx0);
 #else
-  const auto iota0 = Iota(du, uint64_t{0});
-  const auto block_offset =
-      And(iota0, Set(du, static_cast<uint64_t>(~uint64_t{3})));
-  const auto broadcast_idx =
-      IndicesFromVec(du, And(iota0, Set(du, uint64_t{3})));
-  return IndicesFromVec(
-      d, Add(TableLookupLanes(loaded_idx_vect, broadcast_idx), block_offset));
+  return static_cast<uint32_t>(idx3 | (idx2 << 8) | (idx1 << 16) |
+                               (idx0 << 24));
 #endif
 }
-#endif  // HWY_HAVE_INTEGER64 && HWY_MAX_BYTES >= 32
+
+template <class D>
+HWY_INLINE Vec<D> TblLookupPer4LaneBlkU8IdxInBlk(D d, const uint32_t idx3,
+                                                 const uint32_t idx2,
+                                                 const uint32_t idx1,
+                                                 const uint32_t idx0) {
+#if HWY_TARGET == HWY_RVV
+  const AdjustSimdTagToMinVecPow2<Repartition<uint32_t, D>> du32;
+#else
+  const Repartition<uint32_t, D> du32;
+#endif
+
+  return ResizeBitCast(
+      d, Set(du32, U8x4Per4LaneBlkIndices(idx3, idx2, idx1, idx0)));
+}
+
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || \
+    HWY_TARGET == HWY_SVE2_128 || HWY_TARGET == HWY_EMU128
+#define HWY_PER_4_BLK_TBL_LOOKUP_LANES_ENABLE(D) void* = nullptr
+#else
+#define HWY_PER_4_BLK_TBL_LOOKUP_LANES_ENABLE(D) HWY_IF_T_SIZE_D(D, 8)
+
+template <class V, HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4))>
+HWY_INLINE V Per4LaneBlkShufDoTblLookup(V v, V idx) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  return BitCast(d, TableLookupBytes(BitCast(du8, v), BitCast(du8, idx)));
+}
+
+template <class D, HWY_IF_T_SIZE_D(D, 1)>
+HWY_INLINE Vec<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
+                                              const uint32_t idx2,
+                                              const uint32_t idx1,
+                                              const uint32_t idx0) {
+  const Repartition<uint32_t, decltype(d)> du32;
+  const uint32_t idx3210 = U8x4Per4LaneBlkIndices(idx3, idx2, idx1, idx0);
+  const auto v_byte_idx = Per4LaneBlkShufDupSet4xU32(
+      du32, static_cast<uint32_t>(idx3210 + 0x0C0C0C0C),
+      static_cast<uint32_t>(idx3210 + 0x08080808),
+      static_cast<uint32_t>(idx3210 + 0x04040404),
+      static_cast<uint32_t>(idx3210));
+  return ResizeBitCast(d, v_byte_idx);
+}
+
+template <class D, HWY_IF_T_SIZE_D(D, 2)>
+HWY_INLINE Vec<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
+                                              const uint32_t idx2,
+                                              const uint32_t idx1,
+                                              const uint32_t idx0) {
+  const Repartition<uint32_t, decltype(d)> du32;
+#if HWY_IS_LITTLE_ENDIAN
+  const uint32_t idx10 = static_cast<uint32_t>((idx1 << 16) | idx0);
+  const uint32_t idx32 = static_cast<uint32_t>((idx3 << 16) | idx2);
+  constexpr uint32_t kLaneByteOffsets{0x01000100};
+#else
+  const uint32_t idx10 = static_cast<uint32_t>(idx1 | (idx0 << 16));
+  const uint32_t idx32 = static_cast<uint32_t>(idx3 | (idx2 << 16));
+  constexpr uint32_t kLaneByteOffsets{0x00010001};
+#endif
+  constexpr uint32_t kHiLaneByteOffsets{kLaneByteOffsets + 0x08080808u};
+
+  const auto v_byte_idx = Per4LaneBlkShufDupSet4xU32(
+      du32, static_cast<uint32_t>(idx32 * 0x0202u + kHiLaneByteOffsets),
+      static_cast<uint32_t>(idx10 * 0x0202u + kHiLaneByteOffsets),
+      static_cast<uint32_t>(idx32 * 0x0202u + kLaneByteOffsets),
+      static_cast<uint32_t>(idx10 * 0x0202u + kLaneByteOffsets));
+  return ResizeBitCast(d, v_byte_idx);
+}
+
+template <class D, HWY_IF_T_SIZE_D(D, 4)>
+HWY_INLINE Vec<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
+                                              const uint32_t idx2,
+                                              const uint32_t idx1,
+                                              const uint32_t idx0) {
+  const Repartition<uint32_t, decltype(d)> du32;
+#if HWY_IS_LITTLE_ENDIAN
+  constexpr uint32_t kLaneByteOffsets{0x03020100};
+#else
+  constexpr uint32_t kLaneByteOffsets{0x00010203};
+#endif
+
+  const auto v_byte_idx = Per4LaneBlkShufDupSet4xU32(
+      du32, static_cast<uint32_t>(idx3 * 0x04040404u + kLaneByteOffsets),
+      static_cast<uint32_t>(idx2 * 0x04040404u + kLaneByteOffsets),
+      static_cast<uint32_t>(idx1 * 0x04040404u + kLaneByteOffsets),
+      static_cast<uint32_t>(idx0 * 0x04040404u + kLaneByteOffsets));
+  return ResizeBitCast(d, v_byte_idx);
+}
+#endif
+
+template <class D, HWY_IF_T_SIZE_D(D, 1)>
+HWY_INLINE VFromD<D> TblLookupPer4LaneBlkIdxInBlk(D d, const uint32_t idx3,
+                                                  const uint32_t idx2,
+                                                  const uint32_t idx1,
+                                                  const uint32_t idx0) {
+  return TblLookupPer4LaneBlkU8IdxInBlk(d, idx3, idx2, idx1, idx0);
+}
+
+#if HWY_TARGET == HWY_RVV
+template <class D, HWY_IF_NOT_T_SIZE_D(D, 1)>
+HWY_INLINE VFromD<D> TblLookupPer4LaneBlkIdxInBlk(D d, const uint32_t idx3,
+                                                  const uint32_t idx2,
+                                                  const uint32_t idx1,
+                                                  const uint32_t idx0) {
+  const Rebind<uint8_t, decltype(d)> du8;
+  return PromoteTo(d,
+                   TblLookupPer4LaneBlkU8IdxInBlk(du8, idx3, idx2, idx1, idx0));
+}
+#else
+template <class D, HWY_IF_T_SIZE_D(D, 2)>
+HWY_INLINE VFromD<D> TblLookupPer4LaneBlkIdxInBlk(D d, const uint32_t idx3,
+                                                  const uint32_t idx2,
+                                                  const uint32_t idx1,
+                                                  const uint32_t idx0) {
+  const uint16_t u16_idx0 = static_cast<uint16_t>(idx0);
+  const uint16_t u16_idx1 = static_cast<uint16_t>(idx1);
+  const uint16_t u16_idx2 = static_cast<uint16_t>(idx2);
+  const uint16_t u16_idx3 = static_cast<uint16_t>(idx3);
+  alignas(16)
+      const uint16_t indices[8] = {u16_idx0, u16_idx1, u16_idx2, u16_idx3,
+                                   u16_idx0, u16_idx1, u16_idx2, u16_idx3};
+
+#if HWY_TARGET == HWY_NEON || HWY_TARGET == HWY_NEON_WITHOUT_AES
+  constexpr size_t kMinLanesToLoad = 4;
+#else
+  constexpr size_t kMinLanesToLoad = 8;
+#endif
+  constexpr size_t kNumToLoad = HWY_MAX(HWY_MAX_LANES_D(D), kMinLanesToLoad);
+  const CappedTag<uint16_t, kNumToLoad> d_load;
+
+  return ResizeBitCast(d, LoadDup128(d_load, indices));
+}
+
+template <class D, HWY_IF_T_SIZE_D(D, 4)>
+HWY_INLINE VFromD<D> TblLookupPer4LaneBlkIdxInBlk(D d, const uint32_t idx3,
+                                                  const uint32_t idx2,
+                                                  const uint32_t idx1,
+                                                  const uint32_t idx0) {
+  return Per4LaneBlkShufDupSet4xU32(d, idx3, idx2, idx1, idx0);
+}
+
+template <class D, HWY_IF_T_SIZE_D(D, 8)>
+HWY_INLINE VFromD<D> TblLookupPer4LaneBlkIdxInBlk(D d, const uint32_t idx3,
+                                                  const uint32_t idx2,
+                                                  const uint32_t idx1,
+                                                  const uint32_t idx0) {
+  const RebindToUnsigned<decltype(d)> du;
+  const Rebind<uint32_t, decltype(d)> du32;
+  return BitCast(d, PromoteTo(du, Per4LaneBlkShufDupSet4xU32(du32, idx3, idx2,
+                                                             idx1, idx0)));
+}
+#endif
+
+template <class D, HWY_PER_4_BLK_TBL_LOOKUP_LANES_ENABLE(D)>
+HWY_INLINE IndicesFromD<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
+                                                       const uint32_t idx2,
+                                                       const uint32_t idx1,
+                                                       const uint32_t idx0) {
+  const RebindToUnsigned<decltype(d)> du;
+  using TU = TFromD<decltype(du)>;
+  auto idx_in_blk = TblLookupPer4LaneBlkIdxInBlk(du, idx3, idx2, idx1, idx0);
+
+#if HWY_TARGET == HWY_EMU128
+  constexpr size_t kN = HWY_MAX_LANES_D(D);
+  if (kN < 4) {
+    idx_in_blk = And(idx_in_blk, Set(du, static_cast<TU>(kN - 1)));
+  }
+#endif
+
+#if HWY_TARGET == HWY_RVV
+  const auto blk_offsets = AndS(Iota0(du), static_cast<TU>(~TU{3}));
+#else
+  const auto blk_offsets =
+      And(Iota(du, TU{0}), Set(du, static_cast<TU>(~TU{3})));
+#endif
+  return IndicesFromVec(d, Add(idx_in_blk, blk_offsets));
+}
+
+template <class V, HWY_PER_4_BLK_TBL_LOOKUP_LANES_ENABLE(DFromV<V>)>
+HWY_INLINE V Per4LaneBlkShufDoTblLookup(V v, IndicesFromD<DFromV<V>> idx) {
+  return TableLookupLanes(v, idx);
+}
+
+#undef HWY_PER_4_BLK_TBL_LOOKUP_LANES_ENABLE
+
+template <class V>
+HWY_INLINE V TblLookupPer4LaneBlkShuf(V v, size_t idx3210) {
+  const DFromV<decltype(v)> d;
+  const uint32_t idx3 = static_cast<uint32_t>((idx3210 >> 6) & 3);
+  const uint32_t idx2 = static_cast<uint32_t>((idx3210 >> 4) & 3);
+  const uint32_t idx1 = static_cast<uint32_t>((idx3210 >> 2) & 3);
+  const uint32_t idx0 = static_cast<uint32_t>(idx3210 & 3);
+  const auto idx = TblLookupPer4LaneBlkShufIdx(d, idx3, idx2, idx1, idx0);
+  return Per4LaneBlkShufDoTblLookup(v, idx);
+}
 
 // The detail::Per4LaneBlockShuffle overloads that have the extra lane_size_tag
 // and vect_size_tag parameters are only called for vectors that have at
 // least 4 lanes (or scalable vectors that might possibly have 4 or more lanes)
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
-          size_t kLaneSize, size_t kVectSize, class V>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> idx_0_tag,
-                                  hwy::SizeTag<kIdx1> idx_1_tag,
-                                  hwy::SizeTag<kIdx2> idx_2_tag,
-                                  hwy::SizeTag<kIdx3> idx_3_tag,
-                                  hwy::SizeTag<kLaneSize> lane_size_tag,
+template <size_t kIdx3210, size_t kLaneSize, size_t kVectSize, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
+                                  hwy::SizeTag<kLaneSize> /*lane_size_tag*/,
                                   hwy::SizeTag<kVectSize> /*vect_size_tag*/,
                                   V v) {
-  const DFromV<decltype(v)> d;
-  const auto idx = Per4LaneBlockShufIdx(lane_size_tag, d, idx_0_tag, idx_1_tag,
-                                        idx_2_tag, idx_3_tag);
-  return Per4LaneBlockShufTblLookup(lane_size_tag, v, idx);
-}
-
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V,
-          HWY_IF_LANES_LE_D(DFromV<V>, 2)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> idx_0_tag,
-                                  hwy::SizeTag<kIdx1> idx_1_tag,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/, V v) {
-  return Per2LaneBlockShuffle(idx_0_tag, idx_1_tag, v);
-}
-
-template <size_t kIdx0, size_t kIdx1, class V, HWY_IF_LANES_GT_D(DFromV<V>, 2)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> idx_0_tag,
-                                  hwy::SizeTag<kIdx1> idx_1_tag,
-                                  hwy::SizeTag<kIdx0 + 2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx1 + 2> /*idx_3_tag*/, V v) {
-  return Per2LaneBlockShuffle(idx_0_tag, idx_1_tag, v);
+  return TblLookupPer4LaneBlkShuf(v, kIdx3210);
 }
 
 #if HWY_HAVE_FLOAT64
@@ -3323,26 +3432,26 @@ HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> Per4LaneBlockShufCastToWide(
   return BitCast(dw, v);
 }
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2),
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x1B> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse4(d, v);
+}
+
+template <class V,
           HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) |
                                         (HWY_HAVE_INTEGER64 ? (1 << 4) : 0))>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0> /*idx_0_tag*/,
-                                  hwy::SizeTag<1> /*idx_1_tag*/,
-                                  hwy::SizeTag<0> /*idx_2_tag*/,
-                                  hwy::SizeTag<1> /*idx_3_tag*/, V v) {
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x44> /*idx_3210_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const auto vw = Per4LaneBlockShufCastToWide(
       hwy::IsFloatTag<TFromV<V>>(), hwy::SizeTag<sizeof(TFromV<V>)>(), v);
   return BitCast(d, DupEven(vw));
 }
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2),
+template <class V,
           HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) |
                                         (HWY_HAVE_INTEGER64 ? (1 << 4) : 0))>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<2> /*idx_0_tag*/,
-                                  hwy::SizeTag<3> /*idx_1_tag*/,
-                                  hwy::SizeTag<0> /*idx_2_tag*/,
-                                  hwy::SizeTag<1> /*idx_3_tag*/, V v) {
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x4E> /*idx_3210_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const auto vw = Per4LaneBlockShufCastToWide(
       hwy::IsFloatTag<TFromV<V>>(), hwy::SizeTag<sizeof(TFromV<V>)>(), v);
@@ -3350,87 +3459,115 @@ HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<2> /*idx_0_tag*/,
   return BitCast(d, Reverse2(dw, vw));
 }
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2),
+#if HWY_MAX_BYTES >= 32
+template <class V, HWY_IF_T_SIZE_V(V, 8)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x4E> /*idx_3210_tag*/, V v) {
+  return SwapAdjacentBlocks(v);
+}
+#endif
+
+template <class V, HWY_IF_LANES_D(DFromV<V>, 4),
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x50> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return InterleaveLower(d, v, v);
+}
+
+template <class V, HWY_IF_T_SIZE_V(V, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x50> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return InterleaveLower(d, v, v);
+}
+
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xA0> /*idx_3210_tag*/, V v) {
+  return DupEven(v);
+}
+
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xB1> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return Reverse2(d, v);
+}
+
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xE4> /*idx_3210_tag*/, V v) {
+  return v;
+}
+
+template <class V,
           HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) |
                                         (HWY_HAVE_INTEGER64 ? (1 << 4) : 0))>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<2> /*idx_0_tag*/,
-                                  hwy::SizeTag<3> /*idx_1_tag*/,
-                                  hwy::SizeTag<2> /*idx_2_tag*/,
-                                  hwy::SizeTag<3> /*idx_3_tag*/, V v) {
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xEE> /*idx_3210_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const auto vw = Per4LaneBlockShufCastToWide(
       hwy::IsFloatTag<TFromV<V>>(), hwy::SizeTag<sizeof(TFromV<V>)>(), v);
   return BitCast(d, DupOdd(vw));
 }
 
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<3> /*idx_0_tag*/,
-                                  hwy::SizeTag<2> /*idx_1_tag*/,
-                                  hwy::SizeTag<1> /*idx_2_tag*/,
-                                  hwy::SizeTag<0> /*idx_3_tag*/, V v) {
-  const DFromV<decltype(v)> d;
-  return Reverse4(d, v);
+template <class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xF5> /*idx_3210_tag*/, V v) {
+  return DupOdd(v);
 }
 
-template <class V, HWY_IF_LANES_D(DFromV<V>, 4),
-          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2))>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0> /*idx_0_tag*/,
-                                  hwy::SizeTag<0> /*idx_1_tag*/,
-                                  hwy::SizeTag<1> /*idx_2_tag*/,
-                                  hwy::SizeTag<1> /*idx_3_tag*/, V v) {
-  const DFromV<decltype(v)> d;
-  return InterleaveLower(d, v, v);
-}
-
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2), HWY_IF_T_SIZE_V(V, 4)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0> /*idx_0_tag*/,
-                                  hwy::SizeTag<0> /*idx_1_tag*/,
-                                  hwy::SizeTag<1> /*idx_2_tag*/,
-                                  hwy::SizeTag<1> /*idx_3_tag*/, V v) {
-  const DFromV<decltype(v)> d;
-  return InterleaveLower(d, v, v);
-}
-
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 2), HWY_IF_T_SIZE_V(V, 4)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<2> /*idx_0_tag*/,
-                                  hwy::SizeTag<2> /*idx_1_tag*/,
-                                  hwy::SizeTag<3> /*idx_2_tag*/,
-                                  hwy::SizeTag<3> /*idx_3_tag*/, V v) {
+template <class V, HWY_IF_T_SIZE_V(V, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xFA> /*idx_3210_tag*/, V v) {
   const DFromV<decltype(v)> d;
   return InterleaveUpper(d, v, v);
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V,
-          HWY_IF_LANES_GT_D(DFromV<V>, 2),
-          hwy::EnableIf<(kIdx2 != kIdx0 + 2 || kIdx3 != kIdx1 + 2)>* = nullptr>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> idx_0_tag,
-                                  hwy::SizeTag<kIdx1> idx_1_tag,
-                                  hwy::SizeTag<kIdx2> idx_2_tag,
-                                  hwy::SizeTag<kIdx3> idx_3_tag, V v) {
+template <size_t kIdx3210, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> idx_3210_tag, V v) {
   const DFromV<decltype(v)> d;
-  return Per4LaneBlockShuffle(idx_0_tag, idx_1_tag, idx_2_tag, idx_3_tag,
-                              hwy::SizeTag<sizeof(TFromV<V>)>(),
+  return Per4LaneBlockShuffle(idx_3210_tag, hwy::SizeTag<sizeof(TFromV<V>)>(),
                               hwy::SizeTag<d.MaxBytes()>(), v);
 }
 
 }  // namespace detail
 #endif  // HWY_TARGET != HWY_SCALAR
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
+template <size_t kIdx3, size_t kIdx2, size_t kIdx1, size_t kIdx0, class V,
+          HWY_IF_LANES_D(DFromV<V>, 1)>
 HWY_API V Per4LaneBlockShuffle(V v) {
   static_assert(kIdx0 <= 3, "kIdx0 <= 3 must be true");
   static_assert(kIdx1 <= 3, "kIdx1 <= 3 must be true");
   static_assert(kIdx2 <= 3, "kIdx2 <= 3 must be true");
   static_assert(kIdx3 <= 3, "kIdx3 <= 3 must be true");
 
-#if HWY_TARGET == HWY_SCALAR
   return v;
-#else
-  return detail::Per4LaneBlockShuffle(
-      hwy::SizeTag<kIdx0>(), hwy::SizeTag<kIdx1>(), hwy::SizeTag<kIdx2>(),
-      hwy::SizeTag<kIdx3>(), v);
-#endif
 }
+
+#if HWY_TARGET != HWY_SCALAR
+template <size_t kIdx3, size_t kIdx2, size_t kIdx1, size_t kIdx0, class V,
+          HWY_IF_LANES_D(DFromV<V>, 2)>
+HWY_API V Per4LaneBlockShuffle(V v) {
+  static_assert(kIdx0 <= 3, "kIdx0 <= 3 must be true");
+  static_assert(kIdx1 <= 3, "kIdx1 <= 3 must be true");
+  static_assert(kIdx2 <= 3, "kIdx2 <= 3 must be true");
+  static_assert(kIdx3 <= 3, "kIdx3 <= 3 must be true");
+
+  constexpr bool isReverse2 = (kIdx0 == 1 || kIdx1 == 0) && (kIdx0 != kIdx1);
+  constexpr size_t kPer2BlkIdx0 = (kIdx0 <= 1) ? kIdx0 : (isReverse2 ? 1 : 0);
+  constexpr size_t kPer2BlkIdx1 = (kIdx1 <= 1) ? kIdx1 : (isReverse2 ? 0 : 1);
+
+  constexpr size_t kIdx10 = (kPer2BlkIdx1 << 1) | kPer2BlkIdx0;
+  static_assert(kIdx10 <= 3, "kIdx10 <= 3 must be true");
+  return detail::Per2LaneBlockShuffle(hwy::SizeTag<kIdx10>(), v);
+}
+
+template <size_t kIdx3, size_t kIdx2, size_t kIdx1, size_t kIdx0, class V,
+          HWY_IF_LANES_GT_D(DFromV<V>, 2)>
+HWY_API V Per4LaneBlockShuffle(V v) {
+  static_assert(kIdx0 <= 3, "kIdx0 <= 3 must be true");
+  static_assert(kIdx1 <= 3, "kIdx1 <= 3 must be true");
+  static_assert(kIdx2 <= 3, "kIdx2 <= 3 must be true");
+  static_assert(kIdx3 <= 3, "kIdx3 <= 3 must be true");
+
+  constexpr size_t kIdx3210 =
+      (kIdx3 << 6) | (kIdx2 << 4) | (kIdx1 << 2) | kIdx0;
+  return detail::Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210>(), v);
+}
+#endif
 
 // ================================================== Operator wrapper
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3523,6 +3523,12 @@ HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x50> /*idx_3210_tag*/, V v) {
   return InterleaveLower(d, v, v);
 }
 
+template <class V, HWY_IF_LANES_D(DFromV<V>, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0x88> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return ConcatEven(d, v, v);
+}
+
 template <class V>
 HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xA0> /*idx_3210_tag*/, V v) {
   return DupEven(v);
@@ -3532,6 +3538,12 @@ template <class V>
 HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xB1> /*idx_3210_tag*/, V v) {
   const DFromV<decltype(v)> d;
   return Reverse2(d, v);
+}
+
+template <class V, HWY_IF_LANES_D(DFromV<V>, 4)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<0xDD> /*idx_3210_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  return ConcatOdd(d, v, v);
 }
 
 template <class V>

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3402,7 +3402,7 @@ HWY_INLINE IndicesFromD<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
   using TU = TFromD<decltype(du)>;
   auto idx_in_blk = TblLookupPer4LaneBlkIdxInBlk(du, idx3, idx2, idx1, idx0);
 
-#if HWY_TARGET == HWY_EMU128
+#if HWY_TARGET == HWY_EMU128 || HWY_TARGET <= HWY_AVX3
   constexpr size_t kN = HWY_MAX_LANES_D(D);
   if (kN < 4) {
     idx_in_blk = And(idx_in_blk, Set(du, static_cast<TU>(kN - 1)));

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3402,12 +3402,10 @@ HWY_INLINE IndicesFromD<D> TblLookupPer4LaneBlkShufIdx(D d, const uint32_t idx3,
   using TU = TFromD<decltype(du)>;
   auto idx_in_blk = TblLookupPer4LaneBlkIdxInBlk(du, idx3, idx2, idx1, idx0);
 
-#if HWY_TARGET == HWY_EMU128 || HWY_TARGET <= HWY_AVX3
   constexpr size_t kN = HWY_MAX_LANES_D(D);
   if (kN < 4) {
     idx_in_blk = And(idx_in_blk, Set(du, static_cast<TU>(kN - 1)));
   }
-#endif
 
 #if HWY_TARGET == HWY_RVV
   const auto blk_offsets = AndS(Iota0(du), static_cast<TU>(~TU{3}));

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2419,17 +2419,58 @@ HWY_API VFromD<D> OrderedTruncate2To(D d, V a, V b) {
 
 // ------------------------------ DupEven (InterleaveLower)
 
-template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
-HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
-  return Vec128<T, N>{vec_mergee(v.raw, v.raw)};
+template <typename T>
+HWY_API Vec128<T, 1> DupEven(Vec128<T, 1> v) {
+  return v;
 }
 
-template <typename T, size_t N, HWY_IF_T_SIZE(T, 8)>
-HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
+template <typename T>
+HWY_API Vec128<T, 2> DupEven(Vec128<T, 2> v) {
   return InterleaveLower(DFromV<decltype(v)>(), v, v);
 }
 
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
+HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  constexpr __vector unsigned char kShuffle = {0, 0, 2,  2,  4,  4,  6,  6,
+                                               8, 8, 10, 10, 12, 12, 14, 14};
+  return TableLookupBytes(v, BitCast(d, VFromD<decltype(du8)>{kShuffle}));
+}
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
+HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  constexpr __vector unsigned char kShuffle = {0, 1, 0, 1, 4,  5,  4,  5,
+                                               8, 9, 8, 9, 12, 13, 12, 13};
+  return TableLookupBytes(v, BitCast(d, VFromD<decltype(du8)>{kShuffle}));
+}
+
+template <typename T, HWY_IF_T_SIZE(T, 4)>
+HWY_API Vec128<T> DupEven(Vec128<T> v) {
+  return Vec128<T>{vec_mergee(v.raw, v.raw)};
+}
+
 // ------------------------------ DupOdd (InterleaveUpper)
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
+HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  constexpr __vector unsigned char kShuffle = {1, 1, 3,  3,  5,  5,  7,  7,
+                                               9, 9, 11, 11, 13, 13, 15, 15};
+  return TableLookupBytes(v, BitCast(d, VFromD<decltype(du8)>{kShuffle}));
+}
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
+HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  constexpr __vector unsigned char kShuffle = {2,  3,  2,  3,  6,  7,  6,  7,
+                                               10, 11, 10, 11, 14, 15, 14, 15};
+  return TableLookupBytes(v, BitCast(d, VFromD<decltype(du8)>{kShuffle}));
+}
 
 template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2119,6 +2119,28 @@ HWY_API VFromD<DW> ZipUpper(DW dw, V a, V b) {
   return BitCast(dw, InterleaveUpper(D(), a, b));
 }
 
+// ------------------------------ Per4LaneBlkShufDupSet4xU32
+
+// Used by hwy/ops/generic_ops-inl.h to implement Per4LaneBlockShuffle
+namespace detail {
+
+#ifdef HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#undef HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#else
+#define HWY_NATIVE_PER4LANEBLKSHUF_DUP32
+#endif
+
+template <class D>
+HWY_INLINE VFromD<D> Per4LaneBlkShufDupSet4xU32(D d, const uint32_t x3,
+                                                const uint32_t x2,
+                                                const uint32_t x1,
+                                                const uint32_t x0) {
+  const __vector unsigned int raw = {x0, x1, x2, x3};
+  return ResizeBitCast(d, Vec128<uint32_t>{raw});
+}
+
+}  // namespace detail
+
 // ================================================== COMBINE
 
 // ------------------------------ Combine (InterleaveLower)

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -40,6 +40,31 @@ constexpr size_t MLenFromD(Simd<T, N, kPow2> /* tag */) {
   return HWY_MIN(64, sizeof(T) * 8 * 8 / detail::ScaleByPower(8, kPow2));
 }
 
+namespace detail {
+
+template <class D>
+class AdjustSimdTagToMinVecPow2_t {};
+
+template <typename T, size_t N, int kPow2>
+class AdjustSimdTagToMinVecPow2_t<Simd<T, N, kPow2>> {
+ private:
+  using D = Simd<T, N, kPow2>;
+  static constexpr int kMinVecPow2 =
+      -3 + static_cast<int>(FloorLog2(sizeof(T)));
+  static constexpr size_t kNumMaxLanes = HWY_MAX_LANES_D(D);
+  static constexpr int kNewPow2 = HWY_MAX(kPow2, kMinVecPow2);
+  static constexpr size_t kNewN = D::template NewN<kNewPow2, kNumMaxLanes>();
+
+ public:
+  using type = Simd<T, kNewN, kNewPow2>;
+};
+
+template <class D>
+using AdjustSimdTagToMinVecPow2 =
+    typename AdjustSimdTagToMinVecPow2_t<RemoveConst<D>>::type;
+
+}  // namespace detail
+
 // ================================================== MACROS
 
 // Generate specializations and function definitions using X macros. Although
@@ -2572,54 +2597,24 @@ HWY_API VFromD<D> Reverse(D /* tag */, VFromD<D> v) {
 // Shifting and adding requires fewer instructions than blending, but casting to
 // u32 only works for LMUL in [1/2, 8].
 
-template <class D, HWY_IF_T_SIZE_D(D, 1), HWY_IF_POW2_GT_D(D, -3)>
+template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Repartition<uint16_t, D> du16;
-  return BitCast(d, RotateRight<8>(BitCast(du16, v)));
-}
-// For LMUL < 1/4, we can extend and then truncate.
-template <class D, HWY_IF_T_SIZE_D(D, 1), HWY_IF_POW2_LE_D(D, -3)>
-HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Twice<decltype(d)> d2;
-  const Repartition<uint16_t, decltype(d2)> du16;
-  const auto vx = detail::Ext(d2, v);
-  const auto rx = BitCast(d2, RotateRight<8>(BitCast(du16, vx)));
-  return detail::Trunc(rx);
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint16_t, D>> du16;
+  return ResizeBitCast(d, RotateRight<8>(ResizeBitCast(du16, v)));
 }
 
-template <class D, HWY_IF_T_SIZE_D(D, 2), HWY_IF_POW2_GT_D(D, -2)>
+template <class D, HWY_IF_T_SIZE_D(D, 2)>
 HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Repartition<uint32_t, D> du32;
-  return BitCast(d, RotateRight<16>(BitCast(du32, v)));
-}
-// For LMUL < 1/2, we can extend and then truncate.
-template <class D, HWY_IF_T_SIZE_D(D, 2), HWY_IF_POW2_LE_D(D, -2)>
-HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Twice<decltype(d)> d2;
-  const Twice<decltype(d2)> d4;
-  const Repartition<uint32_t, decltype(d4)> du32;
-  const auto vx = detail::Ext(d4, detail::Ext(d2, v));
-  const auto rx = BitCast(d4, RotateRight<16>(BitCast(du32, vx)));
-  return detail::Trunc(detail::Trunc(rx));
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint32_t, D>> du32;
+  return ResizeBitCast(d, RotateRight<16>(ResizeBitCast(du32, v)));
 }
 
 // Shifting and adding requires fewer instructions than blending, but casting to
 // u64 does not work for LMUL < 1.
-template <class D, HWY_IF_T_SIZE_D(D, 4), HWY_IF_POW2_GT_D(D, -1)>
+template <class D, HWY_IF_T_SIZE_D(D, 4)>
 HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Repartition<uint64_t, decltype(d)> du64;
-  return BitCast(d, RotateRight<32>(BitCast(du64, v)));
-}
-
-// For fractions, we can extend and then truncate.
-template <class D, HWY_IF_T_SIZE_D(D, 4), HWY_IF_POW2_LE_D(D, -1)>
-HWY_API VFromD<D> Reverse2(D d, const VFromD<D> v) {
-  const Twice<decltype(d)> d2;
-  const Twice<decltype(d2)> d4;
-  const Repartition<uint64_t, decltype(d4)> du64;
-  const auto vx = detail::Ext(d4, detail::Ext(d2, v));
-  const auto rx = BitCast(d4, RotateRight<32>(BitCast(du64, vx)));
-  return detail::Trunc(detail::Trunc(rx));
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint64_t, D>> du64;
+  return ResizeBitCast(d, RotateRight<32>(ResizeBitCast(du64, v)));
 }
 
 template <class D, class V = VFromD<D>, HWY_IF_T_SIZE_D(D, 8)>
@@ -2633,8 +2628,8 @@ HWY_API V Reverse2(D /* tag */, const V v) {
 
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_API VFromD<D> Reverse4(D d, const VFromD<D> v) {
-  const Repartition<uint16_t, D> du16;
-  return BitCast(d, Reverse2(du16, BitCast(du16, Reverse2(d, v))));
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint16_t, D>> du16;
+  return ResizeBitCast(d, Reverse2(du16, ResizeBitCast(du16, Reverse2(d, v))));
 }
 
 template <class D, HWY_IF_NOT_T_SIZE_D(D, 1)>
@@ -2648,8 +2643,8 @@ HWY_API VFromD<D> Reverse4(D d, const VFromD<D> v) {
 
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_API VFromD<D> Reverse8(D d, const VFromD<D> v) {
-  const Repartition<uint32_t, D> du32;
-  return BitCast(d, Reverse2(du32, BitCast(du32, Reverse4(d, v))));
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint32_t, D>> du32;
+  return ResizeBitCast(d, Reverse2(du32, ResizeBitCast(du32, Reverse4(d, v))));
 }
 
 template <class D, HWY_IF_NOT_T_SIZE_D(D, 1)>
@@ -2662,13 +2657,13 @@ HWY_API VFromD<D> Reverse8(D d, const VFromD<D> v) {
 // ------------------------------ ReverseBlocks (Reverse, Shuffle01)
 template <class D, class V = VFromD<D>>
 HWY_API V ReverseBlocks(D d, V v) {
-  const Repartition<uint64_t, D> du64;
+  const detail::AdjustSimdTagToMinVecPow2<Repartition<uint64_t, D>> du64;
   const size_t N = Lanes(du64);
   const auto rev =
       detail::ReverseSubS(detail::Iota0(du64), static_cast<uint64_t>(N - 1));
   // Swap lo/hi u64 within each block
   const auto idx = detail::XorS(rev, 1);
-  return BitCast(d, TableLookupLanes(BitCast(du64, v), idx));
+  return ResizeBitCast(d, TableLookupLanes(ResizeBitCast(du64, v), idx));
 }
 
 // ------------------------------ Compress

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -3000,43 +3000,46 @@ HWY_API VFromD<DW> ZipUpper(DW dw, V a, V b) {
 // ------------------------------ Per4LaneBlockShuffle
 namespace detail {
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
-          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, size_t kVectSize, class V,
+          HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<1> /*lane_size_tag*/,
                                   hwy::SizeTag<kVectSize> /*vect_size_tag*/,
                                   V v) {
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
   return V{wasm_i8x16_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3,
                               kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4,
                               kIdx0 + 8, kIdx1 + 8, kIdx2 + 8, kIdx3 + 8,
                               kIdx0 + 12, kIdx1 + 12, kIdx2 + 12, kIdx3 + 12)};
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
-          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, size_t kVectSize, class V,
+          HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<2> /*lane_size_tag*/,
                                   hwy::SizeTag<kVectSize> /*vect_size_tag*/,
                                   V v) {
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
   return V{wasm_i16x8_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3,
                               kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4)};
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
-          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, size_t kVectSize, class V,
+          HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<4> /*lane_size_tag*/,
                                   hwy::SizeTag<kVectSize> /*vect_size_tag*/,
                                   V v) {
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
   return V{wasm_i32x4_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3)};
 }
 

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -2997,6 +2997,51 @@ HWY_API VFromD<DW> ZipUpper(DW dw, V a, V b) {
   return BitCast(dw, InterleaveUpper(D(), a, b));
 }
 
+// ------------------------------ Per4LaneBlockShuffle
+namespace detail {
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
+          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<1> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  return V{wasm_i8x16_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3,
+                              kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4,
+                              kIdx0 + 8, kIdx1 + 8, kIdx2 + 8, kIdx3 + 8,
+                              kIdx0 + 12, kIdx1 + 12, kIdx2 + 12, kIdx3 + 12)};
+}
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
+          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<2> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  return V{wasm_i16x8_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3,
+                              kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4)};
+}
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3,
+          size_t kVectSize, class V, HWY_IF_LANES_LE(kVectSize, 16)>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<4> /*lane_size_tag*/,
+                                  hwy::SizeTag<kVectSize> /*vect_size_tag*/,
+                                  V v) {
+  return V{wasm_i32x4_shuffle(v.raw, v.raw, kIdx0, kIdx1, kIdx2, kIdx3)};
+}
+
+}  // namespace detail
+
 // ================================================== COMBINE
 
 // ------------------------------ Combine (InterleaveLower)
@@ -3176,6 +3221,17 @@ HWY_API Vec128<T, 2> ConcatEven(D d, Vec128<T, 2> hi, Vec128<T, 2> lo) {
 
 // ------------------------------ DupEven (InterleaveLower)
 
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
+HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
+  return Vec128<T, N>{wasm_i8x16_shuffle(v.raw, v.raw, 0, 0, 2, 2, 4, 4, 6, 6,
+                                         8, 8, 10, 10, 12, 12, 14, 14)};
+}
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
+HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
+  return Vec128<T, N>{wasm_i16x8_shuffle(v.raw, v.raw, 0, 0, 2, 2, 4, 4, 6, 6)};
+}
+
 template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_API Vec128<T, N> DupEven(Vec128<T, N> v) {
   return Vec128<T, N>{wasm_i32x4_shuffle(v.raw, v.raw, 0, 0, 2, 2)};
@@ -3187,6 +3243,17 @@ HWY_API Vec128<T, N> DupEven(const Vec128<T, N> v) {
 }
 
 // ------------------------------ DupOdd (InterleaveUpper)
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
+HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {
+  return Vec128<T, N>{wasm_i8x16_shuffle(v.raw, v.raw, 1, 1, 3, 3, 5, 5, 7, 7,
+                                         9, 9, 11, 11, 13, 13, 15, 15)};
+}
+
+template <typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
+HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {
+  return Vec128<T, N>{wasm_i16x8_shuffle(v.raw, v.raw, 1, 1, 3, 3, 5, 5, 7, 7)};
+}
 
 template <typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_API Vec128<T, N> DupOdd(Vec128<T, N> v) {

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1270,16 +1270,18 @@ HWY_API Vec256<T> ReverseBlocks(D /* tag */, const Vec256<T> v) {
 // ------------------------------ Per4LaneBlockShuffle
 namespace detail {
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<1> /*lane_size_tag*/,
                                   hwy::SizeTag<32> /*vect_size_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const Half<decltype(d)> dh;
   using VH = VFromD<decltype(dh)>;
+
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
 
   V ret;
   ret.v0 = VH{wasm_i8x16_shuffle(
@@ -1293,16 +1295,18 @@ HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
   return ret;
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<2> /*lane_size_tag*/,
                                   hwy::SizeTag<32> /*vect_size_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const Half<decltype(d)> dh;
   using VH = VFromD<decltype(dh)>;
+
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
 
   V ret;
   ret.v0 = VH{wasm_i16x8_shuffle(v.v0.raw, v.v0.raw, kIdx0, kIdx1, kIdx2, kIdx3,
@@ -1312,16 +1316,18 @@ HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
   return ret;
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<4> /*lane_size_tag*/,
                                   hwy::SizeTag<32> /*vect_size_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const Half<decltype(d)> dh;
   using VH = VFromD<decltype(dh)>;
+
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
 
   V ret;
   ret.v0 =
@@ -1331,16 +1337,18 @@ HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
   return ret;
 }
 
-template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
-HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
-                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
-                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
-                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+template <size_t kIdx3210, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx3210> /*idx_3210_tag*/,
                                   hwy::SizeTag<8> /*lane_size_tag*/,
                                   hwy::SizeTag<32> /*vect_size_tag*/, V v) {
   const DFromV<decltype(v)> d;
   const Half<decltype(d)> dh;
   using VH = VFromD<decltype(dh)>;
+
+  constexpr int kIdx3 = static_cast<int>((kIdx3210 >> 6) & 3);
+  constexpr int kIdx2 = static_cast<int>((kIdx3210 >> 4) & 3);
+  constexpr int kIdx1 = static_cast<int>((kIdx3210 >> 2) & 3);
+  constexpr int kIdx0 = static_cast<int>(kIdx3210 & 3);
 
   V ret;
   ret.v0 = VH{wasm_i64x2_shuffle(v.v0.raw, v.v1.raw, kIdx0, kIdx1)};

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1267,6 +1267,89 @@ HWY_API Vec256<T> ReverseBlocks(D /* tag */, const Vec256<T> v) {
   return SwapAdjacentBlocks(v);  // 2 blocks, so Swap = Reverse
 }
 
+// ------------------------------ Per4LaneBlockShuffle
+namespace detail {
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<1> /*lane_size_tag*/,
+                                  hwy::SizeTag<32> /*vect_size_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  using VH = VFromD<decltype(dh)>;
+
+  V ret;
+  ret.v0 = VH{wasm_i8x16_shuffle(
+      v.v0.raw, v.v0.raw, kIdx0, kIdx1, kIdx2, kIdx3, kIdx0 + 4, kIdx1 + 4,
+      kIdx2 + 4, kIdx3 + 4, kIdx0 + 8, kIdx1 + 8, kIdx2 + 8, kIdx3 + 8,
+      kIdx0 + 12, kIdx1 + 12, kIdx2 + 12, kIdx3 + 12)};
+  ret.v1 = VH{wasm_i8x16_shuffle(
+      v.v1.raw, v.v1.raw, kIdx0, kIdx1, kIdx2, kIdx3, kIdx0 + 4, kIdx1 + 4,
+      kIdx2 + 4, kIdx3 + 4, kIdx0 + 8, kIdx1 + 8, kIdx2 + 8, kIdx3 + 8,
+      kIdx0 + 12, kIdx1 + 12, kIdx2 + 12, kIdx3 + 12)};
+  return ret;
+}
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<2> /*lane_size_tag*/,
+                                  hwy::SizeTag<32> /*vect_size_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  using VH = VFromD<decltype(dh)>;
+
+  V ret;
+  ret.v0 = VH{wasm_i16x8_shuffle(v.v0.raw, v.v0.raw, kIdx0, kIdx1, kIdx2, kIdx3,
+                                 kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4)};
+  ret.v1 = VH{wasm_i16x8_shuffle(v.v1.raw, v.v1.raw, kIdx0, kIdx1, kIdx2, kIdx3,
+                                 kIdx0 + 4, kIdx1 + 4, kIdx2 + 4, kIdx3 + 4)};
+  return ret;
+}
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<4> /*lane_size_tag*/,
+                                  hwy::SizeTag<32> /*vect_size_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  using VH = VFromD<decltype(dh)>;
+
+  V ret;
+  ret.v0 =
+      VH{wasm_i32x4_shuffle(v.v0.raw, v.v0.raw, kIdx0, kIdx1, kIdx2, kIdx3)};
+  ret.v1 =
+      VH{wasm_i32x4_shuffle(v.v1.raw, v.v1.raw, kIdx0, kIdx1, kIdx2, kIdx3)};
+  return ret;
+}
+
+template <size_t kIdx0, size_t kIdx1, size_t kIdx2, size_t kIdx3, class V>
+HWY_INLINE V Per4LaneBlockShuffle(hwy::SizeTag<kIdx0> /*idx_0_tag*/,
+                                  hwy::SizeTag<kIdx1> /*idx_1_tag*/,
+                                  hwy::SizeTag<kIdx2> /*idx_2_tag*/,
+                                  hwy::SizeTag<kIdx3> /*idx_3_tag*/,
+                                  hwy::SizeTag<8> /*lane_size_tag*/,
+                                  hwy::SizeTag<32> /*vect_size_tag*/, V v) {
+  const DFromV<decltype(v)> d;
+  const Half<decltype(d)> dh;
+  using VH = VFromD<decltype(dh)>;
+
+  V ret;
+  ret.v0 = VH{wasm_i64x2_shuffle(v.v0.raw, v.v1.raw, kIdx0, kIdx1)};
+  ret.v1 = VH{wasm_i64x2_shuffle(v.v0.raw, v.v1.raw, kIdx2, kIdx3)};
+  return ret;
+}
+
+}  // namespace detail
+
 // ================================================== CONVERT
 
 // ------------------------------ Promotions (part w/ narrow lanes -> full)

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -6515,6 +6515,7 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 /* tag */, V16 a, V16 b) {
   return VFromD<D32>{_mm_madd_epi16(a.raw, b.raw)};
 }
 
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ShiftLeft)
 
 // Generic for all vector lengths.

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -6486,7 +6486,8 @@ HWY_INLINE Vec256<T> SumOfLanes(hwy::SizeTag<4> /* tag */,
   return v20_31_20_31 + v31_20_31_20;
 }
 template <typename T>
-HWY_INLINE T ReduceSum(hwy::SizeTag<4> /* tag */, const Vec256<T> v3210) {
+HWY_INLINE T ReduceSum(hwy::SizeTag<4> /* tag */,
+                                const Vec256<T> v3210) {
   return GetLane(SumOfLanes(hwy::SizeTag<4>(), v3210));
 }
 template <typename T>
@@ -6513,7 +6514,8 @@ HWY_INLINE Vec256<T> SumOfLanes(hwy::SizeTag<8> /* tag */,
   return v10 + v01;
 }
 template <typename T>
-HWY_INLINE T ReduceSum(hwy::SizeTag<8> /* tag */, const Vec256<T> v10) {
+HWY_INLINE T ReduceSum(hwy::SizeTag<8> /* tag */,
+                                const Vec256<T> v10) {
   return GetLane(SumOfLanes(hwy::SizeTag<8>(), v10));
 }
 template <typename T>
@@ -6529,7 +6531,8 @@ HWY_INLINE Vec256<T> MaxOfLanes(hwy::SizeTag<8> /* tag */,
   return Max(v10, v01);
 }
 
-HWY_API uint16_t ReduceSum(hwy::SizeTag<2> /* tag */, Vec256<uint16_t> v) {
+HWY_API uint16_t ReduceSum(hwy::SizeTag<2> /* tag */,
+                                    Vec256<uint16_t> v) {
   const Full256<uint16_t> d;
   const RepartitionToWide<decltype(d)> d32;
   const auto even = And(BitCast(d32, v), Set(d32, 0xFFFF));
@@ -6544,7 +6547,8 @@ HWY_API Vec256<uint16_t> SumOfLanes(hwy::SizeTag<2> /* tag */,
   return Set(d, ReduceSum(hwy::SizeTag<2>(), v));
 }
 
-HWY_API int16_t ReduceSum(hwy::SizeTag<2> /* tag */, Vec256<int16_t> v) {
+HWY_API int16_t ReduceSum(hwy::SizeTag<2> /* tag */,
+                                   Vec256<int16_t> v) {
   const Full256<int16_t> d;
   const RepartitionToWide<decltype(d)> d32;
   // Sign-extend

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5558,7 +5558,7 @@ HWY_API float ReduceSum(D, Vec512<float> v) {
 }
 template <class D>
 HWY_API double ReduceSum(D, Vec512<double> v) {
-  return _mm512_reduce_add_pd(v.raw);
+  return  _mm512_reduce_add_pd(v.raw);
 }
 template <class D>
 HWY_API uint16_t ReduceSum(D d, Vec512<uint16_t> v) {

--- a/hwy/tests/swizzle_test.cc
+++ b/hwy/tests/swizzle_test.cc
@@ -401,7 +401,7 @@ class TestPer4LaneBlockShuffle {
 
 #if HWY_TARGET != HWY_SCALAR
   template <class D>
-  static HWY_NOINLINE void TestTblLookupPer4LaneBlkShufIdx(
+  static HWY_NOINLINE void TestTblLookupPer4LaneBlkShuf(
       D d, const size_t N, const TFromD<D>* HWY_RESTRICT src_lanes,
       TFromD<D>* HWY_RESTRICT expected) {
     const auto v = Load(d, src_lanes);
@@ -435,7 +435,7 @@ class TestPer4LaneBlockShuffle {
       TFromD<D>* HWY_RESTRICT expected) {
     Store(v, d, src_lanes);
 #if HWY_TARGET != HWY_SCALAR
-    TestTblLookupPer4LaneBlkShufIdx(d, N, src_lanes, expected);
+    TestTblLookupPer4LaneBlkShuf(d, N, src_lanes, expected);
 #endif
     DoTestPer4LaneBlkShuffle<0, 1, 2, 3>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<0, 1, 3, 2>(d, N, v, src_lanes, expected);

--- a/hwy/tests/swizzle_test.cc
+++ b/hwy/tests/swizzle_test.cc
@@ -448,12 +448,14 @@ class TestPer4LaneBlockShuffle {
     DoTestPer4LaneBlkShuffle<1, 2, 1, 3>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<1, 1, 0, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<2, 0, 1, 3>(d, N, v, src_lanes, expected);
+    DoTestPer4LaneBlkShuffle<2, 0, 2, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<2, 1, 2, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<2, 2, 0, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<2, 3, 0, 1>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<2, 3, 3, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<3, 0, 2, 1>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<3, 1, 0, 3>(d, N, v, src_lanes, expected);
+    DoTestPer4LaneBlkShuffle<3, 1, 3, 1>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<3, 2, 1, 0>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<3, 2, 3, 2>(d, N, v, src_lanes, expected);
     DoTestPer4LaneBlkShuffle<3, 3, 0, 1>(d, N, v, src_lanes, expected);

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -554,7 +554,7 @@ class ForPartialVectors {
 
 // ForPartialFixedOrFullScalableVectors calls Test for each D where
 // MaxLanes(D()) == MaxLanes(DFromV<VFromD<D>>())
-#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+#if HWY_HAVE_SCALABLE
 template <class Test>
 class ForPartialFixedOrFullScalableVectors {
   mutable bool called_ = false;
@@ -579,6 +579,10 @@ class ForPartialFixedOrFullScalableVectors {
     detail::ForeachPow2<T, kMinPow2, kMaxPow2, true, Test>::Do(1);
   }
 };
+#elif HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+template <class Test>
+using ForPartialFixedOrFullScalableVectors =
+    ForGEVectors<HWY_MAX_BYTES * 8, Test>;
 #else
 template <class Test>
 using ForPartialFixedOrFullScalableVectors = ForPartialVectors<Test>;


### PR DESCRIPTION
Added DupEven and DupOdd for I8/U8/I16/U16 vector types.

Also fixed issues on RVV where Reverse2, Reverse4, Reverse8, and ReverseBlocks sometimes fail to compile for vector types that have a fractional LMUL.

Also added a new Per4LaneBlockShuffle operation as Per4LaneBlockShuffle is usually more efficient than TableLookupBytes or TableLookupLanes for I16/U16/I32/U32/F32/I64/U64/F64 vectors.

Per4LaneBlockShuffle is equivalent to SSE2 `_mm_shufflelo_epi16(v, _MM_SHUFFLE(kIdx3, kIdx2, kIdx1, kIdx0))`, SSE2 `_mm_shuffle_epi32(v, _MM_SHUFFLE(kIdx3, kIdx2, kIdx1, kIdx0))`, and AVX2 `_mm256_permute4x64_epi64(v, _MM_SHUFFLE(kIdx3, kIdx2, kIdx1, kIdx0))`.

In the case of I64/U64/F64 vectors that have 4 or more lanes, the Per4LaneBlockShuffle operation does a per 256-bit block shuffle of `v` (same behavior as AVX2 `_mm256_permute4x64_epi64` and AVX512 `_mm512_permutex_epi64`).

Also added <code>ForPartialFixedOrFullScalableVectors&lt;Test&gt;</code> in hwy/tests/test_util-inl.h, which only calls `Test` for for each `D` where
`MaxLanes(D()) == MaxLanes(DFromV<VFromD<D>>())`.

ForPartialFixedOrFullScalableVectors allows a test to be invoked for all of the possible vector types for a lane type `T`, but skips over cases where `MaxLanes(D()) < MaxLanes(DFromV<VFromD<D>>())`, which is possible on RVV/SVE targets.

`ForAllTypes(ForPartialVectors<TestPer4LaneBlockShuffle>())` causes the compilation of hwy/tests/swizzle_test.cc to get stuck on the HWY_RVV target, but replacing `ForAllTypes(ForPartialVectors<TestPer4LaneBlockShuffle>())` with `ForAllTypes(ForPartialFixedOrFullScalableVectors<TestPer4LaneBlockShuffle>())` fixes the problem on the HWY_RVV target.

On targets where `MaxLanes(D()) == MaxLanes(DFromV<VFromD<D>>())` is always true, `ForPartialFixedOrFullScalableVectors<Test>` is simply a typedef for `ForPartialVectors<Test>`.