### PR TITLE
Added SatWidenMulPairwiseAdd

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -604,6 +604,13 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     <code>Vec&lt;D&gt; **WidenMulPairwiseAdd**(D d, V a, V b,)</code>: widens `a`
     and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`.
 
+*   `V`: `u8`, `VU`: `Vec<RebindToUnsigned<DFromV<V>>>`,
+    `D`: `RepartitionToWide<DFromV<V>>` \
+    <code>Vec&lt;D&gt; **SatWidenMulPairwiseAdd**(D d, VU a, V b)</code>:
+    widens `a` and `b` to `TFromD<D>` and computes
+    `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`, saturated to the range of
+    `TFromD<D>`.
+
 *   `V`: `{bf,i}16`, `D`: `RepartitionToWide<DFromV<V>>`, `VW`: `Vec<D>` \
     <code>VW **ReorderWidenMulAccumulate**(D d, V a, V b, VW sum0, VW&
     sum1)</code>: widens `a` and `b` to `TFromD<D>`, then adds `a[i] * b[i]` to

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -604,11 +604,11 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     <code>Vec&lt;D&gt; **WidenMulPairwiseAdd**(D d, V a, V b,)</code>: widens `a`
     and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`.
 
-*   `V`: `u8`, `VU`: `Vec<RebindToUnsigned<DFromV<V>>>`,
-    `D`: `RepartitionToWide<DFromV<V>>` \
-    <code>Vec&lt;D&gt; **SatWidenMulPairwiseAdd**(D d, VU a, V b)</code>:
-    widens `a` and `b` to `TFromD<D>` and computes
-    `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`, saturated to the range of
+*   `VI`: `i8`, `VU`: `Vec<RebindToUnsigned<DFromV<VI>>>`,
+    `DI`: `RepartitionToWide<DFromV<VI>>` \
+    <code>Vec&lt;D&gt; **SatWidenMulPairwiseAdd**(DI di, VU a_u, VI b_i)</code>:
+    widens `a_u` and `b_i` to `TFromD<DI>` and computes
+    `a_u[2*i+1]*b_i[2*i+1] + a_u[2*i+0]*b_i[2*i+0]`, saturated to the range of
     `TFromD<D>`.
 
 *   `V`: `{bf,i}16`, `D`: `RepartitionToWide<DFromV<V>>`, `VW`: `Vec<D>` \

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -1795,6 +1795,16 @@ HWY_API Vec1<int32_t> WidenMulPairwiseAdd(D32 /* tag */, Vec1<int16_t> a,
 template <class DI16, HWY_IF_I16_D(DI16)>
 HWY_API Vec1<int16_t> SatWidenMulPairwiseAdd(DI16 /* tag */, Vec1<uint8_t> a,
                                              Vec1<int8_t> b) {
+  // Saturation of a.raw * b.raw is not needed on the HWY_SCALAR target as the
+  // input vectors only have 1 lane on the HWY_SCALAR target and as
+  // a.raw * b.raw is between -32640 and 32385, which is already within the
+  // range of an int16_t.
+
+  // On other targets, a saturated addition of a[0]*b[0] + a[1]*b[1] is needed
+  // as it is possible for the addition of a[0]*b[0] + a[1]*b[1] to overflow if
+  // a[0], a[1], b[0], and b[1] are all non-zero and b[0] and b[1] both have the
+  // same sign.
+
   return Vec1<int16_t>(static_cast<int16_t>(a.raw) *
                        static_cast<int16_t>(b.raw));
 }

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -1784,6 +1784,21 @@ HWY_API Vec1<int32_t> WidenMulPairwiseAdd(D32 /* tag */, Vec1<int16_t> a,
   return Vec1<int32_t>(a.raw * b.raw);
 }
 
+// ------------------------------ SatWidenMulPairwiseAdd
+
+#ifdef HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#undef HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#else
+#define HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#endif
+
+template <class DI16, HWY_IF_I16_D(DI16)>
+HWY_API Vec1<int16_t> SatWidenMulPairwiseAdd(DI16 /* tag */, Vec1<uint8_t> a,
+                                             Vec1<int8_t> b) {
+  return Vec1<int16_t>(static_cast<int16_t>(a.raw) *
+                       static_cast<int16_t>(b.raw));
+}
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)
 
 template <class D32, HWY_IF_F32_D(D32)>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -7091,12 +7091,10 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 /* tag */, V16 a, V16 b) {
 
 // Even if N=1, the input is always at least 2 lanes, hence _mm_maddubs_epi16
 // is safe.
-template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
-          HWY_IF_V_SIZE_LE_D(DI16, 16), HWY_IF_U8_D(DFromV<VU8>),
-          HWY_IF_I8_D(DFromV<VI8>),
-          HWY_IF_LANES_D(DFromV<VU8>, HWY_MAX_LANES_V(VI8)),
-          HWY_IF_LANES_D(DFromV<VU8>, 2 * HWY_MAX_LANES_D(DI16))>
-HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+template <class DI16, HWY_IF_I16_D(DI16), HWY_IF_V_SIZE_LE_D(DI16, 16)>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(
+    DI16 /* tag */, VFromD<Repartition<uint8_t, DI16>> a,
+    VFromD<Repartition<int8_t, DI16>> b) {
   return VFromD<DI16>{_mm_maddubs_epi16(a.raw, b.raw)};
 }
 

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -7079,6 +7079,29 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 /* tag */, V16 a, V16 b) {
   return VFromD<D32>{_mm_madd_epi16(a.raw, b.raw)};
 }
 
