### PR TITLE
Fix compilation on fallback POSIX system

### DIFF
--- a/hwy/timer-inl.h
+++ b/hwy/timer-inl.h
@@ -50,6 +50,8 @@
 #include <intrin.h>
 #endif
 
+#include <time.h>    // clock_gettime
+
 HWY_BEFORE_NAMESPACE();
 namespace hwy {
 namespace HWY_NAMESPACE {


### PR DESCRIPTION
highway/hwy/timer-inl.h:152:17: error: ‘CLOCK_MONOTONIC’ was not declared in this scope
  152 |   clock_gettime(CLOCK_MONOTONIC, &ts);
      |                 ^~~~~~~~~~~~~~~
highway/hwy/timer-inl.h:152:3: error: ‘clock_gettime’ was not declared in this scope
  152 |   clock_gettime(CLOCK_MONOTONIC, &ts);
      |   ^~~~~~~~~~~~~