### PR TITLE
Added InsertBlock, ExtractBlock, BroadcastBlock, BroadcastLane, and NumOfBlocks

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -415,10 +415,19 @@ time-critical code:
     `kBlock` must be in `[0, DFromV<V>().MaxBlocks())`.
 
 *   <code>V **InsertBlock**&lt;int kBlock&gt;(V v, Vec<BlockDFromD<DFromV<V>>>
-    blk_to_insert)</code>: Inserts `blk_to_insert` at lane offset
-    `kBlock * (16 / sizeof(TFromV<V>))`.
+    blk_to_insert)</code>: Inserts `blk_to_insert`, with `blk_to_insert[i]`
+    inserted into lane `kBlock * (16 / sizeof(TFromV<V>)) + i` of the result
+    vector, if `kBlock * 16 < Lanes(DFromV<V>()) * sizeof(TFromV<V>)` is true.
+
+    Otherwise, returns `v` if `kBlock * 16` is greater than or equal to
+    `Lanes(DFromV<V>()) * sizeof(TFromV<V>)`.
 
     `kBlock` must be in `[0, DFromV<V>().MaxBlocks())`.
+
+*   <code>size_t **NumOfBlocks**(D d)</code>: Returns the number of 16-byte
+    blocks if `Lanes(d) * sizeof(TFromD<D>)` is greater than or equal to 16.
+
+    Otherwise, returns 1 if `Lanes(d) * sizeof(TFromD<D>)` is less than 16.
 
 ### Printing
 
@@ -1529,8 +1538,9 @@ instead because they are more general:
 
 *   <code>V **BroadcastBlock**&lt;int kBlock&gt;(V v)</code>: broadcasts the
     16-byte block of vector `v` at index `kBlock` to all of the blocks of the
-    result vector if `Lanes(DFromV<V>()) > (16 / TFromV<V>)` is true.
-    Otherwise, if `Lanes(DFromV<V>()) <= (16 / TFromV<V>)` is true, returns `v`.
+    result vector if `Lanes(DFromV<V>()) * sizeof(TFromV<V>) > 16` is true.
+    Otherwise, if `Lanes(DFromV<V>()) * sizeof(TFromV<V>) <= 16` is true,
+    returns `v`.
 
     `kBlock` must be in `[0, DFromV<V>().MaxBlocks())`.
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -424,8 +424,8 @@ time-critical code:
 
     `kBlock` must be in `[0, DFromV<V>().MaxBlocks())`.
 
-*   <code>size_t **NumOfBlocks**(D d)</code>: Returns the number of 16-byte
-    blocks if `Lanes(d) * sizeof(TFromD<D>)` is greater than or equal to 16.
+*   <code>size_t **Blocks**(D d)</code>: Returns the number of 16-byte blocks
+    if `Lanes(d) * sizeof(TFromD<D>)` is greater than or equal to 16.
 
     Otherwise, returns 1 if `Lanes(d) * sizeof(TFromD<D>)` is less than 16.
 

--- a/hwy/highway_test.cc
+++ b/hwy/highway_test.cc
@@ -464,6 +464,56 @@ HWY_NOINLINE void TestAllDFromV() {
   ForAllTypes(ForPartialVectors<TestDFromV>());
 }
 
