### PR TITLE
Added SumOfMulQuadAccumulate and a few other multiply operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -635,7 +635,8 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     Exception: if `HWY_TARGET == HWY_SCALAR`, returns `a[0]*b[0]`. Note that the
     initial value of `sum1` must be zero, see `ReorderWidenMulAccumulate`.
 
-*   `VN`: `{u,i}{8,16}`, `D`: `Repartition<MakeWide<MakeWide<TFromV<VN>>>>` \
+*   `VN`: `{u,i}{8,16}`,
+    `D`: `RepartitionToWide<RepartitionToWide<DFromV<VN>>>` \
     <code>Vec&lt;D&gt; **SumOfMulQuadAccumulate**(D d, VN a, VN b,
     Vec&lt;D&gt; sum)</code>: widens `a` and `b` to `TFromD<D>` and computes
     `sum[i] + a[4*i+3]*b[4*i+3] + a[4*i+2]*b[4*i+2] + a[4*i+1]*b[4*i+1] +

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -589,29 +589,29 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     multiplication result and storing the upper half. Results are
     implementation-defined iff both inputs are -32768.
 
-*   `V`: `{u,i}{32},u64` \
+*   `V`: `{u,i}{8,16,32},u64` \
     <code>V2 **MulEven**(V a, V b)</code>: returns double-wide result of `a[i] *
     b[i]` for every even `i`, in lanes `i` (lower) and `i + 1` (upper). `V2` is
     a vector with double-width lanes, or the same as `V` for 64-bit inputs
     (which are only supported if `HWY_TARGET != HWY_SCALAR`).
 
-*   `V`: `u64` \
+*   `V`: `{u,i}{8,16,32},u64` \
     <code>V **MulOdd**(V a, V b)</code>: returns double-wide result of `a[i] *
     b[i]` for every odd `i`, in lanes `i - 1` (lower) and `i` (upper). Only
     supported if `HWY_TARGET != HWY_SCALAR`.
 
-*   `V`: `{bf,i}16`, `D`: `RepartitionToWide<DFromV<V>>` \
-    <code>Vec&lt;D&gt; **WidenMulPairwiseAdd**(D d, V a, V b,)</code>: widens `a`
+*   `V`: `{bf,u,i}16`, `D`: `RepartitionToWide<DFromV<V>>` \
+    <code>Vec&lt;D&gt; **WidenMulPairwiseAdd**(D d, V a, V b)</code>: widens `a`
     and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`.
 
 *   `VI`: `i8`, `VU`: `Vec<RebindToUnsigned<DFromV<VI>>>`,
     `DI`: `RepartitionToWide<DFromV<VI>>` \
-    <code>Vec&lt;D&gt; **SatWidenMulPairwiseAdd**(DI di, VU a_u, VI b_i)</code>:
-    widens `a_u` and `b_i` to `TFromD<DI>` and computes
+    <code>Vec&lt;DI&gt; **SatWidenMulPairwiseAdd**(DI di, VU a_u, VI b_i)
+    </code>: widens `a_u` and `b_i` to `TFromD<DI>` and computes
     `a_u[2*i+1]*b_i[2*i+1] + a_u[2*i+0]*b_i[2*i+0]`, saturated to the range of
     `TFromD<D>`.
 
-*   `V`: `{bf,i}16`, `D`: `RepartitionToWide<DFromV<V>>`, `VW`: `Vec<D>` \
+*   `V`: `{bf,u,i}16`, `D`: `RepartitionToWide<DFromV<V>>`, `VW`: `Vec<D>` \
     <code>VW **ReorderWidenMulAccumulate**(D d, V a, V b, VW sum0, VW&
     sum1)</code>: widens `a` and `b` to `TFromD<D>`, then adds `a[i] * b[i]` to
     either `sum1[j]` or lane `j` of the return value, where `j = P(i)` and `P`
@@ -624,7 +624,7 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     `GetLane(SumOfLanes(d, v))` and may be slightly more efficient than later
     adding `v` to `sum0`.
 
-*   `VW`: `{f,i}32` \
+*   `VW`: `{f,u,i}32` \
     <code>VW **RearrangeToOddPlusEven**(VW sum0, VW sum1)</code>: returns in
     each 32-bit lane with index `i` `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`.
     `sum0` must be the return value of a prior `ReorderWidenMulAccumulate`, and
@@ -635,6 +635,19 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     calls to `ReorderWidenMulAccumulate`, as opposed to after each one.
     Exception: if `HWY_TARGET == HWY_SCALAR`, returns `a[0]*b[0]`. Note that the
     initial value of `sum1` must be zero, see `ReorderWidenMulAccumulate`.
+
+*   `VN`: `{u,i}{8,16}`, `D`: `Repartition<MakeWide<MakeWide<TFromV<VN>>>>` \
+    <code>Vec&lt;D&gt; **SumOfMulQuadAccumulate**(D d, VN a, VN b,
+    Vec&lt;D&gt; sum)</code>: widens `a` and `b` to `TFromD<D>` and computes
+    `sum[i] + a[4*i+3]*b[4*i+3] + a[4*i+2]*b[4*i+2] + a[4*i+1]*b[4*i+1] +
+    a[4*i+0]*b[4*i+0]`
+
+*   `VN_I`: `i8`, `VN_U`: `Vec<RebindToUnsigned<DFromV<VN_I>>>`,
+    `DI`: `Repartition<int32_t, DFromV<VN_I>>` \
+    <code>Vec&lt;DI&gt; **SumOfMulQuadAccumulate**(DI di, VN_U a_u, VN_I b_i,
+    Vec&lt;DI&gt; sum)</code>: widens `a` and `b` to `TFromD<DI>` and computes
+    `sum[i] + a[4*i+3]*b[4*i+3] + a[4*i+2]*b[4*i+2] + a[4*i+1]*b[4*i+1] +
+    a[4*i+0]*b[4*i+0]`
 
 #### Fused multiply-add
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -805,6 +805,7 @@ HWY_SVE_FOREACH(HWY_SVE_RETV_ARGPVV, Mul, mul)
 // ------------------------------ MulHigh
 HWY_SVE_FOREACH_UI16(HWY_SVE_RETV_ARGPVV, MulHigh, mulh)
 // Not part of API, used internally:
+HWY_SVE_FOREACH_UI08(HWY_SVE_RETV_ARGPVV, MulHigh, mulh)
 HWY_SVE_FOREACH_UI32(HWY_SVE_RETV_ARGPVV, MulHigh, mulh)
 HWY_SVE_FOREACH_U64(HWY_SVE_RETV_ARGPVV, MulHigh, mulh)
 
@@ -4478,13 +4479,18 @@ namespace detail {
     return sv##OP##_##CHAR##BITS(a, b);                        \
   }
 
+HWY_SVE_FOREACH_UI16(HWY_SVE_MUL_EVEN, MulEvenNative, mullb)
+HWY_SVE_FOREACH_UI32(HWY_SVE_MUL_EVEN, MulEvenNative, mullb)
 HWY_SVE_FOREACH_UI64(HWY_SVE_MUL_EVEN, MulEvenNative, mullb)
+HWY_SVE_FOREACH_UI16(HWY_SVE_MUL_EVEN, MulOddNative, mullt)
+HWY_SVE_FOREACH_UI32(HWY_SVE_MUL_EVEN, MulOddNative, mullt)
+HWY_SVE_FOREACH_UI64(HWY_SVE_MUL_EVEN, MulOddNative, mullt)
 #undef HWY_SVE_MUL_EVEN
 }  // namespace detail
 #endif
 
 template <class V, class DW = RepartitionToWide<DFromV<V>>,
