### PR TITLE
Updated AddWithWraparound to fix warnings in reduction_test

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -1627,14 +1627,13 @@ template <typename TI>
              : static_cast<size_t>(FloorLog2(static_cast<TI>(x - 1)) + 1);
 }
 
-template <typename T>
-HWY_INLINE constexpr T AddWithWraparound(hwy::FloatTag /*tag*/, T t, size_t n) {
+template <typename T, typename T2>
+HWY_INLINE constexpr T AddWithWraparound(hwy::FloatTag /*tag*/, T t, T2 n) {
   return t + static_cast<T>(n);
 }
 
-template <typename T>
-HWY_INLINE constexpr T AddWithWraparound(hwy::NonFloatTag /*tag*/, T t,
-                                         size_t n) {
+template <typename T, typename T2>
+HWY_INLINE constexpr T AddWithWraparound(hwy::NonFloatTag /*tag*/, T t, T2 n) {
   using TU = MakeUnsigned<T>;
   return static_cast<T>(
       static_cast<TU>(static_cast<TU>(t) + static_cast<TU>(n)) &


### PR DESCRIPTION
Changed the type of the third parameter of hwy::AddWithWraparound from `size_t` to `T2` to fix compilation warnings in TestSumOfLanes in hwy/tests/reduction_test.cc.