### PR TITLE
Added IsInteger, IsIntegerLaneType, RemoveVolatile, and RemoveCvRef

### DIFF
--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -151,6 +151,13 @@ struct Simd {
 
  private:
   static_assert(sizeof(Lane) <= 8, "Lanes are up to 64-bit");
+  static_assert(IsSame<Lane, RemoveCvRef<Lane>>(),
+                "Lane must not be a reference type, const-qualified type, or "
+                "volatile-qualified type");
+  static_assert(IsIntegerLaneType<Lane>() || IsFloat<Lane>() ||
+                    IsSpecialFloat<Lane>(),
+                "IsIntegerLaneType<T>(), IsFloat<T>(), or IsSpecialFloat<T>() "
+                "must be true");
   // 20 bits are sufficient for any HWY_MAX_BYTES. This is the 'normal' value of
   // N when kFrac == 0, otherwise it is one (see FracN).
   static constexpr size_t kWhole = N & 0xFFFFF;


### PR DESCRIPTION
Added the following type traits:
- `IsInteger<T>()` - returns true if `T` is one of the following types and returns false otherwise:
  `bool`, `char`, `signed char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned int`, `long`, `unsigned long`, `long long`, `unsigned long long`, `int8_t`, `uint8_t`, `int16_t`, `uint16_t`, `int32_t`, `uint32_t`, `int64_t`, `uint64_t`, `char8_t`, `char16_t`, `char32_t`, `wchar_t`, `intptr_t`, `uintptr_t`, `size_t`, `ptrdiff_t`
- `IsIntegerLaneType<T>()` - returns true if `T` is one of the following types and returns false otherwise:
  `int8_t`, `uint8_t`, `int16_t`, `uint16_t`, `int32_t`, `uint32_t`, `int64_t`, `uint64_t`
- `RemoveVolatile<T>` - removes the `volatile` qualifier off of `T`
- `RemoveCvRef<T>` - equivalent to `RemoveConst<RemoveVolatile<RemoveRef<T>>>`

Resolves issue #1727.