-          HWY_IF_T_SIZE_V(V, 4)>
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4))>
 HWY_API VFromD<DW> MulEven(const V a, const V b) {
 #if HWY_SVE_HAVE_2
   return BitCast(DW(), detail::MulEvenNative(a, b));
@@ -4492,6 +4498,18 @@ HWY_API VFromD<DW> MulEven(const V a, const V b) {
   const auto lo = Mul(a, b);
   const auto hi = MulHigh(a, b);
   return BitCast(DW(), detail::InterleaveEven(lo, hi));
+#endif
+}
+
+template <class V, class DW = RepartitionToWide<DFromV<V>>,
+          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4))>
+HWY_API VFromD<DW> MulOdd(const V a, const V b) {
+#if HWY_SVE_HAVE_2
+  return BitCast(DW(), detail::MulOddNative(a, b));
+#else
+  const auto lo = Mul(a, b);
+  const auto hi = MulHigh(a, b);
+  return BitCast(DW(), detail::InterleaveOdd(lo, hi));
 #endif
 }
 
@@ -4548,6 +4566,24 @@ HWY_API svint32_t WidenMulPairwiseAdd(Simd<int32_t, N, kPow2> d32, svint16_t a,
 #endif
 }
 
+template <size_t N, int kPow2>
+HWY_API svuint32_t WidenMulPairwiseAdd(Simd<uint32_t, N, kPow2> d32,
+                                       svuint16_t a, svuint16_t b) {
+#if HWY_SVE_HAVE_2
+  (void)d32;
+  return svmlalt_u32(svmullb_u32(a, b), a, b);
+#else
+  const svbool_t pg = detail::PTrue(d32);
+  // Shifting extracts the odd lanes as RearrangeToOddPlusEven prefers.
+  // Fortunately SVE has sign-extension for the even lanes.
+  const svuint32_t ae = svexth_u32_x(pg, BitCast(d32, a));
+  const svuint32_t be = svexth_u32_x(pg, BitCast(d32, b));
+  const svuint32_t ao = ShiftRight<16>(BitCast(d32, a));
+  const svuint32_t bo = ShiftRight<16>(BitCast(d32, b));
+  return svmla_u32_x(pg, svmul_u32_x(pg, ao, bo), ae, be);
+#endif
+}
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)
 
 template <size_t N, int kPow2>
@@ -4596,11 +4632,106 @@ HWY_API svint32_t ReorderWidenMulAccumulate(Simd<int32_t, N, kPow2> d32,
 #endif
 }
 
