### PR TITLE
Added SumsOf2/SumsOf4/I8 SumsOf8 plus enhancements to reduce ops

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -509,9 +509,24 @@ from left to right, of the arguments passed to `Create{2-4}`.
 
 *   <code>V **AbsDiff**(V a, V b)</code>: returns `|a[i] - b[i]|` in each lane.
 
+*   `V`: `{i,u}{8,16,32},f32`, `VW`: `RepartitionToWide<DFromV<V>>` \
+    <code>VW **SumsOf2**(V v)</code>
+    returns the sums of 2 consecutive lanes, promoting each sum into a lane of
+    `MakeWide<TFromV<V>>`.
+
+*   `V`: `{i,u}{8,16}`,
+    `VW`: `RepartitionToWide<RepartitionToWide<DFromV<V>>>` \
+    <code>VW **SumsOf4**(V v)</code>
+    returns the sums of 4 consecutive lanes, promoting each sum into a lane of
+    `MakeWide<MakeWide<TFromV<V>>>`.
+
 *   `V`: `u8` \
     <code>VU64 **SumsOf8**(V v)</code> returns the sums of 8 consecutive u8
     lanes, zero-extending each sum into a u64 lane. This is slower on RVV/WASM.
+
+*   `V`: `i8` \
+    <code>VI64 **SumsOf8**(V v)</code> returns the sums of 8 consecutive i8
+    lanes, sign-extending each sum into an i64 lane. This is slower on RVV/WASM.
 
 *   `V`: `u8` \
     <code>VU64 **SumsOf8AbsDiff**(V a, V b)</code> returns the same result as

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -509,29 +509,28 @@ from left to right, of the arguments passed to `Create{2-4}`.
 
 *   <code>V **AbsDiff**(V a, V b)</code>: returns `|a[i] - b[i]|` in each lane.
 
-*   `V`: `{i,u}{8,16,32},f32`, `VW`: `RepartitionToWide<DFromV<V>>` \
+*   `V`: `{i,u}{8,16,32},f32`, `VW`: `Vec<RepartitionToWide<DFromV<V>>>` \
     <code>VW **SumsOf2**(V v)</code>
     returns the sums of 2 consecutive lanes, promoting each sum into a lane of
     `MakeWide<TFromV<V>>`.
 
 *   `V`: `{i,u}{8,16}`,
-    `VW`: `RepartitionToWide<RepartitionToWide<DFromV<V>>>` \
+    `VW`: `Vec<RepartitionToWide<RepartitionToWide<DFromV<V>>>>` \
     <code>VW **SumsOf4**(V v)</code>
     returns the sums of 4 consecutive lanes, promoting each sum into a lane of
     `MakeWide<MakeWide<TFromV<V>>>`.
 
-*   `V`: `u8` \
-    <code>VU64 **SumsOf8**(V v)</code> returns the sums of 8 consecutive u8
-    lanes, zero-extending each sum into a u64 lane. This is slower on RVV/WASM.
+*   `V`: `{i,u}8`, `TW`: `MakeWide<MakeWide<MakeWide<TFromV<V>>>>`,
+    `VW`: `Vec<RepartitionToWide<TW, DFromV<V>>>` \
+    <code>VW **SumsOf8**(V v)</code> returns the sums of 8 consecutive
+    lanes, promoting each sum into a lane of
+    `MakeWide<MakeWide<MakeWide<TFromV<V>>>>`. This is slower on RVV/WASM.
 
-*   `V`: `i8` \
-    <code>VI64 **SumsOf8**(V v)</code> returns the sums of 8 consecutive i8
-    lanes, sign-extending each sum into an i64 lane. This is slower on RVV/WASM.
-
-*   `V`: `u8` \
-    <code>VU64 **SumsOf8AbsDiff**(V a, V b)</code> returns the same result as
+*   `V`: `{i,u}8`, `TW`: `MakeWide<MakeWide<MakeWide<TFromV<V>>>>`,
+    `VW`: `Vec<RepartitionToWide<TW, DFromV<V>>>` \
+    <code>VW **SumsOf8AbsDiff**(V a, V b)</code> returns the same result as
     `SumsOf8(AbsDiff(a, b))` but `SumsOf8AbsDiff(a, b)` is more efficient than
