### PR TITLE
Add GatherIndexN/ScatterIndexN operations

### DIFF
--- a/g3doc/op_wishlist.md
+++ b/g3doc/op_wishlist.md
@@ -192,3 +192,4 @@ For SVE (svld1sb_u32)+WASM? Compiler can probably already fuse.
 *   ~~Add `DupEven` for 16-bit~~ - by johnplatts in #1431
 *   ~~AVX3_SPR target~~
 *   ~~MaskedGather returns zero for mask=false.~~
+*   ~~GatherIndexN/ScatterIndexN~~

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1208,6 +1208,10 @@ F(src[tbl[i]])` because `Scatter` is more expensive than `Gather`.
     stores `v[i]` to `base[indices[i]]`.
 
 *   `D`: `{u,i,f}{32,64}` \
+    <code>void **ScatterIndexN**(Vec&lt;D&gt; v, D, T* base, VI indices, size_t max_lanes_to_store)</code>:
+    Stores `HWY_MIN(Lanes(d), max_lanes_to_store)` lanes `v[i]` to `base[indices[i]]`
+
+*   `D`: `{u,i,f}{32,64}` \
     <code>void **MaskedScatterIndex**(Vec&lt;D&gt; v, M m, D, T* base, VI
     indices)</code>: stores `v[i]` to `base[indices[i]]` if `mask[i]` is true.
     Does not fault for lanes whose `mask` is false.
@@ -1219,6 +1223,12 @@ F(src[tbl[i]])` because `Scatter` is more expensive than `Gather`.
 *   `D`: `{u,i,f}{32,64}` \
     <code>Vec&lt;D&gt; **GatherIndex**(D, const T* base, VI indices)</code>:
     returns vector of `base[indices[i]]`.
+
+*   `D`: `{u,i,f}{32,64}` \
+    <code>Vec&lt;D&gt; **GatherIndexN**(D, const T* base, VI indices, size_t max_lanes_to_load)</code>:
+    Loads `HWY_MIN(Lanes(d), max_lanes_to_load)` lanes of `base[indices[i]]`
+    to the first (lowest-index) lanes of the result vector and zeroes
+    out the remaining lanes.
 
 *   `D`: `{u,i,f}{32,64}` \
     <code>Vec&lt;D&gt; **MaskedGatherIndex**(M mask, D d, const T* base, VI

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1,5 +1,7 @@
 // Copyright 2021 Google LLC
+// Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BSD-3-Clause
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1560,6 +1562,22 @@ HWY_API VFromD<D> MaskedGatherIndex(MFromD<D> m, D d,
 }
 
 #endif  // (defined(HWY_NATIVE_GATHER) == defined(HWY_TARGET_TOGGLE))
+
+// ------------------------------ ScatterN/GatherN
+
+template <class D, typename T = TFromD<D>>
+HWY_API void ScatterIndexN(VFromD<D> v, D d, T* HWY_RESTRICT base,
+                           VFromD<RebindToSigned<D>> index,
+                           const size_t max_lanes_to_store) {
+  MaskedScatterIndex(v, FirstN(d, max_lanes_to_store), d, base, index);
+}
+
+template <class D, typename T = TFromD<D>>
+HWY_API VFromD<D> GatherIndexN(D d, const T* HWY_RESTRICT base,
+                               VFromD<RebindToSigned<D>> index,
+                               const size_t max_lanes_to_load) {
+  return MaskedGatherIndex(FirstN(d, max_lanes_to_load), d, base, index);
+}
 
 // ------------------------------ Integer AbsDiff and SumsOf8AbsDiff
 


### PR DESCRIPTION
Both `ScatterIndexN`/`GatherIndexN` are simply wrappers around `MaskedGatherIndex`/`MaskedScatterIndex`, using FirstN to only collect up to N values.

These interfaces can be updated later with platform-specific optimisations.