+template <size_t N, int kPow2>
+HWY_API svuint32_t ReorderWidenMulAccumulate(Simd<uint32_t, N, kPow2> d32,
+                                             svuint16_t a, svuint16_t b,
+                                             const svuint32_t sum0,
+                                             svuint32_t& sum1) {
+#if HWY_SVE_HAVE_2
+  (void)d32;
+  sum1 = svmlalt_u32(sum1, a, b);
+  return svmlalb_u32(sum0, a, b);
+#else
+  const svbool_t pg = detail::PTrue(d32);
+  // Shifting extracts the odd lanes as RearrangeToOddPlusEven prefers.
+  // Fortunately SVE has sign-extension for the even lanes.
+  const svuint32_t ae = svexth_u32_x(pg, BitCast(d32, a));
+  const svuint32_t be = svexth_u32_x(pg, BitCast(d32, b));
+  const svuint32_t ao = ShiftRight<16>(BitCast(d32, a));
+  const svuint32_t bo = ShiftRight<16>(BitCast(d32, b));
+  sum1 = svmla_u32_x(pg, sum1, ao, bo);
+  return svmla_u32_x(pg, sum0, ae, be);
+#endif
+}
+
 // ------------------------------ RearrangeToOddPlusEven
 template <class VW>
 HWY_API VW RearrangeToOddPlusEven(const VW sum0, const VW sum1) {
   // sum0 is the sum of bottom/even lanes and sum1 of top/odd lanes.
   return Add(sum0, sum1);
+}
+
+// ------------------------------ SumOfMulQuadAccumulate
+
+#ifdef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DI32, HWY_IF_I32_D(DI32)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 /*di32*/, svint8_t a,
+                                            svint8_t b, svint32_t sum) {
+  return svdot_s32(sum, a, b);
+}
+
+#ifdef HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DU32, HWY_IF_U32_D(DU32)>
+HWY_API VFromD<DU32> SumOfMulQuadAccumulate(DU32 /*du32*/, svuint8_t a,
+                                            svuint8_t b, svuint32_t sum) {
+  return svdot_u32(sum, a, b);
+}
+
+#ifdef HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DI32, HWY_IF_I32_D(DI32)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 di32, svuint8_t a_u,
+                                            svint8_t b_i, svint32_t sum) {
+  // TODO: use svusdot_u32 on SVE targets that require support for both SVE2
+  // and SVE I8MM.
+
+  const RebindToUnsigned<decltype(di32)> du32;
+  const Repartition<uint8_t, decltype(di32)> du8;
+
+  const auto b_u = BitCast(du8, b_i);
+  const auto result_sum0 = svdot_u32(BitCast(du32, sum), a_u, b_u);
+  const auto result_sum1 =
+      ShiftLeft<8>(svdot_u32(Zero(du32), a_u, ShiftRight<7>(b_u)));
+
+  return BitCast(di32, Sub(result_sum0, result_sum1));
+}
+
+#ifdef HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DI64, HWY_IF_I64_D(DI64)>
+HWY_API VFromD<DI64> SumOfMulQuadAccumulate(DI64 /*di64*/, svint16_t a,
+                                            svint16_t b, svint64_t sum) {
+  return svdot_s64(sum, a, b);
+}
+
+#ifdef HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DU64, HWY_IF_U64_D(DU64)>
+HWY_API VFromD<DU64> SumOfMulQuadAccumulate(DU64 /*du64*/, svuint16_t a,
+                                            svuint16_t b, svuint64_t sum) {
+  return svdot_u64(sum, a, b);
 }
 
 // ------------------------------ AESRound / CLMul

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -2544,6 +2544,173 @@ HWY_API Vec<DI16> SatWidenMulPairwiseAdd(DI16 di16, VU8 a, VI8 b) {
 
 #endif
 
+// ------------------------------ SumOfMulQuadAccumulate
+
+#if (defined(HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE) == \
+     defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DI32, HWY_IF_I32_D(DI32)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 di32,
+                                            VFromD<Repartition<int8_t, DI32>> a,
+                                            VFromD<Repartition<int8_t, DI32>> b,
+                                            VFromD<DI32> sum) {
+  const Repartition<int16_t, decltype(di32)> di16;
+
+  const auto a0 = ShiftRight<8>(ShiftLeft<8>(BitCast(di16, a)));
+  const auto b0 = ShiftRight<8>(ShiftLeft<8>(BitCast(di16, b)));
+
+  const auto a1 = ShiftRight<8>(BitCast(di16, a));
+  const auto b1 = ShiftRight<8>(BitCast(di16, b));
+
+  return Add(sum, Add(WidenMulPairwiseAdd(di32, a0, b0),
+                      WidenMulPairwiseAdd(di32, a1, b1)));
+}
+
+#endif
+
+#if (defined(HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE) == \
+     defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U8_U8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DU32, HWY_IF_U32_D(DU32)>
+HWY_API VFromD<DU32> SumOfMulQuadAccumulate(
+    DU32 du32, VFromD<Repartition<uint8_t, DU32>> a,
+    VFromD<Repartition<uint8_t, DU32>> b, VFromD<DU32> sum) {
+  const Repartition<uint16_t, decltype(du32)> du16;
+  const RebindToSigned<decltype(du16)> di16;
+  const RebindToSigned<decltype(du32)> di32;
+
+  const auto lo8_mask = Set(di16, int16_t{0x00FF});
+  const auto a0 = And(BitCast(di16, a), lo8_mask);
+  const auto b0 = And(BitCast(di16, b), lo8_mask);
+
+  const auto a1 = BitCast(di16, ShiftRight<8>(BitCast(du16, a)));
+  const auto b1 = BitCast(di16, ShiftRight<8>(BitCast(du16, b)));
+
+  return Add(sum, Add(BitCast(du32, WidenMulPairwiseAdd(di32, a0, b0)),
+                      BitCast(du32, WidenMulPairwiseAdd(di32, a1, b1))));
+}
+
+#endif
+
+#if (defined(HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE) == \
+     defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
+#endif
+
+template <class DI32, HWY_IF_I32_D(DI32)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(
+    DI32 di32, VFromD<Repartition<uint8_t, DI32>> a_u,
+    VFromD<Repartition<int8_t, DI32>> b_i, VFromD<DI32> sum) {
+  const Repartition<int16_t, decltype(di32)> di16;
+  const RebindToUnsigned<decltype(di16)> du16;
+
+  const auto a0 = And(BitCast(di16, a_u), Set(di16, int16_t{0x00FF}));
+  const auto b0 = ShiftRight<8>(ShiftLeft<8>(BitCast(di16, b_i)));
+
+  const auto a1 = BitCast(di16, ShiftRight<8>(BitCast(du16, a_u)));
+  const auto b1 = ShiftRight<8>(BitCast(di16, b_i));
+
+  // NOTE: SatWidenMulPairwiseAdd(di16, a_u, b_i) cannot be used in
+  // SumOfMulQuadAccumulate as it is possible for
+  // a_u[0]*b_i[0]+a_u[1]*b_i[1] to overflow an int16_t if a_u[0], b_i[0],
+  // a_u[1], and b_i[1] are all non-zero and b_i[0] and b_i[1] have the same
+  // sign.
+
+  return Add(sum, Add(WidenMulPairwiseAdd(di32, a0, b0),
+                      WidenMulPairwiseAdd(di32, a1, b1)));
+}
+
+#endif
+
+#if (defined(HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE) == \
+     defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+#endif
+
+#if HWY_HAVE_INTEGER64
+template <class DI64, HWY_IF_I64_D(DI64)>
+HWY_API VFromD<DI64> SumOfMulQuadAccumulate(
+    DI64 di64, VFromD<Repartition<int16_t, DI64>> a,
+    VFromD<Repartition<int16_t, DI64>> b, VFromD<DI64> sum) {
+  const Repartition<int32_t, decltype(di64)> di32;
+
+  // WidenMulPairwiseAdd(di32, a, b) is okay here as
+  // a[0]*b[0]+a[1]*b[1] is between -2147418112 and 2147483648 and as
+  // a[0]*b[0]+a[1]*b[1] can only overflow an int32_t if
+  // a[0], b[0], a[1], and b[1] are all equal to -32768.
+
+  const auto i32_pairwise_sum = WidenMulPairwiseAdd(di32, a, b);
+  const auto i32_pairwise_sum_overflow =
+      VecFromMask(di32, Eq(i32_pairwise_sum, Set(di32, LimitsMin<int32_t>())));
+
+  // The upper 32 bits of sum0 and sum1 need to be zeroed out in the case of
+  // overflow.
+  const auto hi32_mask = Set(di64, static_cast<int64_t>(~int64_t{0xFFFFFFFF}));
+  const auto p0_zero_out_mask =
+      ShiftLeft<32>(BitCast(di64, i32_pairwise_sum_overflow));
+  const auto p1_zero_out_mask =
+      And(BitCast(di64, i32_pairwise_sum_overflow), hi32_mask);
+
+  const auto p0 =
+      AndNot(p0_zero_out_mask,
+             ShiftRight<32>(ShiftLeft<32>(BitCast(di64, i32_pairwise_sum))));
+  const auto p1 =
+      AndNot(p1_zero_out_mask, ShiftRight<32>(BitCast(di64, i32_pairwise_sum)));
+
+  return Add(sum, Add(p0, p1));
+}
+#endif  // HWY_HAVE_INTEGER64
+#endif  // HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE
+
+#if (defined(HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE) == \
+     defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#undef HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#else
+#define HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+#endif
+
+#if HWY_HAVE_INTEGER64
+template <class DU64, HWY_IF_U64_D(DU64)>
+HWY_API VFromD<DU64> SumOfMulQuadAccumulate(
+    DU64 du64, VFromD<Repartition<uint16_t, DU64>> a,
+    VFromD<Repartition<uint16_t, DU64>> b, VFromD<DU64> sum) {
+  const auto u32_even_prod = MulEven(a, b);
+  const auto u32_odd_prod = MulOdd(a, b);
+
+  const auto lo32_mask = Set(du64, uint64_t{0xFFFFFFFFu});
+
+  const auto p0 = Add(And(BitCast(du64, u32_even_prod), lo32_mask),
+                      And(BitCast(du64, u32_odd_prod), lo32_mask));
+  const auto p1 = Add(ShiftRight<32>(BitCast(du64, u32_even_prod)),
+                      ShiftRight<32>(BitCast(du64, u32_odd_prod)));
+
+  return Add(sum, Add(p0, p1));
+}
+#endif  // HWY_HAVE_INTEGER64
+#endif  // HWY_NATIVE_U16_U16_SUMOFMULQUADACCUMULATE
+
 // ------------------------------ F64 ApproximateReciprocal
 
 #if (defined(HWY_NATIVE_F64_APPROX_RECIP) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -1144,9 +1144,8 @@ HWY_RVV_FOREACH_F(HWY_RVV_RETV_ARGVV, Mul, fmul, _ALL)
 // Only for internal use (Highway only promises MulHigh for 16-bit inputs).
 // Used by MulEven; vwmul does not work for m8.
 namespace detail {
-HWY_RVV_FOREACH_I32(HWY_RVV_RETV_ARGVV, MulHigh, mulh, _ALL)
-HWY_RVV_FOREACH_U32(HWY_RVV_RETV_ARGVV, MulHigh, mulhu, _ALL)
-HWY_RVV_FOREACH_U64(HWY_RVV_RETV_ARGVV, MulHigh, mulhu, _ALL)
+HWY_RVV_FOREACH_I(HWY_RVV_RETV_ARGVV, MulHigh, mulh, _ALL)
+HWY_RVV_FOREACH_U(HWY_RVV_RETV_ARGVV, MulHigh, mulhu, _ALL)
 }  // namespace detail
 
 HWY_RVV_FOREACH_U16(HWY_RVV_RETV_ARGVV, MulHigh, mulhu, _ALL)
