### PR TITLE
Added BitCastScalar operation

### DIFF
--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -2446,8 +2446,7 @@ HWY_INLINE VFromD<D> UIntToF32BiasedExp(D d, VFromD<D> v) {
 #if HWY_TARGET == HWY_SCALAR
   const uint64_t u64_val = GetLane(v);
   const float f32_val = static_cast<float>(u64_val);
-  uint32_t f32_bits;
-  CopySameSize(&f32_val, &f32_bits);
+  const uint32_t f32_bits = BitCastScalar<uint32_t>(f32_val);
   return Set(d, static_cast<uint64_t>(f32_bits >> 23));
 #else
   const Repartition<uint32_t, decltype(d)> du32;

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -552,7 +552,7 @@ HWY_RVV_FOREACH_F(HWY_RVV_SET, Set, fmv_v_f, _ALL_VIRT)
 template <size_t N, int kPow2>
 decltype(Set(Simd<int16_t, N, kPow2>(), 0)) Set(Simd<bfloat16_t, N, kPow2> d,
                                                 bfloat16_t arg) {
-  return Set(RebindToSigned<decltype(d)>(), arg.bits);
+  return Set(RebindToSigned<decltype(d)>(), BitCastScalar<int16_t>(arg));
 }
 #if !HWY_HAVE_FLOAT16  // Otherwise already defined above.
 // WARNING: returns a different type than emulated bfloat16_t so that we can
@@ -561,9 +561,7 @@ decltype(Set(Simd<int16_t, N, kPow2>(), 0)) Set(Simd<bfloat16_t, N, kPow2> d,
 template <size_t N, int kPow2>
 decltype(Set(Simd<uint16_t, N, kPow2>(), 0)) Set(Simd<float16_t, N, kPow2> d,
                                                  float16_t arg) {
-  uint16_t bits;
-  CopySameSize(&arg, &bits);
-  return Set(RebindToUnsigned<decltype(d)>(), bits);
+  return Set(RebindToUnsigned<decltype(d)>(), BitCastScalar<uint16_t>(arg));
 }
 #endif
 

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -1815,9 +1815,7 @@ template <size_t kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 2),
           HWY_IF_NOT_SPECIAL_FLOAT(T)>
 HWY_INLINE T ExtractLane(const Vec128<T, N> v) {
   const int16_t lane = wasm_i16x8_extract_lane(v.raw, kLane);
-  T ret;
-  CopySameSize(&lane, &ret);  // for float16_t
-  return ret;
+  return static_cast<T>(lane);
 }
 template <size_t kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 2),
           HWY_IF_SPECIAL_FLOAT(T)>
@@ -1826,10 +1824,7 @@ HWY_INLINE T ExtractLane(const Vec128<T, N> v) {
   const RebindToUnsigned<decltype(d)> du;
 
   const uint16_t bits = ExtractLane<kLane>(BitCast(du, v));
-
-  T ret;
-  CopySameSize(&bits, &ret);
-  return ret;
+  return BitCastScalar<T>(bits);
 }
 template <size_t kLane, typename T, size_t N, HWY_IF_T_SIZE(T, 4)>
 HWY_INLINE T ExtractLane(const Vec128<T, N> v) {

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -228,10 +228,7 @@ struct TestPromoteOddEvenTo {
         HWY_MIN(HWY_MAX(orig_exp_field_val, 1), kMaxExpField - 1)
         << kNumOfMantBits);
 
-    T result;
-    const TU flt_bits = sign_mant_bits | exp_bits;
-    CopySameSize(&flt_bits, &result);
-    return result;
+    return BitCastScalar<T>(static_cast<TU>(sign_mant_bits | exp_bits));
   }
   template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
   static HWY_INLINE T RandomBitsToVal(uint64_t rand_bits) {


### PR DESCRIPTION
Added BitCastScalar operation, which bit casts `val` to `To`.

Also added `HWY_BITCASTSCALAR_CONSTEXPR` macro, which expands to the `constexpr` keyword if the current compiler supports `__builtin_bit_cast` and is defined as an empty macro otherwise.