### PR TITLE
Remove a simple warning on GNU/Hurd system (non-linux)

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -442,7 +442,7 @@ time-critical code:
 As a partial workaround to the "no vectors as class members" compiler limitation
 mentioned in "Using unspecified vector types", we provide special types able to
 carry 2, 3 or 4 vectors, denoted `Tuple{2-4}` below. Their type is unspecified,
-potentially built-in, so use the aliases `Vec{2-4}&lt;D&gt;`. These can (only)
+potentially built-in, so use the aliases `Vec{2-4}<D>`. These can (only)
 be passed as arguments or returned from functions, and created/accessed using
 the functions in this section.
 

--- a/hwy/contrib/sort/vqsort.cc
+++ b/hwy/contrib/sort/vqsort.cc
@@ -93,6 +93,8 @@ bool Fill16BytesSecure(void* bytes) {
     CryptReleaseContext(hProvider, 0);
     if (ok) return true;
   }
+#else
+  (void)bytes;
 #endif
 
   return false;


### PR DESCRIPTION
Fixes:

  hwy/contrib/sort/vqsort.cc:82:30: error: unused parameter ‘bytes’ [-Werror=unused-parameter]

Also fixes a tiny typo in the doc.