@@ -4310,12 +4309,20 @@ HWY_API VFromD<D> Iota(const D d, TFromD<D> first) {
 
 // ------------------------------ MulEven/Odd (Mul, OddEven)
 
-template <class V, HWY_IF_T_SIZE_V(V, 4), class D = DFromV<V>,
-          class DW = RepartitionToWide<D>>
+template <class V, HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4)),
+          class D = DFromV<V>, class DW = RepartitionToWide<D>>
 HWY_API VFromD<DW> MulEven(const V a, const V b) {
   const auto lo = Mul(a, b);
   const auto hi = detail::MulHigh(a, b);
   return BitCast(DW(), OddEven(detail::Slide1Up(hi), lo));
+}
+
+template <class V, HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2) | (1 << 4)),
+          class D = DFromV<V>, class DW = RepartitionToWide<D>>
+HWY_API VFromD<DW> MulOdd(const V a, const V b) {
+  const auto lo = Mul(a, b);
+  const auto hi = detail::MulHigh(a, b);
+  return BitCast(DW(), OddEven(hi, detail::Slide1Down(lo)));
 }
 
 // There is no 64x64 vwmul.
@@ -4455,6 +4462,17 @@ HWY_API VFromD<D> WidenMulPairwiseAdd(D d32, VI16 a, VI16 b) {
   return Add(Mul(ae, be), Mul(ao, bo));
 }
 
+template <class D, HWY_IF_U32_D(D), class VI16>
+HWY_API VFromD<D> WidenMulPairwiseAdd(D du32, VI16 a, VI16 b) {
+  using VU32 = VFromD<decltype(du32)>;
+  // Manual sign extension requires two shifts for even lanes.
+  const VU32 ae = detail::AndS(BitCast(du32, a), uint32_t{0x0000FFFFu});
+  const VU32 be = detail::AndS(BitCast(du32, b), uint32_t{0x0000FFFFu});
+  const VU32 ao = ShiftRight<16>(BitCast(du32, a));
+  const VU32 bo = ShiftRight<16>(BitCast(du32, b));
+  return Add(Mul(ae, be), Mul(ao, bo));
+}
+
 // ------------------------------ ReorderWidenMulAccumulate (MulAdd, ZipLower)
 
 namespace detail {
@@ -4489,6 +4507,7 @@ HWY_API VF32 ReorderWidenMulAccumulateBF16(Simd<float, N, kPow2> df32,
   }
 
 HWY_RVV_FOREACH_I16(HWY_RVV_WIDEN_MACC, WidenMulAcc, wmacc_vv_, _EXT_VIRT)
+HWY_RVV_FOREACH_U16(HWY_RVV_WIDEN_MACC, WidenMulAcc, wmaccu_vv_, _EXT_VIRT)
 #undef HWY_RVV_WIDEN_MACC
 
 // If LMUL is not the max, we can WidenMul first (3 instructions).
@@ -4521,6 +4540,36 @@ HWY_API VFromD<D32> ReorderWidenMulAccumulateI16(D32 d32, VFromD<D16> a,
   return detail::WidenMulAcc(d32, sum0, a0, b0);
 }
 
+// If LMUL is not the max, we can WidenMul first (3 instructions).
+template <class D32, HWY_IF_POW2_LE_D(D32, 2), class V32 = VFromD<D32>,
+          class D16 = RepartitionToNarrow<D32>>
+HWY_API VFromD<D32> ReorderWidenMulAccumulateU16(D32 d32, VFromD<D16> a,
+                                                 VFromD<D16> b, const V32 sum0,
+                                                 V32& sum1) {
+  const Twice<decltype(d32)> d32t;
+  using V32T = VFromD<decltype(d32t)>;
+  V32T sum = Combine(d32t, sum1, sum0);
+  sum = detail::WidenMulAcc(d32t, sum, a, b);
+  sum1 = UpperHalf(d32, sum);
+  return LowerHalf(d32, sum);
+}
+
+// Max LMUL: must LowerHalf first (4 instructions).
+template <class D32, HWY_IF_POW2_GT_D(D32, 2), class V32 = VFromD<D32>,
+          class D16 = RepartitionToNarrow<D32>>
+HWY_API VFromD<D32> ReorderWidenMulAccumulateU16(D32 d32, VFromD<D16> a,
+                                                 VFromD<D16> b, const V32 sum0,
+                                                 V32& sum1) {
+  const Half<D16> d16h;
+  using V16H = VFromD<decltype(d16h)>;
+  const V16H a0 = LowerHalf(d16h, a);
+  const V16H a1 = UpperHalf(d16h, a);
+  const V16H b0 = LowerHalf(d16h, b);
+  const V16H b1 = UpperHalf(d16h, b);
+  sum1 = detail::WidenMulAcc(d32, sum1, a1, b1);
+  return detail::WidenMulAcc(d32, sum0, a0, b0);
+}
+
 }  // namespace detail
 
 template <size_t N, int kPow2, class VN, class VW>
@@ -4533,6 +4582,12 @@ template <size_t N, int kPow2, class VN, class VW>
 HWY_API VW ReorderWidenMulAccumulate(Simd<int32_t, N, kPow2> d32, VN a, VN b,
                                      const VW sum0, VW& sum1) {
   return detail::ReorderWidenMulAccumulateI16(d32, a, b, sum0, sum1);
+}
+
+template <size_t N, int kPow2, class VN, class VW>
+HWY_API VW ReorderWidenMulAccumulate(Simd<uint32_t, N, kPow2> d32, VN a, VN b,
+                                     const VW sum0, VW& sum1) {
+  return detail::ReorderWidenMulAccumulateU16(d32, a, b, sum0, sum1);
 }
 
 // ------------------------------ RearrangeToOddPlusEven
@@ -4562,6 +4617,33 @@ HWY_API vint32m8_t RearrangeToOddPlusEven(vint32m8_t sum0, vint32m8_t sum1) {
   const vint32m4_t lo =
       RearrangeToOddPlusEven(LowerHalf(sum0), UpperHalf(dh, sum0));
   const vint32m4_t hi =
+      RearrangeToOddPlusEven(LowerHalf(sum1), UpperHalf(dh, sum1));
+  return Combine(d, hi, lo);
+}
+
+template <class VW, HWY_IF_UNSIGNED_V(VW)>  // vuint32_t*
+HWY_API VW RearrangeToOddPlusEven(const VW sum0, const VW sum1) {
+  // vwmacc doubles LMUL, so we require a pairwise sum here. This op is
+  // expected to be less frequent than ReorderWidenMulAccumulate, hence it's
+  // preferable to do the extra work here rather than do manual odd/even
+  // extraction there.
+  const DFromV<VW> du32;
+  const Twice<decltype(du32)> du32x2;
+  const RepartitionToWide<decltype(du32x2)> du64x2;
+  const auto combined = BitCast(du64x2, Combine(du32x2, sum1, sum0));
+  // Isolate odd/even int32 in int64 lanes.
+  const auto even = detail::AndS(combined, uint64_t{0xFFFFFFFFu});
+  const auto odd = ShiftRight<32>(combined);
+  return TruncateTo(du32, Add(even, odd));
+}
+
+// For max LMUL, we cannot Combine again and instead manually unroll.
+HWY_API vuint32m8_t RearrangeToOddPlusEven(vuint32m8_t sum0, vuint32m8_t sum1) {
+  const DFromV<vuint32m8_t> d;
+  const Half<decltype(d)> dh;
+  const vuint32m4_t lo =
+      RearrangeToOddPlusEven(LowerHalf(sum0), UpperHalf(dh, sum0));
+  const vuint32m4_t hi =
       RearrangeToOddPlusEven(LowerHalf(sum1), UpperHalf(dh, sum1));
   return Combine(d, hi, lo);
 }

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -738,13 +738,12 @@ HWY_API Vec1<int16_t> MulFixedPoint15(Vec1<int16_t> a, Vec1<int16_t> b) {
 }
 
 // Multiplies even lanes (0, 2 ..) and returns the double-wide result.
