### PR TITLE
Use defined marco to determine whether to use HWY_RVV_AVOID_VXRM

### DIFF
--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -943,8 +943,8 @@ HWY_RVV_FOREACH_U(HWY_RVV_RETV_ARGVV, SaturatedSub, ssubu, _ALL)
 HWY_RVV_FOREACH_I(HWY_RVV_RETV_ARGVV, SaturatedSub, ssub, _ALL)
 
 // ------------------------------ AverageRound
-// Assume that GCC-13 default to legacy vxrm arguments. Tested with GCC 13.1.0
-#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400
+// VXMR is embedded into intrinsic function argument since intrinsic v1.0.
+#if __riscv_v_intrinsic == 11000
 #define HWY_RVV_AVOID_VXRM
 #endif
 


### PR DESCRIPTION
The origin purpose of `HWY_RVV_AVOID_VXRM` is to detect whether VXRM is embedded in an intrinsic function argument.
If not embedded into an argument, `HWY_RVV_AVOID_VXRM` is defined.

This PR changes to use a predefined macro to check to make it available for both clang & gcc.

