### PR TITLE
Fix compilation error with bench_sort.cc on Clang 6

### DIFF
--- a/hwy/contrib/sort/bench_sort.cc
+++ b/hwy/contrib/sort/bench_sort.cc
@@ -87,7 +87,7 @@ HWY_NOINLINE void BenchAllColdSort() {
 #if VQSORT_ENABLED
   HWY_ASSERT(GetGeneratorState() != nullptr);  // vqsort
 #endif
-  RandomState rng(Unpredictable1() * 129);  // this test
+  RandomState rng(static_cast<uint64_t>(Unpredictable1() * 129));  // this test
 
   using T = uint64_t;
   constexpr size_t kSize = 10 * 1000;


### PR DESCRIPTION
Fixed issue where bench_sort.cc failed to compile on Clang 6 as the RandomState constructor takes a uint64_t argument.