-HWY_API Vec1<int64_t> MulEven(const Vec1<int32_t> a, const Vec1<int32_t> b) {
-  const int64_t a64 = a.raw;
-  return Vec1<int64_t>(a64 * b.raw);
-}
-HWY_API Vec1<uint64_t> MulEven(const Vec1<uint32_t> a, const Vec1<uint32_t> b) {
-  const uint64_t a64 = a.raw;
-  return Vec1<uint64_t>(a64 * b.raw);
+template <class T, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4)),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
+HWY_API Vec1<MakeWide<T>> MulEven(const Vec1<T> a, const Vec1<T> b) {
+  using TW = MakeWide<T>;
+  const TW a_wide = a.raw;
+  return Vec1<TW>(static_cast<TW>(a_wide * b.raw));
 }
 
 // Approximate reciprocal
@@ -1852,6 +1851,15 @@ HWY_API Vec1<int32_t> ReorderWidenMulAccumulate(D32 /* tag */, Vec1<int16_t> a,
                                                 const Vec1<int32_t> sum0,
                                                 Vec1<int32_t>& /* sum1 */) {
   return Vec1<int32_t>(a.raw * b.raw + sum0.raw);
+}
+
+template <class DU32, HWY_IF_U32_D(DU32)>
+HWY_API Vec1<uint32_t> ReorderWidenMulAccumulate(DU32 /* tag */,
+                                                 Vec1<uint16_t> a,
+                                                 Vec1<uint16_t> b,
+                                                 const Vec1<uint32_t> sum0,
+                                                 Vec1<uint32_t>& /* sum1 */) {
+  return Vec1<uint32_t>(static_cast<uint32_t>(a.raw) * b.raw + sum0.raw);
 }
 
 // ------------------------------ RearrangeToOddPlusEven

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -850,12 +850,39 @@ HWY_API Vec128<int16_t, N> MulFixedPoint15(Vec128<int16_t, N> a,
 }
 
 // Multiplies even lanes (0, 2 ..) and returns the double-width result.
+template <class T, size_t N, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2)),
+          HWY_IF_SIGNED(T)>
+HWY_API Vec128<MakeWide<T>, (N + 1) / 2> MulEven(const Vec128<T, N> a,
+                                                 const Vec128<T, N> b) {
+  const DFromV<decltype(a)> d;
+  const RepartitionToWide<decltype(d)> dw;
+  constexpr int kSrcBits = sizeof(T) * 8;
+
+  const auto ae =
+      ShiftRight<kSrcBits>(ShiftLeft<kSrcBits>(ResizeBitCast(dw, a)));
+  const auto be =
+      ShiftRight<kSrcBits>(ShiftLeft<kSrcBits>(ResizeBitCast(dw, b)));
+  return ae * be;
+}
+template <class T, size_t N, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2)),
+          HWY_IF_UNSIGNED(T)>
+HWY_API Vec128<MakeWide<T>, (N + 1) / 2> MulEven(const Vec128<T, N> a,
+                                                 const Vec128<T, N> b) {
+  const DFromV<decltype(a)> d;
+  const RepartitionToWide<decltype(d)> dw;
+  const auto kEvenMask = Set(dw, LimitsMax<T>());
+
+  const auto ae = And(ResizeBitCast(dw, a), kEvenMask);
+  const auto be = And(ResizeBitCast(dw, b), kEvenMask);
+  return ae * be;
+}
 template <size_t N>
 HWY_API Vec128<int64_t, (N + 1) / 2> MulEven(const Vec128<int32_t, N> a,
                                              const Vec128<int32_t, N> b) {
-  const auto kEvenMask = wasm_i32x4_make(-1, 0, -1, 0);
-  const auto ae = wasm_v128_and(a.raw, kEvenMask);
-  const auto be = wasm_v128_and(b.raw, kEvenMask);
+  const DFromV<decltype(a)> d;
+  const RepartitionToWide<decltype(d)> dw;
+  const auto ae = ShiftRight<32>(ShiftLeft<32>(ResizeBitCast(dw, a))).raw;
+  const auto be = ShiftRight<32>(ShiftLeft<32>(ResizeBitCast(dw, b))).raw;
   return Vec128<int64_t, (N + 1) / 2>{wasm_i64x2_mul(ae, be)};
 }
 template <size_t N>
@@ -865,6 +892,30 @@ HWY_API Vec128<uint64_t, (N + 1) / 2> MulEven(const Vec128<uint32_t, N> a,
   const auto ae = wasm_v128_and(a.raw, kEvenMask);
   const auto be = wasm_v128_and(b.raw, kEvenMask);
   return Vec128<uint64_t, (N + 1) / 2>{wasm_i64x2_mul(ae, be)};
+}
+
+// Multiplies odd lanes (1, 3 ..) and returns the double-width result.
+template <class T, size_t N, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2)),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
+HWY_API Vec128<MakeWide<T>, (N + 1) / 2> MulOdd(const Vec128<T, N> a,
+                                                const Vec128<T, N> b) {
+  const DFromV<decltype(a)> d;
+  const RepartitionToWide<decltype(d)> dw;
+  constexpr int kSrcBits = sizeof(T) * 8;
+
+  const auto ao = ShiftRight<kSrcBits>(BitCast(dw, a));
+  const auto bo = ShiftRight<kSrcBits>(BitCast(dw, b));
+  return ao * bo;
+}
+template <class T, size_t N, HWY_IF_UI32(T)>
+HWY_API Vec128<MakeWide<T>, (N + 1) / 2> MulOdd(const Vec128<T, N> a,
+                                                const Vec128<T, N> b) {
+  const DFromV<decltype(a)> d;
+  const RepartitionToWide<decltype(d)> dw;
+
+  const auto ao = ShiftRight<32>(BitCast(dw, a));
+  const auto bo = ShiftRight<32>(BitCast(dw, b));
+  return Vec128<MakeWide<T>, (N + 1) / 2>{wasm_i64x2_mul(ao.raw, bo.raw)};
 }
 
 // ------------------------------ Negate
