### PR TITLE
Added fixes for float16_t/bfloat16_t operator++ and operator--

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -449,24 +449,30 @@ struct float16_t {
     return *this;
   }
 
-  float16_t operator--() noexcept {
+  // pre-decrement operator (--x)
+  float16_t& operator--() noexcept {
     raw = static_cast<Raw>(raw - Raw{1});
     return *this;
   }
 
+  // post-decrement operator (x--)
   float16_t operator--(int) noexcept {
+    float16_t result = *this;
     raw = static_cast<Raw>(raw - Raw{1});
-    return *this;
+    return result;
   }
 
-  float16_t operator++() noexcept {
+  // pre-increment operator (++x)
+  float16_t& operator++() noexcept {
     raw = static_cast<Raw>(raw + Raw{1});
     return *this;
   }
 
+  // post-increment operator (x++)
   float16_t operator++(int) noexcept {
+    float16_t result = *this;
     raw = static_cast<Raw>(raw + Raw{1});
-    return *this;
+    return result;
   }
 
   constexpr float16_t operator-() const noexcept {
@@ -546,24 +552,30 @@ struct bfloat16_t {
     return *this;
   }
 
-  bfloat16_t operator--() noexcept {
+  // pre-decrement operator (--x)
+  bfloat16_t& operator--() noexcept {
     raw = static_cast<Raw>(raw - Raw{1});
     return *this;
   }
 
+  // post-decrement operator (x--)
   bfloat16_t operator--(int) noexcept {
+    bfloat16_t result = *this;
     raw = static_cast<Raw>(raw - Raw{1});
-    return *this;
+    return result;
   }
 
-  bfloat16_t operator++() noexcept {
+  // pre-increment operator (++x)
+  bfloat16_t& operator++() noexcept {
     raw = static_cast<Raw>(raw + Raw{1});
     return *this;
   }
 
+  // post-increment operator (x++)
   bfloat16_t operator++(int) noexcept {
+    bfloat16_t result = *this;
     raw = static_cast<Raw>(raw + Raw{1});
-    return *this;
+    return result;
   }
 
   constexpr bfloat16_t operator-() const noexcept {


### PR DESCRIPTION
Fixed `operator--` and `operator++` for hwy::float16_t and hwy::bfloat16_t.

The post-increment operator (`x++`) and the post-decrement operator (`x--`) are supposed to return the value prior to the increment or decrement instead of the value after the increment. Fixed the post-increment operator and post-decrement operator to match the expected behavior.

Also updated the pre-increment operator (`++x`) and pre-decrement operator (`--x`) to return a reference to `*this` as the pre-increment operator and pre-decrement operators are expected to return a reference to `*this`.

Post-increment, post-decrement, pre-increment, and pre-decrement operators are explained at https://en.cppreference.com/w/cpp/language/operator_incdec.