### PR TITLE
Added LoadN and StoreN operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1095,6 +1095,15 @@ aligned memory at indices which are not a multiple of the vector length):
     equivalent to `MaskedLoadOr(Zero(d), mask, d, p)`, but potentially slightly
     more efficient.
 
+*   <code>Vec&lt;D&gt; **LoadN**(D d, const T* p, size_t max_lanes_to_load)
+    </code>: Loads `HWY_MIN(Lanes(d), max_lanes_to_load)` lanes from `p`
+    to the first (lowest-index) lanes of the result vector and zeroes
+    out the remaining lanes.
+
+    LoadN does not fault if all of the elements in `[p, p + max_lanes_to_load)`
+    are accessible, even if `HWY_MEM_OPS_MIGHT_FAULT` is 1 or
+    `max_lanes_to_load < Lanes(d)` is true.
+
 #### Store
 
 *   <code>void **Store**(Vec&lt;D&gt; v, D, T* aligned)</code>: copies `v[i]`
@@ -1126,6 +1135,13 @@ aligned memory at indices which are not a multiple of the vector length):
     than one vector). Potentially more efficient than a scalar loop, but will
     not fault, unlike `BlendedStore`. No alignment requirement. Potentially
     non-atomic, like `BlendedStore`.
+
+*   <code>void **StoreN**(Vec&lt;D&gt; v, D d, T* HWY_RESTRICT p,
+    size_t max_lanes_to_store)</code>: Stores the first (lowest-index)
+    `HWY_MIN(Lanes(d), max_lanes_to_store)` lanes of `v` to p.
+
+    StoreN does not modify any memory past
+    `p + HWY_MIN(Lanes(d), max_lanes_to_store) - 1`.
 
 #### Interleaved
 

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -1351,6 +1351,22 @@ HWY_API VFromD<D> LoadDup128(D d, const TFromD<D>* HWY_RESTRICT aligned) {
   return Load(d, aligned);
 }
 
+#ifdef HWY_NATIVE_LOAD_N
+#undef HWY_NATIVE_LOAD_N
+#else
+#define HWY_NATIVE_LOAD_N
+#endif
+
+template <class D>
+HWY_API VFromD<D> LoadN(D d, const TFromD<D>* HWY_RESTRICT p,
+                        size_t max_lanes_to_load) {
+  VFromD<D> v = Zero(d);
+  const size_t N = Lanes(d);
+  const size_t num_of_lanes_to_load = HWY_MIN(max_lanes_to_load, N);
+  CopyBytes(p, v.raw, num_of_lanes_to_load * sizeof(TFromD<D>));
+  return v;
+}
+
 // ------------------------------ Store
 
 template <class D>
@@ -1369,6 +1385,20 @@ HWY_API void BlendedStore(VFromD<D> v, MFromD<D> m, D d,
   for (size_t i = 0; i < MaxLanes(d); ++i) {
     if (m.bits[i]) p[i] = v.raw[i];
   }
+}
+
+#ifdef HWY_NATIVE_STORE_N
+#undef HWY_NATIVE_STORE_N
+#else
+#define HWY_NATIVE_STORE_N
+#endif
+
+template <class D>
+HWY_API void StoreN(VFromD<D> v, D d, TFromD<D>* HWY_RESTRICT p,
+                    size_t max_lanes_to_store) {
+  const size_t N = Lanes(d);
+  const size_t num_of_lanes_to_store = HWY_MIN(max_lanes_to_store, N);
+  CopyBytes(v.raw, p, num_of_lanes_to_store * sizeof(TFromD<D>));
 }
 
 // ------------------------------ LoadInterleaved2/3/4

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -1076,6 +1076,18 @@ HWY_API Vec1<T> LoadDup128(D d, const T* HWY_RESTRICT aligned) {
   return Load(d, aligned);
 }
 