@@ -3901,15 +3952,13 @@ HWY_API VFromD<D> PromoteUpperTo(D df32, VFromD<Repartition<bfloat16_t, D>> v) {
 }
 
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F64_D(D)>
-HWY_API VFromD<D> PromoteUpperTo(D dd,
-                                 VFromD<Repartition<int32_t, D>> v) {
+HWY_API VFromD<D> PromoteUpperTo(D dd, VFromD<Repartition<int32_t, D>> v) {
   // There is no wasm_f64x2_convert_high_i32x4.
   return PromoteTo(dd, UpperHalf(Rebind<int32_t, D>(), v));
 }
 
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F64_D(D)>
-HWY_API VFromD<D> PromoteUpperTo(D dd,
-                                 VFromD<Repartition<float, D>> v) {
+HWY_API VFromD<D> PromoteUpperTo(D dd, VFromD<Repartition<float, D>> v) {
   // There is no wasm_f64x2_promote_high_f32x4.
   return PromoteTo(dd, UpperHalf(Rebind<float, D>(), v));
 }
@@ -5473,6 +5522,20 @@ HWY_API VFromD<D32> WidenMulPairwiseAdd(D32 /* tag */, V16 a, V16 b) {
   return VFromD<D32>{wasm_i32x4_dot_i16x8(a.raw, b.raw)};
 }
 
+template <class DU32, HWY_IF_U32_D(DU32), HWY_IF_V_SIZE_LE_D(DU32, 16),
+          class VU16 = VFromD<RepartitionToNarrow<DU32>>>
+HWY_API VFromD<DU32> WidenMulPairwiseAdd(DU32 du32, VU16 a, VU16 b) {
+  const auto lo16_mask = Set(du32, 0x0000FFFFu);
+
+  const auto a0 = And(BitCast(du32, a), lo16_mask);
+  const auto b0 = And(BitCast(du32, b), lo16_mask);
+
+  const auto a1 = ShiftRight<16>(BitCast(du32, a));
+  const auto b1 = ShiftRight<16>(BitCast(du32, b));
+
+  return MulAdd(a1, b1, a0 * b0);
+}
+
 // Even if N=1, the input is always at least 2 lanes, hence i32x4_dot_i16x8 is
 // safe.
 template <class D32, HWY_IF_I32_D(D32), HWY_IF_V_SIZE_LE_D(D32, 16),
@@ -5483,10 +5546,26 @@ HWY_API VFromD<D32> ReorderWidenMulAccumulate(D32 d, V16 a, V16 b,
   return sum0 + WidenMulPairwiseAdd(d, a, b);
 }
 
+// Even if N=1, the input is always at least 2 lanes, hence i32x4_dot_i16x8 is
+// safe.
+template <class DU32, HWY_IF_U32_D(DU32), HWY_IF_V_SIZE_LE_D(DU32, 16),
+          class VU16 = VFromD<RepartitionToNarrow<DU32>>>
+HWY_API VFromD<DU32> ReorderWidenMulAccumulate(DU32 d, VU16 a, VU16 b,
+                                               const VFromD<DU32> sum0,
+                                               VFromD<DU32>& /*sum1*/) {
+  return sum0 + WidenMulPairwiseAdd(d, a, b);
+}
+
 // ------------------------------ RearrangeToOddPlusEven
 template <size_t N>
 HWY_API Vec128<int32_t, N> RearrangeToOddPlusEven(
     const Vec128<int32_t, N> sum0, const Vec128<int32_t, N> /*sum1*/) {
+  return sum0;  // invariant already holds
+}
+
+template <size_t N>
+HWY_API Vec128<uint32_t, N> RearrangeToOddPlusEven(
+    const Vec128<uint32_t, N> sum0, const Vec128<uint32_t, N> /*sum1*/) {
   return sum0;  // invariant already holds
 }
 

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -254,23 +254,27 @@ HWY_API Vec256<T> MulFixedPoint15(Vec256<T> a, const Vec256<T> b) {
 
 // Cannot use MakeWide because that returns uint128_t for uint64_t, but we want
 // uint64_t.
-HWY_API Vec256<uint64_t> MulEven(Vec256<uint32_t> a, const Vec256<uint32_t> b) {
-  Vec256<uint64_t> ret;
+template <class T, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4)),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
+HWY_API Vec256<MakeWide<T>> MulEven(Vec256<T> a, const Vec256<T> b) {
+  Vec256<MakeWide<T>> ret;
   ret.v0 = MulEven(a.v0, b.v0);
   ret.v1 = MulEven(a.v1, b.v1);
   return ret;
 }
-HWY_API Vec256<int64_t> MulEven(Vec256<int32_t> a, const Vec256<int32_t> b) {
-  Vec256<int64_t> ret;
+HWY_API Vec256<uint64_t> MulEven(Vec256<uint64_t> a, const Vec256<uint64_t> b) {
+  Vec256<uint64_t> ret;
   ret.v0 = MulEven(a.v0, b.v0);
   ret.v1 = MulEven(a.v1, b.v1);
   return ret;
 }
 
-HWY_API Vec256<uint64_t> MulEven(Vec256<uint64_t> a, const Vec256<uint64_t> b) {
-  Vec256<uint64_t> ret;
-  ret.v0 = MulEven(a.v0, b.v0);
-  ret.v1 = MulEven(a.v1, b.v1);
+template <class T, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4)),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
+HWY_API Vec256<MakeWide<T>> MulOdd(Vec256<T> a, const Vec256<T> b) {
+  Vec256<MakeWide<T>> ret;
+  ret.v0 = MulOdd(a.v0, b.v0);
+  ret.v1 = MulOdd(a.v1, b.v1);
   return ret;
 }
 HWY_API Vec256<uint64_t> MulOdd(Vec256<uint64_t> a, const Vec256<uint64_t> b) {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -5358,6 +5358,24 @@ HWY_API Vec256<int32_t> RearrangeToOddPlusEven(const Vec256<int32_t> sum0,
   return sum0;  // invariant already holds
 }
 
+HWY_API Vec256<uint32_t> RearrangeToOddPlusEven(const Vec256<uint32_t> sum0,
+                                                Vec256<uint32_t> /*sum1*/) {
+  return sum0;  // invariant already holds
+}
+
+// ------------------------------ SumOfMulQuadAccumulate
+
+#if HWY_TARGET <= HWY_AVX3_DL
+
+template <class DI32, HWY_IF_V_SIZE_D(DI32, 32)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(
+    DI32 /*di32*/, VFromD<Repartition<uint8_t, DI32>> a_u,
+    VFromD<Repartition<int8_t, DI32>> b_i, VFromD<DI32> sum) {
+  return VFromD<DI32>{_mm256_dpbusd_epi32(sum.raw, a_u.raw, b_i.raw)};
+}
+
+#endif
+
 // ================================================== CONVERT
 
 // ------------------------------ Promotions (part w/ narrow lanes -> full)

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -6464,6 +6464,24 @@ HWY_API Vec512<int32_t> RearrangeToOddPlusEven(const Vec512<int32_t> sum0,
   return sum0;  // invariant already holds
 }
 
+HWY_API Vec512<uint32_t> RearrangeToOddPlusEven(const Vec512<uint32_t> sum0,
+                                                Vec512<uint32_t> /*sum1*/) {
+  return sum0;  // invariant already holds
+}
+
+// ------------------------------ SumOfMulQuadAccumulate
+
+#if HWY_TARGET <= HWY_AVX3_DL
+
+template <class DI32, HWY_IF_V_SIZE_D(DI32, 64)>
+HWY_API VFromD<DI32> SumOfMulQuadAccumulate(
+    DI32 /*di32*/, VFromD<Repartition<uint8_t, DI32>> a_u,
+    VFromD<Repartition<int8_t, DI32>> b_i, VFromD<DI32> sum) {
+  return VFromD<DI32>{_mm512_dpbusd_epi32(sum.raw, a_u.raw, b_i.raw)};
+}
+
+#endif
+
 // ------------------------------ Reductions
 
 template <class D>

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -220,6 +220,22 @@ HWY_NOINLINE void TestAllMulFixedPoint15() {
 }
 
 struct TestMulEven {
+  template <class D, HWY_IF_SIGNED_D(D)>
+  HWY_INLINE void DoTestNegMulEven(D /*d*/, Vec<D> v) {
+    using T = TFromD<D>;
+    using Wide = MakeWide<T>;
+    const Repartition<Wide, D> d2;
+
+    const auto v_squared = MulEven(v, v);
+    const auto neg_v_squared = Neg(v_squared);
+    const auto neg_v = Neg(v);
+    HWY_ASSERT_VEC_EQ(d2, v_squared, MulEven(neg_v, neg_v));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared, MulEven(neg_v, v));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared, MulEven(v, neg_v));
+  }
+  template <class D, HWY_IF_UNSIGNED_D(D)>
+  HWY_INLINE void DoTestNegMulEven(D /*d*/, Vec<D> /*v*/) {}
+
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     using Wide = MakeWide<T>;
@@ -227,26 +243,92 @@ struct TestMulEven {
     const auto v0 = Zero(d);
     HWY_ASSERT_VEC_EQ(d2, Zero(d2), MulEven(v0, v0));
 
+    constexpr size_t kShiftAmtMask = sizeof(T) * 8 - 1;
     const size_t N = Lanes(d);
     auto in_lanes = AllocateAligned<T>(N);
     auto expected = AllocateAligned<Wide>(Lanes(d2));
     for (size_t i = 0; i < N; i += 2) {
-      in_lanes[i + 0] = LimitsMax<T>() >> i;
+      in_lanes[i + 0] = LimitsMax<T>() >> (i & kShiftAmtMask);
       if (N != 1) {
         in_lanes[i + 1] = 1;  // unused
       }
-      expected[i / 2] = Wide(in_lanes[i + 0]) * in_lanes[i + 0];
+      expected[i / 2] =
+          static_cast<Wide>(Wide(in_lanes[i + 0]) * in_lanes[i + 0]);
     }
 
     const auto v = Load(d, in_lanes.get());
     HWY_ASSERT_VEC_EQ(d2, expected.get(), MulEven(v, v));
+
+    DoTestNegMulEven(d, v);
   }
 };
 
+struct TestMulOdd {
+  template <class D, HWY_IF_SIGNED_D(D)>
+  HWY_INLINE void DoTestNegMulOdd(D d, Vec<D> v) {
+    using T = TFromD<D>;
+    using Wide = MakeWide<T>;
+    const Repartition<Wide, D> d2;
+
+    const auto v_squared = MulOdd(v, v);
+    const auto neg_v_squared = Neg(v_squared);
+    const auto neg_v = Neg(v);
+    HWY_ASSERT_VEC_EQ(d2, v_squared, MulOdd(neg_v, neg_v));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared, MulOdd(neg_v, v));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared, MulOdd(v, neg_v));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared, MulEven(DupOdd(v), DupOdd(neg_v)));
+    HWY_ASSERT_VEC_EQ(d2, neg_v_squared,
+                      MulEven(Reverse2(d, v), Reverse2(d, neg_v)));
+  }
+  template <class D, HWY_IF_UNSIGNED_D(D)>
+  HWY_INLINE void DoTestNegMulOdd(D /*d*/, Vec<D> /*v*/) {}
+
+  template <typename T, class D, HWY_IF_LANES_GT_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const size_t N = Lanes(d);
+    if (N < 2) return;
+
+    using Wide = MakeWide<T>;
+    const Repartition<Wide, D> d2;
+    const auto v0 = Zero(d);
+    HWY_ASSERT_VEC_EQ(d2, Zero(d2), MulOdd(v0, v0));
+
+    constexpr size_t kShiftAmtMask = sizeof(T) * 8 - 1;
+    auto in_lanes = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<Wide>(Lanes(d2));
+    for (size_t i = 0; i < N; i += 2) {
+      in_lanes[i + 0] = 1;  // unused
+      in_lanes[i + 1] = LimitsMax<T>() >> (i & kShiftAmtMask);
+      expected[i / 2] =
+          static_cast<Wide>(Wide(in_lanes[i + 1]) * in_lanes[i + 1]);
+    }
+
+    const auto v = Load(d, in_lanes.get());
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulOdd(v, v));
+
+    const auto v_dupodd = DupOdd(v);
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulEven(v_dupodd, v_dupodd));
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulOdd(v_dupodd, v_dupodd));
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulOdd(v_dupodd, v));
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulOdd(v, v_dupodd));
+
+    const auto v_reverse2 = Reverse2(d, v);
+    HWY_ASSERT_VEC_EQ(d2, expected.get(), MulEven(v_reverse2, v_reverse2));
+
+    DoTestNegMulOdd(d, v);
+#else
+    (void)d;
+#endif
+  }
+  template <typename T, class D, HWY_IF_LANES_LE_D(D, 1)>
+  HWY_INLINE void operator()(T /*unused*/, D /*d*/) {}
+};
+
+#if HWY_HAVE_INTEGER64 && HWY_TARGET != HWY_SCALAR
 struct TestMulEvenOdd64 {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
-#if HWY_TARGET != HWY_SCALAR
     const auto v0 = Zero(d);
     HWY_ASSERT_VEC_EQ(d, Zero(d), MulEven(v0, v0));
     HWY_ASSERT_VEC_EQ(d, Zero(d), MulOdd(v0, v0));
@@ -277,18 +359,30 @@ struct TestMulEvenOdd64 {
       HWY_ASSERT_VEC_EQ(d, expected_even.get(), MulEven(a, b));
       HWY_ASSERT_VEC_EQ(d, expected_odd.get(), MulOdd(a, b));
     }
-#else
-    (void)d;
-#endif  // HWY_TARGET != HWY_SCALAR
   }
 };
