### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ tests on 32-bit x86, including AVX2/3, on GCC 7/8 and Clang 8/11/12. On Ubuntu
 above plus `-isystem /usr/i686-linux-gnu/include/c++/12/i686-linux-gnu`. See
 #1279.
 
+## Building highway - Using vcpkg
+
+highway is now available in [vcpkg](https://github.com/Microsoft/vcpkg)
+
+```bash
+vpkg install highway
+```
+
+The highway port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Quick start
 
 You can use the `benchmark` inside examples/ as a starting point.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ above plus `-isystem /usr/i686-linux-gnu/include/c++/12/i686-linux-gnu`. See
 highway is now available in [vcpkg](https://github.com/Microsoft/vcpkg)
 
 ```bash
-vpkg install highway
+vcpkg install highway
 ```
 
 The highway port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
> highway is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for highway and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build highway, ready to be included in their projects.
> 
> We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.
> 
> I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/highway/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)

Dup of #978 by @JonLiu1993
Since #978 is not merged yet, I decied to open this one.