+#ifdef HWY_NATIVE_LOAD_N
+#undef HWY_NATIVE_LOAD_N
+#else
+#define HWY_NATIVE_LOAD_N
+#endif
+
+template <class D, typename T = TFromD<D>>
+HWY_API VFromD<D> LoadN(D d, const T* HWY_RESTRICT p,
+                        size_t max_lanes_to_load) {
+  return (max_lanes_to_load > 0) ? Load(d, p) : Zero(d);
+}
+
 // ------------------------------ Store
 
 template <class D, typename T = TFromD<D>>
@@ -1092,6 +1104,20 @@ template <class D, typename T = TFromD<D>>
 HWY_API void BlendedStore(const Vec1<T> v, Mask1<T> m, D d, T* HWY_RESTRICT p) {
   if (!m.bits) return;
   StoreU(v, d, p);
+}
+
+#ifdef HWY_NATIVE_STORE_N
+#undef HWY_NATIVE_STORE_N
+#else
+#define HWY_NATIVE_STORE_N
+#endif
+
+template <class D, typename T = TFromD<D>>
+HWY_API void StoreN(VFromD<D> v, D d, T* HWY_RESTRICT p,
+                    size_t max_lanes_to_store) {
+  if (max_lanes_to_store > 0) {
+    Store(v, d, p);
+  }
 }
 
 // ------------------------------ LoadInterleaved2/3/4

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -5909,7 +5909,18 @@ HWY_API void StoreN(VFromD<D> v, D d, T* HWY_RESTRICT p,
                     size_t max_lanes_to_store) {
   const size_t num_of_lanes_to_store =
       HWY_MIN(max_lanes_to_store, HWY_MAX_LANES_D(D));
+
+#if HWY_COMPILER_MSVC
+  // Work around MSVC compiler bug by using a HWY_FENCE before the BlendedStore
+  HWY_FENCE;
+#endif
+
   BlendedStore(v, FirstN(d, num_of_lanes_to_store), d, p);
+
+#if HWY_COMPILER_MSVC
+  // Work around MSVC compiler bug by using a HWY_FENCE after the BlendedStore
+  HWY_FENCE;
+#endif
 }
 
 #if HWY_TARGET > HWY_AVX3
@@ -5978,6 +5989,11 @@ HWY_API void StoreN(VFromD<D> v, D d, T* HWY_RESTRICT p,
       di32_full, VecFromMask(du_full, FirstN(du_full, num_of_lanes_to_store)));
   const auto vi32 = ResizeBitCast(di32_full, v);
 
+#if HWY_COMPILER_MSVC
+  // Work around MSVC compiler bug by using a HWY_FENCE before the BlendedStore
+  HWY_FENCE;
+#endif
+
   BlendedStore(vi32, MaskFromVec(i32_store_mask), di32_full,
                reinterpret_cast<int32_t*>(p));
 
@@ -5991,6 +6007,11 @@ HWY_API void StoreN(VFromD<D> v, D d, T* HWY_RESTRICT p,
                           num_of_lanes_to_store / kNumOfLanesPerI32));
     detail::AVX2UIF8Or16StoreTrailingN(v_trailing, d, p, num_of_lanes_to_store);
   }
+
+#if HWY_COMPILER_MSVC
+  // Work around MSVC compiler bug by using a HWY_FENCE after the BlendedStore
+  HWY_FENCE;
+#endif
 }
 #endif  // HWY_TARGET > HWY_AVX3
 #endif  // HWY_TARGET <= HWY_AVX2


### PR DESCRIPTION
Added the LoadN operation to allow only the first (lowest-indexed) `HWY_MIN(Lanes(d), max_lanes_to_load)` lanes to be loaded without faulting.

Also added the StoreN operation to allow only the first (lowest-indexed) `HWY_MIN(Lanes(d), max_lanes_to_store)` lanes to be stored without faulting or modifying any memory past `p + HWY_MIN(Lanes(d), max_lanes_to_store) - 1`.