### PR TITLE
Fix arm64 build on Windows with Visual Studio.

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -340,7 +340,7 @@ static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 16;
 
 // float16_t load/store/conversion intrinsics are always supported on Armv8 and
 // VFPv4. On Armv7 Clang requires __ARM_FP & 2; GCC requires -mfp16-format=ieee.
-#if HWY_ARCH_ARM_A64 ||                                            \
+#if HWY_ARCH_ARM_A64 &&                                            \
     (HWY_COMPILER_CLANG && defined(__ARM_FP) && (__ARM_FP & 2)) || \
     HWY_COMPILER_GCC_ACTUAL && defined(__ARM_FP16_FORMAT_IEEE)
 #define HWY_NEON_HAVE_FLOAT16C 1


### PR DESCRIPTION
We are using this project in an arm64 build of the @ImageMagick library and this no longer works with the latest release. This is happening because `HWY_NEON_HAVE_FLOAT16C` becomes `1` while it shouldn't. And it also looks like the current code breaks the next check `(HWY_SVE_HAVE_BFLOAT16)` because the first one will always be true on arm64. This pull request resolves that issue.

p.s. Would you be interested in a Visual Studio x86?/x64/arm64 build to make sure that this project continues to work on the Windows platform?