+// ------------------------------ SatWidenMulPairwiseAdd
+
+#if HWY_TARGET <= HWY_SSSE3
+
+#ifdef HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#undef HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#else
+#define HWY_NATIVE_U8_I8_SATWIDENMULPAIRWISEADD
+#endif
+
+// Even if N=1, the input is always at least 2 lanes, hence _mm_maddubs_epi16
+// is safe.
+template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
+          HWY_IF_V_SIZE_LE_D(DI16, 16), HWY_IF_U8_D(DFromV<VU8>),
+          HWY_IF_I8_D(DFromV<VI8>),
+          HWY_IF_LANES_D(DFromV<VU8>, HWY_MAX_LANES_V(VI8)),
+          HWY_IF_LANES_D(DFromV<VU8>, 2 * HWY_MAX_LANES_D(DI16))>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+  return VFromD<DI16>{_mm_maddubs_epi16(a.raw, b.raw)};
+}
+
+#endif
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ShiftLeft)
 
 // Generic for all vector lengths.

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -5307,6 +5307,16 @@ HWY_API Vec256<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec256<int16_t> a,
   return Vec256<int32_t>{_mm256_madd_epi16(a.raw, b.raw)};
 }
 
+// ------------------------------ SatWidenMulPairwiseAdd
+
+template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
+          HWY_IF_V_SIZE_D(DI16, 32), HWY_IF_U8_D(DFromV<VU8>),
+          HWY_IF_I8_D(DFromV<VI8>), HWY_IF_LANES_D(DFromV<VU8>, 32),
+          HWY_IF_LANES_D(DFromV<VI8>, 32)>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+  return VFromD<DI16>{_mm256_maddubs_epi16(a.raw, b.raw)};
+}
+
 // ------------------------------ ReorderWidenMulAccumulate
 template <class D, HWY_IF_SIGNED_D(D)>
 HWY_API Vec256<int32_t> ReorderWidenMulAccumulate(D d, Vec256<int16_t> a,

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -5309,11 +5309,10 @@ HWY_API Vec256<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec256<int16_t> a,
 
 // ------------------------------ SatWidenMulPairwiseAdd
 
-template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
-          HWY_IF_V_SIZE_D(DI16, 32), HWY_IF_U8_D(DFromV<VU8>),
-          HWY_IF_I8_D(DFromV<VI8>), HWY_IF_LANES_D(DFromV<VU8>, 32),
-          HWY_IF_LANES_D(DFromV<VI8>, 32)>
-HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+template <class DI16, HWY_IF_I16_D(DI16), HWY_IF_V_SIZE_D(DI16, 32)>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(
+    DI16 /* tag */, VFromD<Repartition<uint8_t, DI16>> a,
+    VFromD<Repartition<int8_t, DI16>> b) {
   return VFromD<DI16>{_mm256_maddubs_epi16(a.raw, b.raw)};
 }
 

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -6425,6 +6425,16 @@ HWY_API Vec512<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec512<int16_t> a,
   return Vec512<int32_t>{_mm512_madd_epi16(a.raw, b.raw)};
 }
 
