### PR TITLE
Narrow include in algo-inl.h

### DIFF
--- a/hwy/contrib/sort/algo-inl.h
+++ b/hwy/contrib/sort/algo-inl.h
@@ -252,7 +252,7 @@ static inline const char* AlgoName(Algo algo) {
 #include "hwy/contrib/sort/traits-inl.h"
 #include "hwy/contrib/sort/traits128-inl.h"
 #include "hwy/contrib/sort/vqsort-inl.h"  // HeapSort
-#include "hwy/tests/test_util-inl.h"
+#include "hwy/aligned_allocator.h"
 
 HWY_BEFORE_NAMESPACE();
 


### PR DESCRIPTION
At the moment, algo-inl.h pulls in the test util header which in turn depends on the Google Test library. It seems however that only aligned allocator support is required. Narrow the include to permit using this header in contexts which do not form part of testing, or where a dependency on Google Test is not desired.