### PR TITLE
Made fixes and enhancements to IfNegativeThenElse

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -3566,7 +3566,7 @@ HWY_API V IfNegativeThenElse(V v, V yes, V no) {
   const DFromV<V> d;
   const RebindToSigned<decltype(d)> di;
 
-  const svbool_t m = MaskFromVec(BitCast(d, BroadcastSignBit(BitCast(di, v))));
+  const svbool_t m = detail::LtN(BitCast(di, v), 0);
   return IfThenElse(m, yes, no);
 }
 

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -354,8 +354,12 @@ HWY_API Vec128<T, N> IfThenZeroElse(Mask128<T, N> mask, Vec128<T, N> no) {
 template <typename T, size_t N>
 HWY_API Vec128<T, N> IfNegativeThenElse(Vec128<T, N> v, Vec128<T, N> yes,
                                         Vec128<T, N> no) {
+  const DFromV<decltype(v)> d;
+  const RebindToSigned<decltype(d)> di;
+  const auto vi = BitCast(di, v);
+
   for (size_t i = 0; i < N; ++i) {
-    v.raw[i] = v.raw[i] < 0 ? yes.raw[i] : no.raw[i];
+    v.raw[i] = vi.raw[i] < 0 ? yes.raw[i] : no.raw[i];
   }
   return v;
 }

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1114,22 +1114,20 @@ template <class V, HWY_IF_I32_D(DFromV<V>)>
 HWY_API V SaturatedAdd(V a, V b) {
   const DFromV<decltype(a)> d;
   const auto sum = Add(a, b);
-  const auto overflow_mask =
-      MaskFromVec(BroadcastSignBit(AndNot(Xor(a, b), Xor(a, sum))));
+  const auto overflow_mask = AndNot(Xor(a, b), Xor(a, sum));
   const auto overflow_result =
       Xor(BroadcastSignBit(a), Set(d, LimitsMax<int32_t>()));
-  return IfThenElse(overflow_mask, overflow_result, sum);
+  return IfNegativeThenElse(overflow_mask, overflow_result, sum);
 }
 
 template <class V, HWY_IF_I32_D(DFromV<V>)>
 HWY_API V SaturatedSub(V a, V b) {
   const DFromV<decltype(a)> d;
   const auto diff = Sub(a, b);
-  const auto overflow_mask =
-      MaskFromVec(BroadcastSignBit(And(Xor(a, b), Xor(a, diff))));
+  const auto overflow_mask = And(Xor(a, b), Xor(a, diff));
   const auto overflow_result =
       Xor(BroadcastSignBit(a), Set(d, LimitsMax<int32_t>()));
-  return IfThenElse(overflow_mask, overflow_result, diff);
+  return IfNegativeThenElse(overflow_mask, overflow_result, diff);
 }
 
 #endif  // HWY_NATIVE_I32_SATURATED_ADDSUB
@@ -1145,22 +1143,20 @@ template <class V, HWY_IF_I64_D(DFromV<V>)>
 HWY_API V SaturatedAdd(V a, V b) {
   const DFromV<decltype(a)> d;
   const auto sum = Add(a, b);
-  const auto overflow_mask =
-      MaskFromVec(BroadcastSignBit(AndNot(Xor(a, b), Xor(a, sum))));
+  const auto overflow_mask = AndNot(Xor(a, b), Xor(a, sum));
   const auto overflow_result =
       Xor(BroadcastSignBit(a), Set(d, LimitsMax<int64_t>()));
-  return IfThenElse(overflow_mask, overflow_result, sum);
+  return IfNegativeThenElse(overflow_mask, overflow_result, sum);
 }
 
 template <class V, HWY_IF_I64_D(DFromV<V>)>
 HWY_API V SaturatedSub(V a, V b) {
   const DFromV<decltype(a)> d;
   const auto diff = Sub(a, b);
-  const auto overflow_mask =
-      MaskFromVec(BroadcastSignBit(And(Xor(a, b), Xor(a, diff))));
+  const auto overflow_mask = And(Xor(a, b), Xor(a, diff));
   const auto overflow_result =
       Xor(BroadcastSignBit(a), Set(d, LimitsMax<int64_t>()));
-  return IfThenElse(overflow_mask, overflow_result, diff);
+  return IfNegativeThenElse(overflow_mask, overflow_result, diff);
 }
 
 #endif  // HWY_NATIVE_I64_SATURATED_ADDSUB

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -1450,8 +1450,7 @@ HWY_API V IfNegativeThenElse(V v, V yes, V no) {
   const DFromV<V> d;
   const RebindToSigned<decltype(d)> di;
 
-  MFromD<decltype(d)> m =
-      MaskFromVec(BitCast(d, BroadcastSignBit(BitCast(di, v))));
+  MFromD<decltype(d)> m = detail::LtS(BitCast(di, v), 0);
   return IfThenElse(m, yes, no);
 }
 

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -338,7 +338,11 @@ HWY_API Vec1<T> IfThenZeroElse(const Mask1<T> mask, const Vec1<T> no) {
 
 template <typename T>
 HWY_API Vec1<T> IfNegativeThenElse(Vec1<T> v, Vec1<T> yes, Vec1<T> no) {
-  return v.raw < 0 ? yes : no;
+  const DFromV<decltype(v)> d;
+  const RebindToSigned<decltype(d)> di;
+  const auto vi = BitCast(di, v);
+
+  return vi.raw < 0 ? yes : no;
 }
 
 template <typename T>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -3206,6 +3206,7 @@ HWY_API Vec128<T, N> IfNegativeThenElse(Vec128<T, N> v, Vec128<T, N> yes,
 #if HWY_TARGET <= HWY_AVX3
   // No need to cast to float or broadcast sign bit on AVX3 as IfThenElse only
   // looks at the MSB on AVX3
+  (void)d;
   const auto mask = MaskFromVec(v);
 #else
   const RebindToSigned<decltype(d)> di;

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2007,12 +2007,12 @@ HWY_API Vec256<int8_t> IfNegativeThenElse(Vec256<int8_t> v, Vec256<int8_t> yes,
 template <typename T, HWY_IF_T_SIZE(T, 2)>
 HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
   static_assert(IsSigned<T>(), "Only works for signed/float");
-  const DFromV<decltype(v)> d;
 
 #if HWY_TARGET <= HWY_AVX3
   const auto mask = MaskFromVec(v);
 #else
   // 16-bit: no native blendv on AVX2, so copy sign to lower byte's MSB.
+  const DFromV<decltype(v)> d;
   const RebindToSigned<decltype(d)> di;
   const auto mask = MaskFromVec(BitCast(d, BroadcastSignBit(BitCast(di, v))));
 #endif
@@ -2023,13 +2023,13 @@ HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
 template <typename T, HWY_IF_T_SIZE_ONE_OF(T, (1 << 4) | (1 << 8))>
 HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
   static_assert(IsSigned<T>(), "Only works for signed/float");
-  const DFromV<decltype(v)> d;
 
 #if HWY_TARGET <= HWY_AVX3
   // No need to cast to float on AVX3 as IfThenElse only looks at the MSB on
   // AVX3
   return IfThenElse(MaskFromVec(v), yes, no);
 #else
+  const DFromV<decltype(v)> d;
   const RebindToFloat<decltype(d)> df;
   // 32/64-bit: use float IfThenElse, which only looks at the MSB.
   const MFromD<decltype(df)> msb = MaskFromVec(BitCast(df, v));

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2008,22 +2008,33 @@ template <typename T, HWY_IF_T_SIZE(T, 2)>
 HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
   static_assert(IsSigned<T>(), "Only works for signed/float");
   const DFromV<decltype(v)> d;
-  const RebindToSigned<decltype(d)> di;
 
-  // 16-bit: no native blendv, so copy sign to lower byte's MSB.
-  v = BitCast(d, BroadcastSignBit(BitCast(di, v)));
-  return IfThenElse(MaskFromVec(v), yes, no);
+#if HWY_TARGET <= HWY_AVX3
+  const auto mask = MaskFromVec(v);
+#else
+  // 16-bit: no native blendv on AVX2, so copy sign to lower byte's MSB.
+  const RebindToSigned<decltype(d)> di;
+  const auto mask = MaskFromVec(BitCast(d, BroadcastSignBit(BitCast(di, v))));
+#endif
+
+  return IfThenElse(mask, yes, no);
 }
 
-template <typename T, HWY_IF_NOT_T_SIZE(T, 2)>
+template <typename T, HWY_IF_T_SIZE_ONE_OF(T, (1 << 4) | (1 << 8))>
 HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
   static_assert(IsSigned<T>(), "Only works for signed/float");
   const DFromV<decltype(v)> d;
-  const RebindToFloat<decltype(d)> df;
 
+#if HWY_TARGET <= HWY_AVX3
+  // No need to cast to float on AVX3 as IfThenElse only looks at the MSB on
+  // AVX3
+  return IfThenElse(MaskFromVec(v), yes, no);
+#else
+  const RebindToFloat<decltype(d)> df;
   // 32/64-bit: use float IfThenElse, which only looks at the MSB.
   const MFromD<decltype(df)> msb = MaskFromVec(BitCast(df, v));
   return BitCast(d, IfThenElse(msb, BitCast(df, yes), BitCast(df, no)));
+#endif
 }
 
 // ------------------------------ ShiftLeftSame


### PR DESCRIPTION
Made the following bug fixes to IfNegativeThenElse:
- Updated SSE2/SSSE3 implementations to broadcast the sign bit
- Updated EMU128/SCALAR implementations to use `vi` (which is `v` bitcasted to `Vec<RebindToSigned<DFromV<decltype(v)>>>`) to match the behavior of x86/NEON/PPC IfNegativeThenElse

Made the following enhancements to IfNegativeThenElse:
- Updated RVV/SVE IfNegativeThenElse to avoid broadcasting the sign bit and simply do a signed integer less-than comparison (as RVV/SVE MaskFromVec simply does a comparison against zero)
- Updated PPC10 IfNegativeThenElse to do a vec_blend (which has the same behavior as SSE4 _mm_blendv_epi8, _mm_blendv_ps, and _mm_blend_pd)

Also updated TestIfNegative to add additional checks that would expose the bugs that were previously there with the SSE2/SSSE3 IfNegativeThenElse implementation.

Also updated I32/I64 SaturatedAdd and SaturatedSub implementations in ppc_vsx-inl.h and generic_ops-inl.h and to use IfNegativeThenElse instead of IfThenElse.