### PR TITLE
Explicit public linking to hwy for hwy_contrib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 
 if (HWY_ENABLE_CONTRIB)
 add_library(hwy_contrib ${HWY_LIBRARY_TYPE} ${HWY_CONTRIB_SOURCES})
-target_link_libraries(hwy_contrib hwy)
+target_link_libraries(hwy_contrib PUBLIC hwy)
 target_compile_options(hwy_contrib PRIVATE ${HWY_FLAGS})
 set_property(TARGET hwy_contrib PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_target_properties(hwy_contrib PROPERTIES VERSION ${LIBRARY_VERSION} SOVERSION ${LIBRARY_SOVERSION})


### PR DESCRIPTION
Recent cmake version fails to handle both target_link_libraries signatures and reports:

CMake Error at CMakeLists.txt:335 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "hwy_contrib".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * CMakeLists.txt:324 (target_link_libraries)

This commit fixes this configuration error