### PR TITLE
Made enhancements to x86 ExtractLane operation

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -4060,9 +4060,8 @@ template <size_t kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_INLINE T ExtractLane(const Vec128<T, N> v) {
   static_assert(kLane < N, "Lane index out of bounds");
 #if HWY_TARGET >= HWY_SSSE3
-  alignas(16) T lanes[4];
-  Store(v, DFromV<decltype(v)>(), lanes);
-  return lanes[kLane];
+  return static_cast<T>(_mm_cvtsi128_si32(
+      (kLane == 0) ? v.raw : _mm_shuffle_epi32(v.raw, kLane)));
 #else
   return static_cast<T>(_mm_extract_epi32(v.raw, kLane));
 #endif
@@ -4087,9 +4086,8 @@ template <size_t kLane, size_t N>
 HWY_INLINE float ExtractLane(const Vec128<float, N> v) {
   static_assert(kLane < N, "Lane index out of bounds");
 #if HWY_TARGET >= HWY_SSSE3
-  alignas(16) float lanes[4];
-  Store(v, DFromV<decltype(v)>(), lanes);
-  return lanes[kLane];
+  return _mm_cvtss_f32((kLane == 0) ? v.raw
+                                    : _mm_shuffle_ps(v.raw, v.raw, kLane));
 #else
   // Bug in the intrinsic, returns int but should be float.
   const int32_t bits = _mm_extract_ps(v.raw, kLane);

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -3011,6 +3011,14 @@ template <typename T>
 HWY_API T ExtractLane(const Vec256<T> v, size_t i) {
   const DFromV<decltype(v)> d;
   HWY_DASSERT(i < Lanes(d));
+
+#if !HWY_IS_DEBUG_BUILD && HWY_COMPILER_GCC  // includes clang
+  constexpr size_t kLanesPerBlock = 16 / sizeof(T);
+  if (__builtin_constant_p(i < kLanesPerBlock) && (i < kLanesPerBlock)) {
+    return ExtractLane(LowerHalf(Half<decltype(d)>(), v), i);
+  }
+#endif
+
   alignas(32) T lanes[32 / sizeof(T)];
   Store(v, d, lanes);
   return lanes[i];


### PR DESCRIPTION
Made the following enhancements to ExtractLane on x86:
- Updated implementation of detail::ExtractLane in hwy/ops/x86_128-inl.h for I32/U32/F32 vectors on SSE2/SSSE3 targets to do an shuffle followed by a _mm_cvtsi128_si32 or _mm_cvtss_f32
- Updated AVX2/AVX3 implementation of ExtractLane for 32-byte and 64-byte vectors to call ExtractLane on the extracted 16-byte block if `__builtin_constant_p(i < kLanesPerBlock) && (i < kLanesPerBlock)` is true