### PR TITLE
Replaced memcpy with 3-argument CopyBytes

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -282,6 +282,15 @@ HWY_API void CopyBytes(const From* from, To* to) {
 #endif
 }
 
+HWY_API void CopyBytes(const void* HWY_RESTRICT from, void* HWY_RESTRICT to,
+                       size_t num_of_bytes_to_copy) {
+#if HWY_COMPILER_MSVC
+  memcpy(to, from, num_of_bytes_to_copy);
+#else
+  __builtin_memcpy(to, from, num_of_bytes_to_copy);
+#endif
+}
+
 // Same as CopyBytes, but for same-sized objects; avoids a size argument.
 template <typename From, typename To>
 HWY_API void CopySameSize(const From* HWY_RESTRICT from, To* HWY_RESTRICT to) {

--- a/hwy/contrib/sort/algo-inl.h
+++ b/hwy/contrib/sort/algo-inl.h
@@ -18,7 +18,6 @@
 #define HIGHWAY_HWY_CONTRIB_SORT_ALGO_INL_H_
 
 #include <stdint.h>
-#include <string.h>  // memcpy
 
 #include <algorithm>   // std::sort, std::min, std::max
 #include <functional>  // std::less, std::greater
@@ -385,7 +384,7 @@ InputStats<T> GenerateInput(const Dist dist, T* v, size_t num) {
   if (i < num) {
     const V values = RandomValues(d, s0, s1, mask);
     StoreU(values, d, buf.get());
-    memcpy(v + i, buf.get(), (num - i) * sizeof(T));
+    CopyBytes(buf.get(), v + i, (num - i) * sizeof(T));
   }
 
   InputStats<T> input_stats;

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -18,7 +18,6 @@
 #define HIGHWAY_HWY_CONTRIB_SORT_VQSORT_INL_H_
 
 #include <stdio.h>  // unconditional #include so we can use if(VQSORT_PRINT).
-#include <string.h>  // memcpy
 #include <time.h>    // clock
 
 // IWYU pragma: begin_exports
@@ -556,8 +555,8 @@ HWY_INLINE size_t PartitionToMultipleOfUnroll(D d, Traits st,
   // mask from `keys + num`. Combining a loop with memcpy for the remainders is
   // slower than just memcpy, so we use that for simplicity.
   num -= bufR;
-  memcpy(posL, keys + num, bufR * sizeof(T));
-  memcpy(keys + num, buf, bufR * sizeof(T));
+  CopyBytes(keys + num, posL, bufR * sizeof(T));
+  CopyBytes(buf, keys + num, bufR * sizeof(T));
   return static_cast<size_t>(posL - keys);  // caller will shrink num by this.
 }
 

--- a/hwy/contrib/unroller/unroller-inl.h
+++ b/hwy/contrib/unroller/unroller-inl.h
@@ -21,8 +21,6 @@
 #define HIGHWAY_HWY_CONTRIB_UNROLLER_UNROLLER_INL_H_
 #endif
 
-#include <string.h>  // memcpy
-
 #include <cstdlib>  // std::abs
 
 #include "hwy/highway.h"
@@ -302,13 +300,13 @@ inline void Unroller(FUNC& f, IN_T* HWY_RESTRICT x, OUT_T* HWY_RESTRICT y,
     HWY_ALIGN IN_T xtmp[static_cast<size_t>(lane_sz)];
     HWY_ALIGN OUT_T ytmp[static_cast<size_t>(lane_sz)];
 
-    memcpy(xtmp, x, static_cast<size_t>(n) * sizeof(IN_T));
+    CopyBytes(x, xtmp, static_cast<size_t>(n) * sizeof(IN_T));
     xx = f.MaskLoad(0, xtmp, n);
     yy = f.Func(0, xx, yy);
     Store(Zero(d), d, ytmp);
     i += f.MaskStore(0, ytmp, yy, n);
     i += f.Reduce(yy, ytmp);
-    memcpy(y, ytmp, static_cast<size_t>(i) * sizeof(OUT_T));
+    CopyBytes(ytmp, y, static_cast<size_t>(i) * sizeof(OUT_T));
     return;
   }
 #endif
@@ -391,15 +389,15 @@ inline void Unroller(FUNC& HWY_RESTRICT f, IN0_T* HWY_RESTRICT x0,
     HWY_ALIGN IN1_T xtmp1[static_cast<size_t>(max_lane_sz)];
     HWY_ALIGN OUT_T ytmp[static_cast<size_t>(max_lane_sz)];
 
-    memcpy(xtmp0, x0, static_cast<size_t>(n) * sizeof(IN0_T));
-    memcpy(xtmp1, x1, static_cast<size_t>(n) * sizeof(IN1_T));
+    CopyBytes(x0, xtmp0, static_cast<size_t>(n) * sizeof(IN0_T));
+    CopyBytes(x1, xtmp1, static_cast<size_t>(n) * sizeof(IN1_T));
     xx00 = f.MaskLoad0(0, xtmp0, n);
     xx10 = f.MaskLoad1(0, xtmp1, n);
     yy = f.Func(0, xx00, xx10, yy);
     Store(Zero(d), d, ytmp);
     i += f.MaskStore(0, ytmp, yy, n);
     i += f.Reduce(yy, ytmp);
-    memcpy(y, ytmp, static_cast<size_t>(i) * sizeof(OUT_T));
+    CopyBytes(ytmp, y, static_cast<size_t>(i) * sizeof(OUT_T));
     return;
   }
 #endif

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -2166,7 +2166,8 @@ HWY_API VFromD<D> SlideUpLanes(D d, VFromD<D> v, size_t amt) {
   VFromD<D> ret = Zero(d);
   constexpr size_t N = HWY_MAX_LANES_D(D);
   const size_t clamped_amt = HWY_MIN(amt, N);
-  memcpy(ret.raw + clamped_amt, v.raw, (N - clamped_amt) * sizeof(TFromD<D>));
+  CopyBytes(v.raw, ret.raw + clamped_amt,
+            (N - clamped_amt) * sizeof(TFromD<D>));
   return ret;
 }
 
@@ -2177,7 +2178,8 @@ HWY_API VFromD<D> SlideDownLanes(D d, VFromD<D> v, size_t amt) {
   VFromD<D> ret = Zero(d);
   constexpr size_t N = HWY_MAX_LANES_D(D);
   const size_t clamped_amt = HWY_MIN(amt, N);
-  memcpy(ret.raw, v.raw + clamped_amt, (N - clamped_amt) * sizeof(TFromD<D>));
+  CopyBytes(v.raw + clamped_amt, ret.raw,
+            (N - clamped_amt) * sizeof(TFromD<D>));
   return ret;
 }
 

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -30,8 +30,6 @@
 #pragma pop_macro("pixel")
 #pragma pop_macro("bool")
 
-#include <string.h>  // memcpy
-
 #include "hwy/ops/shared-inl.h"
 
 // clang's altivec.h gates some intrinsics behind #ifdef __POWER10_VECTOR__, and

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -39,7 +39,6 @@ HWY_DIAGNOSTICS_OFF(disable : 4701 4703 6001 26494,
 #include <wmmintrin.h>  // CLMUL
 #endif
 #endif
-#include <string.h>  // memcpy
 
 #include "hwy/ops/shared-inl.h"
 
@@ -8592,7 +8591,7 @@ HWY_API size_t CompressBlendedStore(VFromD<D> v, MFromD<D> m, D d,
     // FirstN, so we can just copy.
     alignas(16) T buf[MaxLanes(d)];
     Store(compressed, d, buf);
-    memcpy(unaligned, buf, count * sizeof(T));
+    CopyBytes(buf, unaligned, count * sizeof(T));
 #else
     BlendedStore(compressed, FirstN(d, count), d, unaligned);
 #endif

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -48,8 +48,6 @@ HWY_DIAGNOSTICS_OFF(disable : 4701 4703 6001 26494,
 #include <smmintrin.h>
 #endif  // HWY_COMPILER_CLANGCL
 
-#include <string.h>  // memcpy
-
 // For half-width vectors. Already includes base.h.
 #include "hwy/ops/shared-inl.h"
 // Already included by shared-inl, but do it again to avoid IDE warnings.
@@ -6513,7 +6511,7 @@ HWY_API size_t CompressBlendedStore(Vec256<T> v, Mask256<T> m, D d,
   // FirstN, so we can just copy.
   alignas(32) T buf[16];
   Store(compressed, d, buf);
-  memcpy(unaligned, buf, count * sizeof(T));
+  CopyBytes(buf, unaligned, count * sizeof(T));
 #else
   BlendedStore(compressed, FirstN(d, count), d, unaligned);
 #endif


### PR DESCRIPTION
Added a new 3-argument CopyBytes function in hwy/base.h that takes an additional num_of_bytes_to_copy argument.

Also replaced `memcpy(to, from, N)` calls with `CopyBytes(from, to, N)` calls (where `N` is the number of bytes to copy) in hwy/contrib/sort/algo-inl.h, hwy/contrib/sort/vqsort-inl.h, hwy/contrib/unroller/unroller-inl.h, hwy/ops/emu128-inl.h, 
hwy/ops/x86_128-inl.h, and hwy/ops/x86_256-inl.h.