### PR TITLE
Make sure to link hwy_contrib against atomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,8 @@ target_include_directories(hwy_contrib PUBLIC
 target_compile_features(hwy_contrib PUBLIC cxx_std_11)
 set_target_properties(hwy_contrib PROPERTIES
   LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hwy/hwy.version)
+# For GCC __atomic_store_8, see #887
+target_link_libraries(hwy_contrib PRIVATE ${ATOMICS_LIBRARIES})
 # not supported by MSVC/Clang, safe to skip (we use DLLEXPORT annotations)
 if(UNIX AND NOT APPLE)
   set_property(TARGET hwy_contrib APPEND_STRING PROPERTY


### PR DESCRIPTION
Fixes report on powerpc 32 system:

dpkg-shlibdeps: warning: symbol __atomic_store_8 used by debian/libhwy1/usr/lib/powerpc-linux-gnu/libhwy_contrib.so.1.0.5 found in none of the libraries
dpkg-shlibdeps: warning: symbol __atomic_load_8 used by debian/libhwy1/usr/lib/powerpc-linux-gnu/libhwy_contrib.so.1.0.5 found in none of the libraries