### PR TITLE
Fixed PPC9 LoadN compilation error with older GCC/Clang releases

### DIFF
--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -1028,8 +1028,10 @@ HWY_API VFromD<D> LoadN(D d, const T* HWY_RESTRICT p,
       HWY_MIN(max_lanes_to_load, HWY_MAX_LANES_D(D)) * sizeof(TFromD<D>);
   const Repartition<uint8_t, decltype(d)> du8;
   return BitCast(
-      d, VFromD<decltype(du8)>{vec_xl_len(
-             reinterpret_cast<const unsigned char*>(p), num_of_bytes_to_load)});
+      d,
+      VFromD<decltype(du8)>{vec_xl_len(
+          const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(p)),
+          num_of_bytes_to_load)});
 }
 #endif
 


### PR DESCRIPTION
Fixed compilation error in PPC9 LoadN with GCC 9 or earlier and Clang 10 and earlier by adding a const_cast to `unsigned char*`