### PR TITLE
Made fixes to TestMulFixedPoint15 and EMU128/SCALAR MulFixedPoint15

### DIFF
--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -858,7 +858,7 @@ template <size_t N>
 HWY_API Vec128<int16_t, N> MulFixedPoint15(Vec128<int16_t, N> a,
                                            Vec128<int16_t, N> b) {
   for (size_t i = 0; i < N; ++i) {
-    a.raw[i] = static_cast<int16_t>((2 * a.raw[i] * b.raw[i] + 32768) >> 16);
+    a.raw[i] = static_cast<int16_t>((a.raw[i] * b.raw[i] + 16384) >> 15);
   }
   return a;
 }

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -734,7 +734,7 @@ HWY_API Vec1<uint16_t> MulHigh(const Vec1<uint16_t> a, const Vec1<uint16_t> b) {
 }
 
 HWY_API Vec1<int16_t> MulFixedPoint15(Vec1<int16_t> a, Vec1<int16_t> b) {
-  return Vec1<int16_t>(static_cast<int16_t>((2 * a.raw * b.raw + 32768) >> 16));
+  return Vec1<int16_t>(static_cast<int16_t>((a.raw * b.raw + 16384) >> 15));
 }
 
 // Multiplies even lanes (0, 2 ..) and returns the double-wide result.

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -193,7 +193,10 @@ struct TestMulFixedPoint15 {
       for (size_t i = 0; i < N; ++i) {
         // There are three ways to compute the results. x86 and Arm are defined
         // using 32-bit multiplication results:
-        const int arm = (2 * in1[i] * in2[i] + 0x8000) >> 16;
+        const int arm =
+            static_cast<int32_t>(2u * static_cast<uint32_t>(in1[i] * in2[i]) +
+                                 0x8000u) >>
+            16;
         const int x86 = (((in1[i] * in2[i]) >> 14) + 1) >> 1;
         // On other platforms, split the result into upper and lower 16 bits.
         const auto v1 = Set(d, in1[i]);


### PR DESCRIPTION
Updated EMU128/SCALAR MulFixedPoint15 to compute `(a[i] * b[i] + 16384) >> 15` instead of `(2 * a[i] * b[i] + 32768) >> 16` to avoid overflow in the case where `a[i]` and `b[i]` are both equal to -32768.

Also changed `2 * in1[i] * in2[i] + 0x8000` to `static_cast<int32_t>(2u * static_cast<uint32_t>(in1[i] * in2[i]) + 0x8000u)` in TestMulFixedPoint15 to avoid undefined behavior in the case where `in1[i]` and `in2[i]` are both equal to -32768.