### PR TITLE
Fixes to SVE F32->U64 PromoteEvenTo and TestPromoteOddEvenTo

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -3650,7 +3650,7 @@ HWY_INLINE VFromD<D> PromoteEvenTo(hwy::UnsignedTag /*to_type_tag*/,
                                    hwy::FloatTag /*from_type_tag*/, D d_to,
                                    svfloat32_t v) {
   const Repartition<float, decltype(d_to)> d_from;
-  return svcvt_s64_f32_x(detail::PTrue(d_from), v);
+  return svcvt_u64_f32_x(detail::PTrue(d_from), v);
 }
 
 // F16->F32 PromoteOddTo


### PR DESCRIPTION
Fixed SVE F32->U64 PromoteEvenTo implementation to call svcvt_u64_f32_x instead of svcvt_s64_f32_x.

Also updated TestPromoteOddEvenTo to test F32->I64 and F32->U64 PromoteEvenTo/PromoteOddTo.