+// ------------------------------ SatWidenMulPairwiseAdd
+
+template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
+          HWY_IF_V_SIZE_D(DI16, 64), HWY_IF_U8_D(DFromV<VU8>),
+          HWY_IF_I8_D(DFromV<VI8>), HWY_IF_LANES_D(DFromV<VU8>, 64),
+          HWY_IF_LANES_D(DFromV<VI8>, 64)>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+  return VFromD<DI16>{_mm512_maddubs_epi16(a.raw, b.raw)};
+}
+
 // ------------------------------ ReorderWidenMulAccumulate
 template <class D, HWY_IF_I32_D(D)>
 HWY_API Vec512<int32_t> ReorderWidenMulAccumulate(D d, Vec512<int16_t> a,

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -6427,11 +6427,10 @@ HWY_API Vec512<int32_t> WidenMulPairwiseAdd(D /*d32*/, Vec512<int16_t> a,
 
 // ------------------------------ SatWidenMulPairwiseAdd
 
-template <class DI16, class VU8, class VI8, HWY_IF_I16_D(DI16),
-          HWY_IF_V_SIZE_D(DI16, 64), HWY_IF_U8_D(DFromV<VU8>),
-          HWY_IF_I8_D(DFromV<VI8>), HWY_IF_LANES_D(DFromV<VU8>, 64),
-          HWY_IF_LANES_D(DFromV<VI8>, 64)>
-HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(DI16 /* tag */, VU8 a, VI8 b) {
+template <class DI16, HWY_IF_I16_D(DI16), HWY_IF_V_SIZE_D(DI16, 64)>
+HWY_API VFromD<DI16> SatWidenMulPairwiseAdd(
+    DI16 /* tag */, VFromD<Repartition<uint8_t, DI16>> a,
+    VFromD<Repartition<int8_t, DI16>> b) {
   return VFromD<DI16>{_mm512_maddubs_epi16(a.raw, b.raw)};
 }
 

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -435,6 +435,186 @@ HWY_NOINLINE void TestAllWidenMulPairwiseAdd() {
   ForShrinkableVectors<TestWidenMulPairwiseAdd>()(int16_t());
 }
 
+struct TestSatWidenMulPairwiseAdd {
+  template <typename TN, class DN>
+  HWY_NOINLINE void operator()(TN /*unused*/, DN dn) {
+    static_assert(IsSame<TN, int8_t>(), "TN should be int8_t");
+
+    using TN_U = MakeUnsigned<TN>;
+    using TW = MakeWide<TN>;
+    const RepartitionToWide<DN> dw;
+    using VW = Vec<decltype(dw)>;
+    using VN = Vec<decltype(dn)>;
+    const size_t NN = Lanes(dn);
+    const size_t NW = Lanes(dw);
+    HWY_ASSERT(NN == NW * 2);
+
+    const RebindToUnsigned<decltype(dn)> dn_u;
+
+    const VW f0 = Zero(dw);
+    const VN nf0 = Zero(dn);
+    const VN nf1 = Set(dn, TN{1});
+
+    // Any input zero => both outputs zero
+    HWY_ASSERT_VEC_EQ(dw, f0,
+                      SatWidenMulPairwiseAdd(dw, BitCast(dn_u, nf0), nf0));
+    HWY_ASSERT_VEC_EQ(dw, f0,
+                      SatWidenMulPairwiseAdd(dw, BitCast(dn_u, nf0), nf1));
+    HWY_ASSERT_VEC_EQ(dw, f0,
+                      SatWidenMulPairwiseAdd(dw, BitCast(dn_u, nf1), nf0));
+
+    // delta[p] := p all others zero.
+    auto delta_w = AllocateAligned<TW>(NN);
+    HWY_ASSERT(delta_w);
+
+    auto expected = AllocateAligned<TW>(NW);
+    HWY_ASSERT(expected);
+    Store(f0, dw, expected.get());
+
+    for (size_t p = 0; p < NN; ++p) {
+      // Workaround for incorrect Clang wasm codegen: re-initialize the entire
+      // array rather than zero-initialize once and then set lane p to p.
+
+      const TN pn = static_cast<TN>(p);
+      const TN_U pn_u = static_cast<TN_U>(pn);
+      for (size_t i = 0; i < NN; ++i) {
+        delta_w[i] = static_cast<TW>((i == p) ? pn : 0);
+      }
+      const VW delta0 = Load(dw, delta_w.get() + 0);
+      const VW delta1 = Load(dw, delta_w.get() + NN / 2);
+      const VN delta = OrderedDemote2To(dn, delta0, delta1);
+
+      expected[p / 2] = static_cast<TW>(pn_u);
+      const VW actual_1 = SatWidenMulPairwiseAdd(dw, BitCast(dn_u, delta), nf1);
+      HWY_ASSERT_VEC_EQ(dw, expected.get(), actual_1);
+
+      // Swapped arg order
+      expected[p / 2] = static_cast<TW>(pn);
+      const VW actual_2 = SatWidenMulPairwiseAdd(dw, BitCast(dn_u, nf1), delta);
+      HWY_ASSERT_VEC_EQ(dw, expected.get(), actual_2);
+
+      expected[p / 2] = TW{0};
+    }
+
+    const auto vn_signed_min = Set(dn, LimitsMin<TN>());
+    const auto vn_signed_max = Set(dn, LimitsMax<TN>());
+    const auto vn_unsigned_max = Set(dn_u, LimitsMax<TN_U>());
+    const auto vw_signed_min = Set(dw, LimitsMin<TW>());
+    const auto vw_signed_max = Set(dw, LimitsMax<TW>());
+    const auto vw_neg_tn_unsigned_max =
+        Set(dw, static_cast<TW>(-static_cast<TW>(LimitsMax<TN_U>())));
+
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_max,
+        SatWidenMulPairwiseAdd(dw, vn_unsigned_max, vn_signed_max));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_min,
+        SatWidenMulPairwiseAdd(dw, vn_unsigned_max, vn_signed_min));
+    HWY_ASSERT_VEC_EQ(dw, vw_neg_tn_unsigned_max,
+                      SatWidenMulPairwiseAdd(
+                          dw, vn_unsigned_max,
+                          InterleaveLower(dn, vn_signed_max, vn_signed_min)));
+    HWY_ASSERT_VEC_EQ(dw, vw_neg_tn_unsigned_max,
+                      SatWidenMulPairwiseAdd(
+                          dw, vn_unsigned_max,
+                          InterleaveLower(dn, vn_signed_min, vn_signed_max)));
+
+    const auto vn_iota_zero_repl =
+        Set(dn, static_cast<TN>(LimitsMax<TN>() - 16));
+
+    auto vn_a = And(Iota(dn, TN{1}), vn_signed_max);
+    vn_a = Or(vn_a, IfThenElseZero(Eq(vn_a, nf0), vn_iota_zero_repl));
+
+    auto tmp_lanes = AllocateAligned<TN>(NN);
+    HWY_ASSERT(tmp_lanes);
+
+    Store(vn_a, dn, tmp_lanes.get());
+    for (size_t i = 0; i < NW; i++) {
+      const TW a0 = static_cast<TW>(tmp_lanes[2 * i]);
+      const TW a1 = static_cast<TW>(tmp_lanes[2 * i + 1]);
+      expected[i] = static_cast<TW>(a0 * a0 + a1 * a1);
+    }
+
+    HWY_ASSERT_VEC_EQ(dw, expected.get(),
+                      SatWidenMulPairwiseAdd(dw, BitCast(dn_u, vn_a), vn_a));
+
+    for (size_t i = 0; i < NW; i++) {
+      expected[i] = -expected[i];
+    }
+
+    HWY_ASSERT_VEC_EQ(
+        dw, expected.get(),
+        SatWidenMulPairwiseAdd(dw, BitCast(dn_u, vn_a), Neg(vn_a)));
+
+    auto vn_b = Add(And(vn_a, Set(dn, TN{63})), Set(dn, TN{20}));
+    Store(vn_b, dn, tmp_lanes.get());
+
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_max,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, BitCast(dn_u, vn_b), vn_unsigned_max),
+            InterleaveLower(dn, vn_b, vn_signed_max)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_max,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveUpper(dn_u, BitCast(dn_u, vn_b), vn_unsigned_max),
+            InterleaveUpper(dn, vn_b, vn_signed_max)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_max,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
+            InterleaveLower(dn, vn_signed_max, vn_b)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_max,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveUpper(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
+            InterleaveUpper(dn, vn_signed_max, vn_b)));
+
+    const auto vn_neg_b = Neg(vn_b);
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_min,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, BitCast(dn_u, vn_b), vn_unsigned_max),
+            InterleaveLower(dn, vn_neg_b, vn_signed_min)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_min,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveUpper(dn_u, BitCast(dn_u, vn_b), vn_unsigned_max),
+            InterleaveUpper(dn, vn_neg_b, vn_signed_min)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_min,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
+            InterleaveLower(dn, vn_signed_min, vn_neg_b)));
+    HWY_ASSERT_VEC_EQ(
+        dw, vw_signed_min,
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveUpper(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
+            InterleaveUpper(dn, vn_signed_min, vn_neg_b)));
+
+    for (size_t i = 0; i < NW; i++) {
+      const TW b = static_cast<TW>(tmp_lanes[i]);
+      expected[i] =
+          static_cast<TW>(b * b + static_cast<TW>(LimitsMax<TN_U>()) *
+                                      static_cast<TW>(LimitsMin<TN>()));
+    }
+    HWY_ASSERT_VEC_EQ(
+        dw, expected.get(),
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
+            InterleaveLower(dn, vn_signed_min, vn_b)));
+    HWY_ASSERT_VEC_EQ(
+        dw, expected.get(),
+        SatWidenMulPairwiseAdd(
+            dw, InterleaveLower(dn_u, BitCast(dn_u, vn_b), vn_unsigned_max),
+            InterleaveLower(dn, vn_b, vn_signed_min)));
+  }
+};
+
+HWY_NOINLINE void TestAllSatWidenMulPairwiseAdd() {
+  ForShrinkableVectors<TestSatWidenMulPairwiseAdd>()(int8_t());
+}
+
 struct TestReorderWidenMulAccumulate {
   // Must be inlined on aarch64 for bf16, else clang crashes.
   template <typename TN, class DN>
@@ -572,6 +752,7 @@ HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulFixedPoint15);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulEven);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulAdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllWidenMulPairwiseAdd);
+HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllSatWidenMulPairwiseAdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllReorderWidenMulAccumulate);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllRearrangeToOddPlusEven);
 

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -592,8 +592,13 @@ struct TestSatWidenMulPairwiseAdd {
             dw, InterleaveUpper(dn_u, vn_unsigned_max, BitCast(dn_u, vn_b)),
             InterleaveUpper(dn, vn_signed_min, vn_neg_b)));
 
+    constexpr size_t kMaxLanesPerNBlock = 16 / sizeof(TN);
+    constexpr size_t kMaxLanesPerWBlock = 16 / sizeof(TW);
+
     for (size_t i = 0; i < NW; i++) {
-      const TW b = static_cast<TW>(tmp_lanes[i]);
+      const size_t blk_idx = i / kMaxLanesPerWBlock;
+      const TW b = static_cast<TW>(tmp_lanes[blk_idx * kMaxLanesPerNBlock +
+                                             (i & (kMaxLanesPerWBlock - 1))]);
       expected[i] =
           static_cast<TW>(b * b + static_cast<TW>(LimitsMax<TN_U>()) *
                                       static_cast<TW>(LimitsMin<TN>()));


### PR DESCRIPTION
Added U8xI8 SatWidenMulPairwiseAdd operation, which is a saturated pairwise sum of two adjacent U8xI8 products.

SSSE3/SSE4/AVX2/AVX3 can do an U8xI8 SatWidenMulPairwiseAdd operation using a single pmaddubsw instruction.