+#endif  // HWY_HAVE_INTEGER64 && HWY_TARGET != HWY_SCALAR
 
 HWY_NOINLINE void TestAllMulEven() {
-  ForGEVectors<64, TestMulEven> test;
-  test(int32_t());
-  test(uint32_t());
+  ForUI8(ForGEVectors<16, TestMulEven>());
+  ForUI16(ForGEVectors<32, TestMulEven>());
 
+#if HWY_HAVE_INTEGER64
+  ForUI32(ForGEVectors<64, TestMulEven>());
+#if HWY_TARGET != HWY_SCALAR
   ForGEVectors<128, TestMulEvenOdd64>()(uint64_t());
+#endif  // HWY_TARGET != HWY_SCALAR
+#endif  // HWY_HAVE_INTEGER64
+}
+
+HWY_NOINLINE void TestAllMulOdd() {
+  ForUI8(ForGEVectors<16, TestMulOdd>());
+  ForUI16(ForGEVectors<32, TestMulOdd>());
+#if HWY_HAVE_INTEGER64
+  ForUI32(ForGEVectors<64, TestMulOdd>());
+#endif
+
+  // uint64_t MulOdd is already tested in TestMulEvenOdd64
 }
 
 #ifndef HWY_NATIVE_FMA
@@ -433,6 +527,7 @@ struct TestWidenMulPairwiseAdd {
 HWY_NOINLINE void TestAllWidenMulPairwiseAdd() {
   ForShrinkableVectors<TestWidenMulPairwiseAdd>()(bfloat16_t());
   ForShrinkableVectors<TestWidenMulPairwiseAdd>()(int16_t());
+  ForShrinkableVectors<TestWidenMulPairwiseAdd>()(uint16_t());
 }
 
 struct TestSatWidenMulPairwiseAdd {
@@ -693,6 +788,7 @@ struct TestReorderWidenMulAccumulate {
 HWY_NOINLINE void TestAllReorderWidenMulAccumulate() {
   ForShrinkableVectors<TestReorderWidenMulAccumulate>()(bfloat16_t());
   ForShrinkableVectors<TestReorderWidenMulAccumulate>()(int16_t());
+  ForShrinkableVectors<TestReorderWidenMulAccumulate>()(uint16_t());
 }
 
 struct TestRearrangeToOddPlusEven {
@@ -740,6 +836,97 @@ HWY_NOINLINE void TestAllRearrangeToOddPlusEven() {
   ForShrinkableVectors<TestRearrangeToOddPlusEven>()(bfloat16_t());
 #endif
   ForShrinkableVectors<TestRearrangeToOddPlusEven>()(int16_t());
+  ForShrinkableVectors<TestRearrangeToOddPlusEven>()(uint16_t());
+}
+
+template <bool MixedSignedness>
+struct TestSumOfMulQuadAccumulate {
+  template <class DW2, class TN1, class TN2>
+  static HWY_INLINE void TestConsecutiveSeqMulQuadAccum(DW2 dw2, TN1 a0,
+                                                        TN2 b0) {
+    using TW2 = TFromD<DW2>;
+    const Repartition<TN1, DW2> dn1;
+    const Repartition<TN2, DW2> dn2;
+
+    const auto vn_iota0_mod4 = And(Iota(dn1, TN1{0}), Set(dn1, TN1{3}));
+
+    const auto va = Add(vn_iota0_mod4, Set(dn1, a0));
+    const auto vb = Add(BitCast(dn2, vn_iota0_mod4), Set(dn2, b0));
+    const auto expected =
+        Set(dw2,
+            static_cast<TW2>((TW2{4} * static_cast<TW2>(a0) * b0) +
+                             (TW2{6} * (static_cast<TW2>(a0) + b0)) + TW2{17}));
+
+    HWY_ASSERT_VEC_EQ(dw2, expected,
+                      SumOfMulQuadAccumulate(dw2, va, vb, Set(dw2, TW2{3})));
+  }
+
+  template <typename TN2, class DN2>
+  HWY_INLINE void operator()(TN2 /*unused*/, DN2 dn2) {
+    static_assert(!MixedSignedness || IsSigned<TN2>(),
+                  "TN2 must be signed if MixedSignedness is true");
+    using TN1 = If<MixedSignedness, MakeUnsigned<TN2>, TN2>;
+    using TW2 = MakeWide<MakeWide<TN2>>;
+
+    const Rebind<TN1, DN2> dn1;
+    const Repartition<TW2, DN2> dw2;
+
+    const auto vn1_k1 = Set(dn1, TN1{1});
+    const auto vn2_k1 = BitCast(dn2, vn1_k1);
+    const auto vn1_k4 = Set(dn1, TN1{4});
+    const auto vn2_k4 = BitCast(dn2, vn1_k4);
+
+    const auto vw2_k0 = Zero(dw2);
+    const auto vw2_k1 = Set(dw2, TW2{1});
+    const auto vw2_k4 = Set(dw2, TW2{4});
+    const auto vw2_k5 = Set(dw2, TW2{5});
+    const auto vw2_k21 = Set(dw2, TW2{21});
+
+    HWY_ASSERT_VEC_EQ(dw2, vw2_k4,
+                      SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k0));
+    HWY_ASSERT_VEC_EQ(dw2, vw2_k4,
+                      SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k0));
+    HWY_ASSERT_VEC_EQ(dw2, vw2_k5,
+                      SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k1));
+    HWY_ASSERT_VEC_EQ(dw2, vw2_k21,
+                      SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k4, vw2_k5));
+    HWY_ASSERT_VEC_EQ(dw2, vw2_k21,
+                      SumOfMulQuadAccumulate(dw2, vn1_k4, vn2_k1, vw2_k5));
+
+    constexpr TN1 kTN1ValWithMaxMag =
+        static_cast<TN1>(IsSigned<TN1>() ? LimitsMin<TN1>() : LimitsMax<TN1>());
+    constexpr TN2 kTN2ValWithMaxMag =
+        static_cast<TN2>(IsSigned<TN2>() ? LimitsMin<TN2>() : LimitsMax<TN2>());
+    HWY_ASSERT_VEC_EQ(
+        dw2,
+        Set(dw2, static_cast<TW2>(static_cast<TW2>(kTN1ValWithMaxMag) *
+                                  kTN2ValWithMaxMag * TW2{4})),
+        SumOfMulQuadAccumulate(dw2, Set(dn1, kTN1ValWithMaxMag),
+                               Set(dn2, kTN2ValWithMaxMag), vw2_k0));
+
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(27),
+                                   static_cast<TN2>(34));
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(13),
+                                   static_cast<TN2>(-5));
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(-29),
+                                   static_cast<TN2>(2));
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(-14),
+                                   static_cast<TN2>(-35));
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(LimitsMin<TN1>() + 5),
+                                   static_cast<TN2>(LimitsMax<TN2>() - 4));
+    TestConsecutiveSeqMulQuadAccum(dw2, static_cast<TN1>(LimitsMax<TN1>() - 4),
+                                   static_cast<TN2>(LimitsMin<TN2>() + 11));
+  }
+};
+
+HWY_NOINLINE void TestAllSumOfMulQuadAccumulate() {
+  ForShrinkableVectors<TestSumOfMulQuadAccumulate<false>, 2>()(int8_t());
+  ForShrinkableVectors<TestSumOfMulQuadAccumulate<false>, 2>()(uint8_t());
+  ForShrinkableVectors<TestSumOfMulQuadAccumulate<true>, 2>()(int8_t());
+#if HWY_HAVE_INTEGER64
+  ForShrinkableVectors<TestSumOfMulQuadAccumulate<false>, 2>()(int16_t());
+  ForShrinkableVectors<TestSumOfMulQuadAccumulate<false>, 2>()(uint16_t());
+#endif
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -755,11 +942,13 @@ HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMul);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulHigh);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulFixedPoint15);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulEven);
+HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulOdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulAdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllWidenMulPairwiseAdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllSatWidenMulPairwiseAdd);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllReorderWidenMulAccumulate);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllRearrangeToOddPlusEven);
+HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllSumOfMulQuadAccumulate);
 
 }  // namespace hwy
 

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -894,8 +894,6 @@ struct TestSumOfMulQuadAccumulate {
 
     HWY_ASSERT_VEC_EQ(dw2, vw2_k4,
                       SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k0));
-    HWY_ASSERT_VEC_EQ(dw2, vw2_k4,
-                      SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k0));
     HWY_ASSERT_VEC_EQ(dw2, vw2_k5,
                       SumOfMulQuadAccumulate(dw2, vn1_k1, vn2_k1, vw2_k1));
     HWY_ASSERT_VEC_EQ(dw2, vw2_k21,


### PR DESCRIPTION
Added the following operations:
- SumOfMulQuadAccumulate
- U16 WidenMulPairwiseAdd
- U16 ReorderWidenMulAccumulate
- U32 RearrangeToOddPlusEven
- I8/U8/I16/U16 MulEven
- I8/U8/I16/U16/I32/U32 MulOdd

Also fixed bug in WASM I32 MulEven where I32 MulEven incorrectly zero-extended the low 32-bit integers to 64-bit integers instead of sign-extending the 32-bit integers to 64-bit integers.

Also re-implemented SSE2/SSSE3 I32 MulEven to avoid a store followed by scalar multiplications followed by a reload of the scalar multiplication result.