+struct TestNumOfBlocks {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    const size_t num_of_blocks = NumOfBlocks(d);
+    static constexpr size_t kNumOfLanesPer16ByteBlk = 16 / sizeof(T);
+    HWY_ASSERT(num_of_blocks >= 1);
+    HWY_ASSERT(num_of_blocks <= d.MaxBlocks());
+    HWY_ASSERT(
+        num_of_blocks ==
+        ((N < kNumOfLanesPer16ByteBlk) ? 1 : (N / kNumOfLanesPer16ByteBlk)));
+  }
+};
+
+HWY_NOINLINE void TestAllNumOfBlocks() {
+  ForAllTypes(ForPartialVectors<TestDFromV>());
+}
+
+struct TestBlockDFromD {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const BlockDFromD<decltype(d)> d_block;
+    static_assert(d_block.MaxBytes() <= 16,
+                  "d_block.MaxBytes() <= 16 must be true");
+    static_assert(d_block.MaxBytes() <= d.MaxBytes(),
+                  "d_block.MaxBytes() <= d.MaxBytes() must be true");
+    static_assert(d.MaxBytes() > 16 || d_block.MaxBytes() == d.MaxBytes(),
+                  "d_block.MaxBytes() == d.MaxBytes() must be true if "
+                  "d.MaxBytes() is less than or equal to 16");
+    static_assert(d.MaxBytes() < 16 || d_block.MaxBytes() == 16,
+                  "d_block.MaxBytes() == 16 must be true if d.MaxBytes() is "
+                  "greater than or equal to 16");
+    static_assert(
+        IsSame<Vec<decltype(d_block)>, decltype(ExtractBlock<0>(Zero(d)))>(),
+        "Vec<decltype(d_block)> should be the same vector type as "
+        "decltype(ExtractBlock<0>(Zero(d)))");
+    const size_t d_bytes = Lanes(d) * sizeof(T);
+    const size_t d_block_bytes = Lanes(d_block) * sizeof(T);
+    HWY_ASSERT(d_block_bytes >= 1);
+    HWY_ASSERT(d_block_bytes <= d_bytes);
+    HWY_ASSERT(d_block_bytes <= 16);
+    HWY_ASSERT(d_bytes > 16 || d_block_bytes == d_bytes);
+    HWY_ASSERT(d_bytes < 16 || d_block_bytes == 16);
+  }
+};
+
+HWY_NOINLINE void TestAllBlockDFromD() {
+  ForAllTypes(ForPartialVectors<TestBlockDFromD>());
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -486,6 +536,8 @@ HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllIsFinite);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllCopyAndAssign);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllGetLane);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllDFromV);
+HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllNumOfBlocks);
+HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllBlockDFromD);
 }  // namespace hwy
 
 #endif

--- a/hwy/highway_test.cc
+++ b/hwy/highway_test.cc
@@ -464,11 +464,11 @@ HWY_NOINLINE void TestAllDFromV() {
   ForAllTypes(ForPartialVectors<TestDFromV>());
 }
 