-    `SumsOf8(AbsDiff(a, b))` on SSSE3/SSE4/AVX2/AVX3.
+    `SumsOf8(AbsDiff(a, b))` on SSE2/SSSE3/SSE4/AVX2/AVX3.
 
 *   `V`: `{u,i}{8,16}` \
     <code>V **SaturatedAdd**(V a, V b)</code> returns `a[i] + b[i]` saturated to

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -1842,6 +1842,89 @@ HWY_API Vec128<uint64_t> SumsOf8(const Vec128<uint8_t> v) {
 HWY_API Vec64<uint64_t> SumsOf8(const Vec64<uint8_t> v) {
   return Vec64<uint64_t>(vpaddl_u32(vpaddl_u16(vpaddl_u8(v.raw))));
 }
+HWY_API Vec128<int64_t> SumsOf8(const Vec128<int8_t> v) {
+  return Vec128<int64_t>(vpaddlq_s32(vpaddlq_s16(vpaddlq_s8(v.raw))));
+}
+HWY_API Vec64<int64_t> SumsOf8(const Vec64<int8_t> v) {
+  return Vec64<int64_t>(vpaddl_s32(vpaddl_s16(vpaddl_s8(v.raw))));
+}
+
+// ------------------------------ SumsOf2
+namespace detail {
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<1> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_s8(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<1> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_s8(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<1> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_u8(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<1> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_u8(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<2> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_s16(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<2> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_s16(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<2> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_u16(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<2> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_u16(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<4> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_s32(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::SignedTag, hwy::SizeTag<4> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_s32(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_LE_V(V, 8)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<4> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddl_u32(v.raw));
+}
+
+template <class V, HWY_IF_V_SIZE_V(V, 16)>
+HWY_INLINE VFromD<RepartitionToWide<DFromV<V>>> SumsOf2(
+    hwy::UnsignedTag, hwy::SizeTag<4> /*lane_size_tag*/, V v) {
+  return VFromD<RepartitionToWide<DFromV<V>>>(vpaddlq_u32(v.raw));
+}
+
+}  // namespace detail
 
 // ------------------------------ SaturatedAdd
 
@@ -7181,13 +7264,15 @@ HWY_API VFromD<D> MaxOfLanes(D d, VFromD<D> v) {
 
 // Armv7 lacks N=2 and 8-bit x4, so enable generic versions of those.
 #undef HWY_IF_SUM_OF_LANES_D
-#define HWY_IF_SUM_OF_LANES_D(D) \
-      hwy::EnableIf<(HWY_MAX_LANES_D(D) == 2) || \
-          (sizeof(TFromD<D>) == 1 && HWY_MAX_LANES_D(D) == 4)>* = nullptr
+#define HWY_IF_SUM_OF_LANES_D(D)                                        \
+  hwy::EnableIf<(HWY_MAX_LANES_D(D) == 2) ||                            \
+                (sizeof(TFromD<D>) == 1 && HWY_MAX_LANES_D(D) == 4)>* = \
+      nullptr
 #undef HWY_IF_MINMAX_OF_LANES_D
-#define HWY_IF_MINMAX_OF_LANES_D(D)\
-      hwy::EnableIf<(HWY_MAX_LANES_D(D) == 2) || \
-          (sizeof(TFromD<D>) == 1 && HWY_MAX_LANES_D(D) == 4)>* = nullptr
+#define HWY_IF_MINMAX_OF_LANES_D(D)                                     \
+  hwy::EnableIf<(HWY_MAX_LANES_D(D) == 2) ||                            \
+                (sizeof(TFromD<D>) == 1 && HWY_MAX_LANES_D(D) == 4)>* = \
+      nullptr
 
 // For arm7, we implement reductions using a series of pairwise operations. This
 // produces the full vector result, so we express Reduce* in terms of *OfLanes.
@@ -7242,6 +7327,19 @@ HWY_NEON_DEF_PAIRWISE_REDUCTIONS(Max, vpmax)
 #undef HWY_NEON_DEF_WIDE_PAIRWISE_REDUCTION
 #undef HWY_NEON_DEF_PAIRWISE_REDUCTION
 #undef HWY_NEON_BUILD_TYPE_T
+
+// GetLane(SumsOf4(v)) is more efficient on ArmV7 NEON than the default
+// N=4 I8/U8 ReduceSum implementation in generic_ops-inl.h
+#ifdef HWY_NATIVE_REDUCE_SUM_4_UI8
+#undef HWY_NATIVE_REDUCE_SUM_4_UI8
+#else
+#define HWY_NATIVE_REDUCE_SUM_4_UI8
+#endif
+
+template <class D, HWY_IF_V_SIZE_D(D, 4), HWY_IF_UI8_D(D)>
+HWY_API TFromD<D> ReduceSum(D /*d*/, VFromD<D> v) {
+  return static_cast<TFromD<D>>(GetLane(SumsOf4(v)));
+}
 
 #endif  // HWY_ARCH_ARM_A64
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2666,7 +2666,7 @@ HWY_SVE_FOREACH_F(HWY_SVE_REDUCE, MaxOfLanesM, maxnmv)
 
 // detail::SumOfLanesM, detail::MinOfLanesM, and detail::MaxOfLanesM is more
 // efficient for N=4 I8/U8 reductions on SVE than the default implementations
-// of the N=4 I8/U8 ReduceSum/ReduceMin/ReduceMax implementations in
+// of the N=4 I8/U8 ReduceSum/ReduceMin/ReduceMax operations in
 // generic_ops-inl.h
 #undef HWY_IF_REDUCE_D
 #define HWY_IF_REDUCE_D(D) hwy::EnableIf<HWY_MAX_LANES_D(D) != 1>* = nullptr

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -614,6 +614,15 @@ HWY_API Vec128<uint64_t, (N + 7) / 8> SumsOf8(Vec128<uint8_t, N> v) {
   return sums;
 }
 
+template <size_t N>
+HWY_API Vec128<int64_t, (N + 7) / 8> SumsOf8(Vec128<int8_t, N> v) {
+  Vec128<int64_t, (N + 7) / 8> sums;
+  for (size_t i = 0; i < N; ++i) {
+    sums.raw[i / 8] += v.raw[i];
+  }
+  return sums;
+}
+
 // ------------------------------ SaturatedAdd
 template <typename T, size_t N, HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2)),
           HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -528,8 +528,20 @@ HWY_API Vec1<double> operator-(const Vec1<double> a, const Vec1<double> b) {
 
 // ------------------------------ SumsOf8
 
+HWY_API Vec1<int64_t> SumsOf8(const Vec1<int8_t> v) {
+  return Vec1<int64_t>(v.raw);
+}
 HWY_API Vec1<uint64_t> SumsOf8(const Vec1<uint8_t> v) {
   return Vec1<uint64_t>(v.raw);
+}
+
+// ------------------------------ SumsOf2
+
+template <class T>
+HWY_API Vec1<MakeWide<T>> SumsOf2(const Vec1<T> v) {
+  const DFromV<decltype(v)> d;
+  const Rebind<MakeWide<T>, decltype(d)> dw;
+  return PromoteTo(dw, v);
 }
 
 // ------------------------------ SaturatedAdd

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -4677,6 +4677,31 @@ HWY_API Vec128<uint64_t, N / 8> SumsOf8(const Vec128<uint8_t, N> v) {
   return And(BitCast(du64, sxx_xx_xx_F8_xx_xx_xx_70), Set(du64, 0xFFFF));
 }
 
+template <size_t N>
+HWY_API Vec128<int64_t, N / 8> SumsOf8(const Vec128<int8_t, N> v) {
+  const DFromV<decltype(v)> di8;
+  const RepartitionToWide<decltype(di8)> di16;
+  const RepartitionToWide<decltype(di16)> di32;
+  const RepartitionToWide<decltype(di32)> di64;
+  const RebindToUnsigned<decltype(di32)> du32;
+  const RebindToUnsigned<decltype(di64)> du64;
+  using VI16 = VFromD<decltype(di16)>;
+
+  const VI16 vFDB97531 = ShiftRight<8>(BitCast(di16, v));
+  const VI16 vECA86420 = ShiftRight<8>(ShiftLeft<8>(BitCast(di16, v)));
+  const VI16 sFE_DC_BA_98_76_54_32_10 = Add(vFDB97531, vECA86420);
+
+  const VI16 sDC_zz_98_zz_54_zz_10_zz =
+      BitCast(di16, ShiftLeft<16>(BitCast(du32, sFE_DC_BA_98_76_54_32_10)));
+  const VI16 sFC_xx_B8_xx_74_xx_30_xx =
+      Add(sFE_DC_BA_98_76_54_32_10, sDC_zz_98_zz_54_zz_10_zz);
+  const VI16 sB8_xx_zz_zz_30_xx_zz_zz =
+      BitCast(di16, ShiftLeft<32>(BitCast(du64, sFC_xx_B8_xx_74_xx_30_xx)));
+  const VI16 sF8_xx_xx_xx_70_xx_xx_xx =
+      Add(sFC_xx_B8_xx_74_xx_30_xx, sB8_xx_zz_zz_30_xx_zz_zz);
+  return ShiftRight<48>(BitCast(di64, sF8_xx_xx_xx_70_xx_xx_xx));
+}
+
 // ------------------------------ LoadMaskBits (TestBit)
 
 namespace detail {

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -146,6 +146,13 @@ HWY_API Vec256<uint64_t> SumsOf8(const Vec256<uint8_t> v) {
   return ret;
 }
 
+HWY_API Vec256<int64_t> SumsOf8(const Vec256<int8_t> v) {
+  Vec256<int64_t> ret;
+  ret.v0 = SumsOf8(v.v0);
+  ret.v1 = SumsOf8(v.v1);
+  return ret;
+}
+
 template <typename T>
 HWY_API Vec256<T> SaturatedAdd(Vec256<T> a, const Vec256<T> b) {
   a.v0 = SaturatedAdd(a.v0, b.v0);

--- a/hwy/tests/test_util.h
+++ b/hwy/tests/test_util.h
@@ -68,6 +68,33 @@ static HWY_INLINE uint32_t Random32(RandomState* rng) {
 
 static HWY_INLINE uint64_t Random64(RandomState* rng) { return (*rng)(); }
 
+template <class T, HWY_IF_FLOAT_OR_SPECIAL(T)>
+static HWY_INLINE T RandomFiniteValue(RandomState* rng) {
+  const uint64_t rand_bits = Random64(rng);
+
+  using TU = MakeUnsigned<T>;
+  constexpr TU kExponentMask = ExponentMask<T>();
+  constexpr TU kSignMantMask = static_cast<TU>(~kExponentMask);
+  constexpr TU kMaxExpField = static_cast<TU>(MaxExponentField<T>());
+  constexpr int kNumOfMantBits = MantissaBits<T>();
+
+  const TU orig_exp_field_val =
+      static_cast<TU>((rand_bits >> kNumOfMantBits) & kMaxExpField);
+
+  const TU sign_mant_bits = static_cast<TU>(rand_bits & kSignMantMask);
+  const TU exp_bits =
+      static_cast<TU>(HWY_MIN(HWY_MAX(orig_exp_field_val, 1), kMaxExpField - 1)
+                      << kNumOfMantBits);
+
+  return BitCastScalar<T>(static_cast<TU>(sign_mant_bits | exp_bits));
+}
+
+template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
+static HWY_INLINE T RandomFiniteValue(RandomState* rng) {
+  using TU = MakeUnsigned<T>;
+  return static_cast<T>(Random64(rng) & LimitsMax<TU>());
+}
+
 HWY_TEST_DLLEXPORT bool BytesEqual(const void* p1, const void* p2, size_t size,
                                    size_t* pos = nullptr);
 


### PR DESCRIPTION
Added the SumsOf2 and SumsOf4 operations.

Also added the SumsOf8 and SumsOf8AbsDiff operations for I8 vectors.

Also updated the N=4 I8/U8 ReduceSum/ReduceMin/ReduceMax operations in generic_ops-inl.h to allow for target-specific optimized implementations of the N=4 I8/U8 ReduceSum/ReduceMin/ReduceMax operations.

Updated the N=4 I8/U8 ReduceSum implementation on PPC8/PPC9/PPC10/Armv7 Neon to do a `GetLane(SumsOf4(v))` instead of the default implementation in generic_ops-inl.h as `GetLane(SumsOf4(v))` is more efficient than the default implementation in generic_ops-inl.h for N=4 I8/U8 vectors on PPC8/PPC9/PPC10/Armv7 Neon.

Also updated implementations of ReduceSum/ReduceMin/ReduceMax on RVV/SVE to use the ReduceSum/ReduceMin/ReduceMax implementations in arm_sve-inl.h or rvv-inl.h for N=4 I8/U8 vectors instead of the default implementation in generic_ops-inl.h as the implementations of ReduceSum/ReduceMin/ReduceMax in arm_sve-inl.h and rvv-inl.h can deal with N=4 I8/U8 vectors.