### PR TITLE
Fixed UI64 ScalarAbsDiff in TestIntegerAbsDiff

### DIFF
--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -502,9 +502,11 @@ struct TestIntegerAbsDiff {
   template<typename T, HWY_IF_T_SIZE(T, 8)>
   static inline T ScalarAbsDiff(T a, T b) {
     if (a >= b) {
-      return a - b;
+      return static_cast<T>(static_cast<uint64_t>(a) -
+                            static_cast<uint64_t>(b));
     } else {
-      return b - a;
+      return static_cast<T>(static_cast<uint64_t>(b) -
+                            static_cast<uint64_t>(a));
     }
   }
 


### PR DESCRIPTION
Updated UI64 ScalarAbsDiff in TestIntegerAbsDiff to cast its operands to uint64_t before subtraction as subtraction overflow in int64_t ScalarAbsDiff is possible on the RVV target if `Lanes(ScalableTag<int64_t>()) >= 8` is true (which implies that `Lanes(ScalableTag<int64_t, 3>()) >= 64` is true on the RVV target).