-struct TestNumOfBlocks {
+struct TestBlocks {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const size_t N = Lanes(d);
-    const size_t num_of_blocks = NumOfBlocks(d);
+    const size_t num_of_blocks = Blocks(d);
     static constexpr size_t kNumOfLanesPer16ByteBlk = 16 / sizeof(T);
     HWY_ASSERT(num_of_blocks >= 1);
     HWY_ASSERT(num_of_blocks <= d.MaxBlocks());
@@ -478,7 +478,7 @@ struct TestNumOfBlocks {
   }
 };
 
-HWY_NOINLINE void TestAllNumOfBlocks() {
+HWY_NOINLINE void TestAllBlocks() {
   ForAllTypes(ForPartialVectors<TestDFromV>());
 }
 
@@ -536,7 +536,7 @@ HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllIsFinite);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllCopyAndAssign);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllGetLane);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllDFromV);
-HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllNumOfBlocks);
+HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllBlocks);
 HWY_EXPORT_AND_TEST_P(HighwayTest, TestAllBlockDFromD);
 }  // namespace hwy
 

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -4428,6 +4428,16 @@ HWY_API VFromD<DH> UpperHalf(DH dh, VFromD<Twice<DH>> v) {
 #if HWY_ARCH_ARM_A64
 // Unsigned
 template <int kLane>
+HWY_API Vec128<uint8_t> Broadcast(Vec128<uint8_t> v) {
+  static_assert(0 <= kLane && kLane < 16, "Invalid lane");
+  return Vec128<uint8_t>(vdupq_laneq_u8(v.raw, kLane));
+}
+template <int kLane, size_t N, HWY_IF_V_SIZE_LE(uint8_t, N, 8)>
+HWY_API Vec128<uint8_t, N> Broadcast(Vec128<uint8_t, N> v) {
+  static_assert(0 <= kLane && kLane < N, "Invalid lane");
+  return Vec128<uint8_t, N>(vdup_lane_u8(v.raw, kLane));
+}
+template <int kLane>
 HWY_API Vec128<uint16_t> Broadcast(Vec128<uint16_t> v) {
   static_assert(0 <= kLane && kLane < 8, "Invalid lane");
   return Vec128<uint16_t>(vdupq_laneq_u16(v.raw, kLane));
@@ -4455,6 +4465,16 @@ HWY_API Vec128<uint64_t> Broadcast(Vec128<uint64_t> v) {
 // Vec64<uint64_t> is defined below.
 
 // Signed
+template <int kLane>
+HWY_API Vec128<int8_t> Broadcast(Vec128<int8_t> v) {
+  static_assert(0 <= kLane && kLane < 16, "Invalid lane");
+  return Vec128<int8_t>(vdupq_laneq_s8(v.raw, kLane));
+}
+template <int kLane, size_t N, HWY_IF_V_SIZE_LE(int8_t, N, 8)>
+HWY_API Vec128<int8_t, N> Broadcast(Vec128<int8_t, N> v) {
+  static_assert(0 <= kLane && kLane < N, "Invalid lane");
+  return Vec128<int8_t, N>(vdup_lane_s8(v.raw, kLane));
+}
 template <int kLane>
 HWY_API Vec128<int16_t> Broadcast(Vec128<int16_t> v) {
   static_assert(0 <= kLane && kLane < 8, "Invalid lane");
@@ -4509,6 +4529,16 @@ HWY_API Vec64<double> Broadcast(Vec64<double> v) {
 
 // Unsigned
 template <int kLane>
+HWY_API Vec128<uint8_t> Broadcast(Vec128<uint8_t> v) {
+  static_assert(0 <= kLane && kLane < 16, "Invalid lane");
+  return Vec128<uint8_t>(vdupq_n_u8(vgetq_lane_u8(v.raw, kLane)));
+}
+template <int kLane, size_t N, HWY_IF_V_SIZE_LE(uint8_t, N, 8)>
+HWY_API Vec128<uint8_t, N> Broadcast(Vec128<uint8_t, N> v) {
+  static_assert(0 <= kLane && kLane < N, "Invalid lane");
+  return Vec128<uint8_t, N>(vdup_lane_u8(v.raw, kLane));
+}
+template <int kLane>
 HWY_API Vec128<uint16_t> Broadcast(Vec128<uint16_t> v) {
   static_assert(0 <= kLane && kLane < 8, "Invalid lane");
   return Vec128<uint16_t>(vdupq_n_u16(vgetq_lane_u16(v.raw, kLane)));
@@ -4536,6 +4566,16 @@ HWY_API Vec128<uint64_t> Broadcast(Vec128<uint64_t> v) {
 // Vec64<uint64_t> is defined below.
 
 // Signed
+template <int kLane>
+HWY_API Vec128<int8_t> Broadcast(Vec128<int8_t> v) {
+  static_assert(0 <= kLane && kLane < 16, "Invalid lane");
+  return Vec128<int8_t>(vdupq_n_s8(vgetq_lane_s8(v.raw, kLane)));
+}
+template <int kLane, size_t N, HWY_IF_V_SIZE_LE(int8_t, N, 8)>
+HWY_API Vec128<int8_t, N> Broadcast(Vec128<int8_t, N> v) {
+  static_assert(0 <= kLane && kLane < N, "Invalid lane");
+  return Vec128<int8_t, N>(vdup_lane_s8(v.raw, kLane));
+}
 template <int kLane>
 HWY_API Vec128<int16_t> Broadcast(Vec128<int16_t> v) {
   static_assert(0 <= kLane && kLane < 8, "Invalid lane");

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -233,9 +233,9 @@ HWY_INLINE size_t AllHardwareLanes() {
 template <typename T, size_t N, int kPow2>
 HWY_API size_t Lanes(Simd<T, N, kPow2> d) {
   const size_t actual = detail::AllHardwareLanes<T>();
+  constexpr size_t kMaxLanes = MaxLanes(d);
   // Common case of full vectors: avoid any extra instructions.
-  if (detail::IsFull(d)) return actual;
-  return detail::ScaleByPower(HWY_MIN(actual, N), kPow2);
+  return (detail::IsFull(d)) ? actual : HWY_MIN(actual, kMaxLanes);
 }
 
 #endif  // HWY_HAVE_SCALABLE

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2679,16 +2679,6 @@ HWY_SVE_FOREACH_UI(HWY_SVE_REVERSE_BITS, ReverseBits, rbit)
 #undef HWY_SVE_REVERSE_BITS
 
 // ------------------------------ Block insert/extract/broadcast ops
-#ifdef HWY_NATIVE_BLOCKDFROMD
-#undef HWY_NATIVE_BLOCKDFROMD
-#else
-#define HWY_NATIVE_BLOCKDFROMD
-#endif
-
-template <class D>
-using BlockDFromD =
-    FixedTag<TFromD<D>, HWY_MIN(16 / sizeof(TFromD<D>), HWY_MAX_LANES_D(D))>;
-
 #if HWY_TARGET != HWY_SVE2_128
 
 #ifdef HWY_NATIVE_BLK_INSERT_EXTRACT

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -234,8 +234,10 @@ template <typename T, size_t N, int kPow2>
 HWY_API size_t Lanes(Simd<T, N, kPow2> d) {
   const size_t actual = detail::AllHardwareLanes<T>();
   constexpr size_t kMaxLanes = MaxLanes(d);
+  constexpr int kClampedPow2 = HWY_MIN(kPow2, 0);
   // Common case of full vectors: avoid any extra instructions.
-  return (detail::IsFull(d)) ? actual : HWY_MIN(actual, kMaxLanes);
+  if (detail::IsFull(d)) return actual;
+  return HWY_MIN(detail::ScaleByPower(actual, kClampedPow2), kMaxLanes);
 }
 
 #endif  // HWY_HAVE_SCALABLE

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3623,10 +3623,10 @@ HWY_API V Per4LaneBlockShuffle(V v) {
 }
 #endif
 
-// ------------------------------ NumOfBlocks
+// ------------------------------ Blocks
 
 template <class D>
-HWY_API size_t NumOfBlocks(D d) {
+HWY_API size_t Blocks(D d) {
   return (d.MaxBytes() <= 16) ? 1 : ((Lanes(d) * sizeof(TFromD<D>) + 15) / 16);
 }
 
@@ -3657,17 +3657,6 @@ HWY_API V BroadcastBlock(V v) {
 }
 
 #endif  // HWY_NATIVE_BLK_INSERT_EXTRACT
-
-#if (defined(HWY_NATIVE_BLOCKDFROMD) == defined(HWY_TARGET_TOGGLE))
-#ifdef HWY_NATIVE_BLOCKDFROMD
-#undef HWY_NATIVE_BLOCKDFROMD
-#else
-#define HWY_NATIVE_BLOCKDFROMD
-#endif
-
-template<class D>
-using BlockDFromD = DFromV<decltype(ExtractBlock<0>(Zero(D())))>;
-#endif  // HWY_NATIVE_BLOCKDFROMD
 
 // ------------------------------ BroadcastLane
 #if (defined(HWY_NATIVE_BROADCASTLANE) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3623,6 +3623,68 @@ HWY_API V Per4LaneBlockShuffle(V v) {
 }
 #endif
 
+// ------------------------------ NumOfBlocks
+
+template <class D>
+HWY_API size_t NumOfBlocks(D d) {
+  return (d.MaxBytes() <= 16) ? 1 : ((Lanes(d) * sizeof(TFromD<D>) + 15) / 16);
+}
+
+// ------------------------------ Block insert/extract/broadcast ops
+#if (defined(HWY_NATIVE_BLK_INSERT_EXTRACT) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_BLK_INSERT_EXTRACT
+#undef HWY_NATIVE_BLK_INSERT_EXTRACT
+#else
+#define HWY_NATIVE_BLK_INSERT_EXTRACT
+#endif
+
+template <int kBlockIdx, class V, HWY_IF_V_SIZE_LE_V(V, 16)>
+HWY_API V InsertBlock(V /*v*/, V blk_to_insert) {
+  static_assert(kBlockIdx == 0, "Invalid block index");
+  return blk_to_insert;
+}
+
+template <int kBlockIdx, class V, HWY_IF_V_SIZE_LE_V(V, 16)>
+HWY_API V ExtractBlock(V v) {
+  static_assert(kBlockIdx == 0, "Invalid block index");
+  return v;
+}
+
+template <int kBlockIdx, class V, HWY_IF_V_SIZE_LE_V(V, 16)>
+HWY_API V BroadcastBlock(V v) {
+  static_assert(kBlockIdx == 0, "Invalid block index");
+  return v;
+}
+
+#endif  // HWY_NATIVE_BLK_INSERT_EXTRACT
+
+#if (defined(HWY_NATIVE_BLOCKDFROMD) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_BLOCKDFROMD
+#undef HWY_NATIVE_BLOCKDFROMD
+#else
+#define HWY_NATIVE_BLOCKDFROMD
+#endif
+
+template<class D>
+using BlockDFromD = DFromV<decltype(ExtractBlock<0>(Zero(D())))>;
+#endif  // HWY_NATIVE_BLOCKDFROMD
+
+// ------------------------------ BroadcastLane
+#if (defined(HWY_NATIVE_BROADCASTLANE) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_BROADCASTLANE
+#undef HWY_NATIVE_BROADCASTLANE
+#else
+#define HWY_NATIVE_BROADCASTLANE
+#endif
+
+template<int kLane, class V, HWY_IF_V_SIZE_LE_V(V, 16)>
+HWY_API V BroadcastLane(V v) {
+  return Broadcast<kLane>(v);
+}
+
+#endif  // HWY_NATIVE_BROADCASTLANE
+
+
 // ================================================== Operator wrapper
 
 // SVE* and RVV currently cannot define operators and have already defined

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -3127,27 +3127,6 @@ HWY_API V BroadcastLane(V v) {
 }
 
 // ------------------------------ InsertBlock
-namespace detail {
-
-template <class D>
-class BlockDFromD_t {};
-
-template <typename T, size_t N, int kPow2>
-class BlockDFromD_t<Simd<T, N, kPow2>> {
-  using D = Simd<T, N, kPow2>;
-  static constexpr int kNewPow2 = HWY_MIN(kPow2, 0);
-  static constexpr size_t kMaxLpb = HWY_MIN(16 / sizeof(T), HWY_MAX_LANES_D(D));
-  static constexpr size_t kNewN = D::template NewN<kNewPow2, kMaxLpb>();
-
- public:
-  using type = Simd<T, kNewN, kNewPow2>;
-};
-
-}  // namespace detail
-
-template <class D>
-using BlockDFromD = typename detail::BlockDFromD_t<RemoveConst<D>>::type;
-
 #ifdef HWY_NATIVE_BLK_INSERT_EXTRACT
 #undef HWY_NATIVE_BLK_INSERT_EXTRACT
 #else

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -855,6 +855,10 @@ HWY_RVV_FOREACH_UI(HWY_RVV_RETV_ARGVV, Add, add, _ALL)
 HWY_RVV_FOREACH_F(HWY_RVV_RETV_ARGVV, Add, fadd, _ALL)
 
 // ------------------------------ Sub
+namespace detail {
+HWY_RVV_FOREACH_UI(HWY_RVV_RETV_ARGVS, SubS, sub_vx, _ALL)
+}  // namespace detail
+
 HWY_RVV_FOREACH_UI(HWY_RVV_RETV_ARGVV, Sub, sub, _ALL)
 HWY_RVV_FOREACH_F(HWY_RVV_RETV_ARGVV, Sub, fsub, _ALL)
 
@@ -3092,6 +3096,150 @@ HWY_API V Broadcast(const V v) {
     idx = detail::AddS(idx, kLane);
   }
   return TableLookupLanes(v, idx);
+}
+
+// ------------------------------ BroadcastLane
+#ifdef HWY_NATIVE_BROADCASTLANE
+#undef HWY_NATIVE_BROADCASTLANE
+#else
+#define HWY_NATIVE_BROADCASTLANE
+#endif
+
+template <int kLane, class V,
+          hwy::EnableIf<(sizeof(TFromV<V>) != 1 || kLane <= 255)>* = nullptr>
+HWY_API V BroadcastLane(V v) {
+  static_assert(0 <= kLane && kLane < HWY_MAX_LANES_V(V), "Invalid lane");
+  const DFromV<V> d;
+  const RebindToUnsigned<decltype(d)> du;
+  using TU = TFromD<decltype(du)>;
+  return TableLookupLanes(v, Set(du, static_cast<TU>(kLane)));
+}
+
+template <int kLane, class V, HWY_IF_T_SIZE_V(V, 1),
+          hwy::EnableIf<(kLane > 255)>* = nullptr,
+          HWY_IF_POW2_LE_D(DFromV<V>, 2)>
+HWY_API V BroadcastLane(V v) {
+  static_assert(kLane < HWY_MAX_LANES_V(V), "Invalid lane");
+  const DFromV<V> d;
+  const Rebind<uint16_t, decltype(d)> du16;
+  return detail::TableLookupLanes16(v, Set(du16, static_cast<uint16_t>(kLane)));
+}
+
+template <int kLane, class V, HWY_IF_T_SIZE_V(V, 1),
+          hwy::EnableIf<(kLane > 255)>* = nullptr,
+          HWY_IF_POW2_GT_D(DFromV<V>, 2)>
+HWY_API V BroadcastLane(V v) {
+  static_assert(kLane < HWY_MAX_LANES_V(V), "Invalid lane");
+  const DFromV<V> d;
+  const RebindToUnsigned<decltype(d)> du;
+  return TableLookupLanes(detail::SlideDown(v, static_cast<size_t>(kLane)),
+                          Zero(du));
+}
+
+// ------------------------------ InsertBlock
+
+#ifdef HWY_NATIVE_BLOCKDFROMD
+#undef HWY_NATIVE_BLOCKDFROMD
+#else
+#define HWY_NATIVE_BLOCKDFROMD
+#endif
+
+namespace detail {
+
+template <class D>
+class BlockDFromD_t {};
+
+template <typename T, size_t N, int kPow2>
+class BlockDFromD_t<Simd<T, N, kPow2>> {
+  using D = Simd<T, N, kPow2>;
+  static constexpr int kNewPow2 = HWY_MIN(kPow2, 0);
+  static constexpr size_t kMaxLpb = HWY_MIN(16 / sizeof(T), HWY_MAX_LANES_D(D));
+  static constexpr size_t kNewN = D::template NewN<kNewPow2, kMaxLpb>();
+
+ public:
+  using type = Simd<T, kNewN, kNewPow2>;
+};
+
+}  // namespace detail
+
+template <class D>
+using BlockDFromD = typename detail::BlockDFromD_t<RemoveConst<D>>::type;
+
+#ifdef HWY_NATIVE_BLK_INSERT_EXTRACT
+#undef HWY_NATIVE_BLK_INSERT_EXTRACT
+#else
+#define HWY_NATIVE_BLK_INSERT_EXTRACT
+#endif
+
+template <int kBlockIdx, class V>
+HWY_API V InsertBlock(V v, VFromD<BlockDFromD<DFromV<V>>> blk_to_insert) {
+  const DFromV<decltype(v)> d;
+  using TU = If<(sizeof(TFromV<V>) == 1 && DFromV<V>().Pow2() >= -2), uint16_t,
+                MakeUnsigned<TFromV<V>>>;
+  using TIdx = If<sizeof(TU) == 1, uint16_t, TU>;
+
+  const Repartition<TU, decltype(d)> du;
+  const Rebind<TIdx, decltype(du)> d_idx;
+  static_assert(0 <= kBlockIdx && kBlockIdx < d.MaxBlocks(),
+                "Invalid block index");
+  constexpr size_t kMaxLanesPerBlock = 16 / sizeof(TU);
+
+  constexpr size_t kBlkByteOffset =
+      static_cast<size_t>(kBlockIdx) * kMaxLanesPerBlock;
+  const auto vu = BitCast(du, v);
+  const auto vblk = ResizeBitCast(du, blk_to_insert);
+  const auto vblk_shifted = detail::SlideUp(vblk, vblk, kBlkByteOffset);
+  const auto insert_mask = RebindMask(du, detail::LtS(
+      detail::SubS(detail::Iota0(d_idx), static_cast<TIdx>(kBlkByteOffset)),
+      static_cast<TIdx>(kMaxLanesPerBlock)));
+
+  return BitCast(d, IfThenElse(insert_mask, vblk_shifted, vu));
+}
+
+// ------------------------------ BroadcastBlock
+template <int kBlockIdx, class V, HWY_IF_POW2_LE_D(DFromV<V>, -3)>
+HWY_API V BroadcastBlock(V v) {
+  const DFromV<decltype(v)> d;
+  const Repartition<uint8_t, decltype(d)> du8;
+  const Rebind<uint16_t, decltype(d)> du16;
+
+  static_assert(0 <= kBlockIdx && kBlockIdx < d.MaxBlocks(),
+                "Invalid block index");
+
+  const auto idx = detail::AddS(detail::AndS(detail::Iota0(du16), uint16_t{15}),
+                                static_cast<uint16_t>(kBlockIdx * 16));
+  return BitCast(d, detail::TableLookupLanes16(BitCast(du8, v), idx));
+}
+
+template <int kBlockIdx, class V, HWY_IF_POW2_GT_D(DFromV<V>, -3)>
+HWY_API V BroadcastBlock(V v) {
+  const DFromV<decltype(v)> d;
+  using TU = If<sizeof(TFromV<V>) == 1, uint16_t, MakeUnsigned<TFromV<V>>>;
+  const Repartition<TU, decltype(d)> du;
+
+  static_assert(0 <= kBlockIdx && kBlockIdx < d.MaxBlocks(),
+                "Invalid block index");
+  constexpr size_t kMaxLanesPerBlock = 16 / sizeof(TU);
+
+  const auto idx = detail::AddS(
+      detail::AndS(detail::Iota0(du), static_cast<TU>(kMaxLanesPerBlock - 1)),
+      static_cast<TU>(static_cast<size_t>(kBlockIdx) * kMaxLanesPerBlock));
+  return BitCast(d, TableLookupLanes(BitCast(du, v), idx));
+}
+
+// ------------------------------ ExtractBlock
+template <int kBlockIdx, class V>
+HWY_API VFromD<BlockDFromD<DFromV<V>>> ExtractBlock(V v) {
+  const DFromV<decltype(v)> d;
+  const BlockDFromD<decltype(d)> d_block;
+
+  static_assert(0 <= kBlockIdx && kBlockIdx < d.MaxBlocks(),
+                "Invalid block index");
+  constexpr size_t kMaxLanesPerBlock = 16 / sizeof(TFromD<decltype(d)>);
+  constexpr size_t kBlkByteOffset =
+      static_cast<size_t>(kBlockIdx) * kMaxLanesPerBlock;
+
+  return ResizeBitCast(d_block, detail::SlideDown(v, kBlkByteOffset));
 }
 
 // ------------------------------ ShiftLeftLanes

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -400,7 +400,28 @@ template <class D>
 using Twice = typename D::Twice;
 
 // Tag for a 16-byte block with the same lane type as D
-#if HWY_TARGET != HWY_RVV
+#if HWY_HAVE_SCALABLE
+namespace detail {
+
+template <class D>
+class BlockDFromD_t {};
+
+template <typename T, size_t N, int kPow2>
+class BlockDFromD_t<Simd<T, N, kPow2>> {
+  using D = Simd<T, N, kPow2>;
+  static constexpr int kNewPow2 = HWY_MIN(kPow2, 0);
+  static constexpr size_t kMaxLpb = HWY_MIN(16 / sizeof(T), HWY_MAX_LANES_D(D));
+  static constexpr size_t kNewN = D::template NewN<kNewPow2, kMaxLpb>();
+
+ public:
+  using type = Simd<T, kNewN, kNewPow2>;
+};
+
+}  // namespace detail
+
+template <class D>
+using BlockDFromD = typename detail::BlockDFromD_t<RemoveConst<D>>::type;
+#else
 template <class D>
 using BlockDFromD =
     Simd<TFromD<D>, HWY_MIN(16 / sizeof(TFromD<D>), HWY_MAX_LANES_D(D)), 0>;

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -168,6 +168,7 @@ struct Simd {
 
   constexpr size_t MaxLanes() const { return kPrivateLanes; }
   constexpr size_t MaxBytes() const { return kPrivateLanes * sizeof(Lane); }
+  constexpr size_t MaxBlocks() const { return (MaxBytes() + 15) / 16; }
   // For SFINAE on RVV.
   constexpr int Pow2() const { return kPow2; }
 

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -399,6 +399,13 @@ using Half = typename D::Half;
 template <class D>
 using Twice = typename D::Twice;
 
+// Tag for a 16-byte block with the same lane type as D
+#if HWY_TARGET != HWY_RVV
+template <class D>
+using BlockDFromD =
+    Simd<TFromD<D>, HWY_MIN(16 / sizeof(TFromD<D>), HWY_MAX_LANES_D(D)), 0>;
+#endif
+
 // ------------------------------ Choosing overloads (SFINAE)
 
 // Same as base.h macros but with a Simd<T, N, kPow2> argument instead of T.

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -2431,6 +2431,14 @@ HWY_API VFromD<D> CombineShiftRightBytes(D d, VFromD<D> hi, VFromD<D> lo) {
 
 // ------------------------------ Broadcast/splat any lane
 
+template <int kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
+HWY_API Vec128<T, N> Broadcast(const Vec128<T, N> v) {
+  static_assert(0 <= kLane && kLane < N, "Invalid lane");
+  return Vec128<T, N>{wasm_i8x16_shuffle(
+      v.raw, v.raw, kLane, kLane, kLane, kLane, kLane, kLane, kLane, kLane,
+      kLane, kLane, kLane, kLane, kLane, kLane, kLane, kLane)};
+}
+
 template <int kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 2)>
 HWY_API Vec128<T, N> Broadcast(const Vec128<T, N> v) {
   static_assert(0 <= kLane && kLane < N, "Invalid lane");

--- a/hwy/tests/blockwise_test.cc
+++ b/hwy/tests/blockwise_test.cc
@@ -68,11 +68,7 @@ struct TestBroadcast {
 };
 
 HWY_NOINLINE void TestAllBroadcast() {
-  const ForPartialVectors<TestBroadcast> test;
-  // No u/i8.
-  test(uint16_t());
-  test(int16_t());
-  ForUIF3264(test);
+  ForAllTypes(ForPartialVectors<TestBroadcast>());
 }
 
 template <bool kFull>


### PR DESCRIPTION
Added the following new operations:
- InsertBlock - inserts a block of `HWY_MIN(Lanes(DFromV<V>()), 16 / sizeof(TFromV<V>))` lanes to the result vector if `kBlock * 16` is less than `Lanes(DFromV<V>()) * sizeof(TFromV<V>)`. Otherwise, returns `v`.
- ExtractBlock - extracts a block of `HWY_MIN(Lanes(DFromV<V>()), 16 / sizeof(TFromV<V>))` lanes from `v`
- BroadcastBlock - broadcasts a block of `HWY_MIN(Lanes(DFromV<V>()), 16 / sizeof(TFromV<V>))` lanes to all of the other blocks of the result vector
- BroadcastLane - broadcasts a lane to all of the other lanes of the result vector (even in the case of vectors that are larger than 16 bytes)
- NumOfBlocks - returns the number of blocks with `HWY_MIN(Lanes(DFromV<V>()), 16 / sizeof(TFromV<V>))` lanes

Also added `BlockDFromD`, which returns a SIMD tag for a block of `HWY_MIN(Lanes(D()), 16 / sizeof(TFromD<D>))` lanes

Also added I8/U8 Broadcast for the SSE2/SSSE3/SSE4/AVX2/AVX3, NEON, and WASM targets (I8/U8 was already implemented on the SVE, RVV, PPC, EMU128, and SCALAR targets).