### PR TITLE
Added IfNegativeThenNegOrUndefIfZero operation

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -850,6 +850,12 @@ Special functions for signed types:
     <code>V **IfNegativeThenElse**(V v, V yes, V no)</code>: returns `v[i] < 0 ?
     yes[i] : no[i]`. This may be more efficient than `IfThenElse(Lt..)`.
 
+*   `V`: `{i,f}` \
+    <code>V **CondNegateOrZero**(V a, V b)</code>: returns `b[i] < 0 ? (-a[i]) :
+    ((b[i] == 0) ? 0 : a[i])`. `CondNegateOrZero(a, b)` is more efficient than
+    `IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a))` for
+    I8/I16/I32 vectors on SSSE3/SSE4/AVX2/AVX3.
+
 ### Masks
 
 Let `M` denote a mask capable of storing a logical true/false for each lane (the

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -851,10 +851,14 @@ Special functions for signed types:
     yes[i] : no[i]`. This may be more efficient than `IfThenElse(Lt..)`.
 
 *   `V`: `{i,f}` \
-    <code>V **CondNegateOrZero**(V a, V b)</code>: returns `b[i] < 0 ? (-a[i]) :
-    ((b[i] == 0) ? 0 : a[i])`. `CondNegateOrZero(a, b)` is more efficient than
-    `IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a))` for
-    I8/I16/I32 vectors on SSSE3/SSE4/AVX2/AVX3.
+    <code>V **IfNegativeThenNegOrUndefIfZero**(V mask, V v)</code>: returns
+    `mask[i] < 0 ? (-v[i]) : ((mask[i] > 0) ? v[i] : impl_defined_val)`, where
+    `impl_defined_val` is an implementation-defined value that is equal to
+    either 0 or `v[i]`.
+
+    `IfNegativeThenNegOrUndefIfZero(mask, v)` is more efficient than
+    `IfNegativeThenElse(mask, Neg(v), v)` for I8/I16/I32 vectors that are
+    32 bytes or smaller on SSSE3/SSE4/AVX2/AVX3 targets.
 
 ### Masks
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -294,28 +294,32 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
-// ------------------------------ CondNegateOrZero
+// ------------------------------ IfNegativeThenNegOrUndefIfZero
 
-#if (defined(HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO) == \
+#if (defined(HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG) == \
      defined(HWY_TARGET_TOGGLE))
-#ifdef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
-#undef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#ifdef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
+#undef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
 #else
-#define HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#define HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
 #endif
 
 template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
-HWY_API V CondNegateOrZero(V a, V b) {
-  const DFromV<decltype(a)> d;
-  return IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a));
+HWY_API V IfNegativeThenNegOrUndefIfZero(V mask, V v) {
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+  // MaskedSubOr is more efficient than IfNegativeThenElse on RVV/SVE
+  const auto zero = Zero(DFromV<V>());
+  return MaskedSubOr(v, Lt(mask, zero), zero, v);
+#else
+  return IfNegativeThenElse(mask, Neg(v), v);
+#endif
 }
 
-#endif  // HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#endif  // HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
 
 template <class V, HWY_IF_FLOAT_V(V)>
-HWY_API V CondNegateOrZero(V a, V b) {
-  const DFromV<decltype(a)> d;
-  return IfThenZeroElse(Eq(b, Zero(d)), CopySign(a, Xor(a, b)));
+HWY_API V IfNegativeThenNegOrUndefIfZero(V mask, V v) {
+  return CopySign(v, Xor(mask, v));
 }
 
 // ------------------------------ Reductions

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -294,6 +294,30 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
+// ------------------------------ CondNegateOrZero
+
+#if (defined(HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO) == \
+     defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#undef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#else
+#define HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#endif
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V CondNegateOrZero(V a, V b) {
+  const DFromV<decltype(a)> d;
+  return IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a));
+}
+
+#endif  // HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V CondNegateOrZero(V a, V b) {
+  const DFromV<decltype(a)> d;
+  return IfThenZeroElse(Eq(b, Zero(d)), CopySign(a, Xor(a, b)));
+}
+
 // ------------------------------ Reductions
 
 // Targets follow one of two strategies. If HWY_NATIVE_REDUCE_SCALAR is toggled,

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -3804,48 +3804,48 @@ HWY_API Vec128<T, N> IfNegativeThenElse(Vec128<T, N> v, Vec128<T, N> yes,
 #endif
 }
 
-// ------------------------------ CondNegateOrZero
+// ------------------------------ IfNegativeThenNegOrUndefIfZero
 
 #if HWY_TARGET <= HWY_SSSE3
 
-#ifdef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
-#undef HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#ifdef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
+#undef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
 #else
-#define HWY_NATIVE_INTEGER_COND_NEGATE_OR_ZERO
+#define HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
 #endif
 
 template <size_t N>
-HWY_API Vec128<int8_t, N> CondNegateOrZero(Vec128<int8_t, N> a,
-                                           Vec128<int8_t, N> b) {
-  return Vec128<int8_t, N>{_mm_sign_epi8(a.raw, b.raw)};
+HWY_API Vec128<int8_t, N> IfNegativeThenNegOrUndefIfZero(Vec128<int8_t, N> mask,
+                                                         Vec128<int8_t, N> v) {
+  return Vec128<int8_t, N>{_mm_sign_epi8(v.raw, mask.raw)};
 }
 
 template <size_t N>
-HWY_API Vec128<int16_t, N> CondNegateOrZero(Vec128<int16_t, N> a,
-                                            Vec128<int16_t, N> b) {
-  return Vec128<int16_t, N>{_mm_sign_epi16(a.raw, b.raw)};
+HWY_API Vec128<int16_t, N> IfNegativeThenNegOrUndefIfZero(
+    Vec128<int16_t, N> mask, Vec128<int16_t, N> v) {
+  return Vec128<int16_t, N>{_mm_sign_epi16(v.raw, mask.raw)};
 }
 
 template <size_t N>
-HWY_API Vec128<int32_t, N> CondNegateOrZero(Vec128<int32_t, N> a,
-                                            Vec128<int32_t, N> b) {
-  return Vec128<int32_t, N>{_mm_sign_epi32(a.raw, b.raw)};
+HWY_API Vec128<int32_t, N> IfNegativeThenNegOrUndefIfZero(
+    Vec128<int32_t, N> mask, Vec128<int32_t, N> v) {
+  return Vec128<int32_t, N>{_mm_sign_epi32(v.raw, mask.raw)};
 }
 
 // Generic for all vector lengths
 template <class V, HWY_IF_I64_D(DFromV<V>)>
-HWY_API V CondNegateOrZero(V a, V b) {
-  const DFromV<decltype(a)> d;
-
+HWY_API V IfNegativeThenNegOrUndefIfZero(V mask, V v) {
 #if HWY_TARGET <= HWY_AVX3
-  return IfThenZeroElse(Eq(b, Zero(d)),
-                        MaskedSubOr(a, MaskFromVec(b), Zero(d), a));
+  // MaskedSubOr is more efficient than IfNegativeThenElse on AVX3
+  const DFromV<decltype(v)> d;
+  return MaskedSubOr(v, MaskFromVec(mask), Zero(d), v);
 #else
-  return IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a));
+  // IfNegativeThenElse is more efficient than MaskedSubOr on SSE4/AVX2
+  return IfNegativeThenElse(mask, Neg(v), v);
 #endif
 }
 
-#endif
+#endif  // HWY_TARGET <= HWY_SSSE3
 
 // ------------------------------ ShiftLeftSame
 
@@ -4264,25 +4264,25 @@ HWY_API Vec256<float16_t> MaskedDivOr(Vec256<float16_t> no,
 
 template <typename T, size_t N, HWY_IF_I8(T)>
 HWY_API Vec128<T, N> MaskedSatAddOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_adds_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_U8(T)>
 HWY_API Vec128<T, N> MaskedSatAddOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_adds_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_I16(T)>
 HWY_API Vec128<T, N> MaskedSatAddOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_adds_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_U16(T)>
 HWY_API Vec128<T, N> MaskedSatAddOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_adds_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 
@@ -4290,25 +4290,25 @@ HWY_API Vec128<T, N> MaskedSatAddOr(Vec128<T, N> no, Mask128<T, N> m,
 
 template <typename T, size_t N, HWY_IF_I8(T)>
 HWY_API Vec128<T, N> MaskedSatSubOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_subs_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_U8(T)>
 HWY_API Vec128<T, N> MaskedSatSubOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_subs_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_I16(T)>
 HWY_API Vec128<T, N> MaskedSatSubOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_subs_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, size_t N, HWY_IF_U16(T)>
 HWY_API Vec128<T, N> MaskedSatSubOr(Vec128<T, N> no, Mask128<T, N> m,
-                                 Vec128<T, N> a, Vec128<T, N> b) {
+                                    Vec128<T, N> a, Vec128<T, N> b) {
   return Vec128<T, N>{_mm_mask_subs_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2187,18 +2187,21 @@ HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
 #endif
 }
 
-// ------------------------------ CondNegateOrZero
+// ------------------------------ IfNegativeThenNegOrUndefIfZero
 
-HWY_API Vec256<int8_t> CondNegateOrZero(Vec256<int8_t> a, Vec256<int8_t> b) {
-  return Vec256<int8_t>{_mm256_sign_epi8(a.raw, b.raw)};
+HWY_API Vec256<int8_t> IfNegativeThenNegOrUndefIfZero(Vec256<int8_t> mask,
+                                                      Vec256<int8_t> v) {
+  return Vec256<int8_t>{_mm256_sign_epi8(v.raw, mask.raw)};
 }
 
-HWY_API Vec256<int16_t> CondNegateOrZero(Vec256<int16_t> a, Vec256<int16_t> b) {
-  return Vec256<int16_t>{_mm256_sign_epi16(a.raw, b.raw)};
+HWY_API Vec256<int16_t> IfNegativeThenNegOrUndefIfZero(Vec256<int16_t> mask,
+                                                       Vec256<int16_t> v) {
+  return Vec256<int16_t>{_mm256_sign_epi16(v.raw, mask.raw)};
 }
 
-HWY_API Vec256<int32_t> CondNegateOrZero(Vec256<int32_t> a, Vec256<int32_t> b) {
-  return Vec256<int32_t>{_mm256_sign_epi32(a.raw, b.raw)};
+HWY_API Vec256<int32_t> IfNegativeThenNegOrUndefIfZero(Vec256<int32_t> mask,
+                                                       Vec256<int32_t> v) {
+  return Vec256<int32_t>{_mm256_sign_epi32(v.raw, mask.raw)};
 }
 
 // ------------------------------ ShiftLeftSame
@@ -2561,52 +2564,52 @@ HWY_API Vec256<float16_t> MaskedDivOr(Vec256<float16_t> no,
 // ------------------------------ MaskedSatAddOr
 
 template <typename T, HWY_IF_I8(T)>
-HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_adds_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U8(T)>
-HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_adds_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_I16(T)>
-HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_adds_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U16(T)>
-HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatAddOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_adds_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 // ------------------------------ MaskedSatSubOr
 
 template <typename T, HWY_IF_I8(T)>
-HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_subs_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U8(T)>
-HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_subs_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_I16(T)>
-HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_subs_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U16(T)>
-HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m,
-                                 Vec256<T> a, Vec256<T> b) {
+HWY_API Vec256<T> MaskedSatSubOr(Vec256<T> no, Mask256<T> m, Vec256<T> a,
+                                 Vec256<T> b) {
   return Vec256<T>{_mm256_mask_subs_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2187,6 +2187,20 @@ HWY_API Vec256<T> IfNegativeThenElse(Vec256<T> v, Vec256<T> yes, Vec256<T> no) {
 #endif
 }
 
+// ------------------------------ CondNegateOrZero
+
+HWY_API Vec256<int8_t> CondNegateOrZero(Vec256<int8_t> a, Vec256<int8_t> b) {
+  return Vec256<int8_t>{_mm256_sign_epi8(a.raw, b.raw)};
+}
+
+HWY_API Vec256<int16_t> CondNegateOrZero(Vec256<int16_t> a, Vec256<int16_t> b) {
+  return Vec256<int16_t>{_mm256_sign_epi16(a.raw, b.raw)};
+}
+
+HWY_API Vec256<int32_t> CondNegateOrZero(Vec256<int32_t> a, Vec256<int32_t> b) {
+  return Vec256<int32_t>{_mm256_sign_epi32(a.raw, b.raw)};
+}
+
 // ------------------------------ ShiftLeftSame
 
 HWY_API Vec256<uint16_t> ShiftLeftSame(const Vec256<uint16_t> v,

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -896,6 +896,15 @@ HWY_API Vec512<T> IfNegativeThenElse(Vec512<T> v, Vec512<T> yes, Vec512<T> no) {
   return IfThenElse(MaskFromVec(v), yes, no);
 }
 
+template <typename T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T),
+          HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4))>
+HWY_API Vec512<T> CondNegateOrZero(Vec512<T> a, Vec512<T> b) {
+  const DFromV<decltype(a)> d;
+  // AVX3 MaskFromVec only looks at the MSB
+  return IfThenZeroElse(Eq(b, Zero(d)),
+                        MaskedSubOr(a, MaskFromVec(b), Zero(d), a));
+}
+
 template <typename T, HWY_IF_FLOAT(T)>
 HWY_API Vec512<T> ZeroIfNegative(const Vec512<T> v) {
   // AVX3 MaskFromVec only looks at the MSB

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -898,11 +898,10 @@ HWY_API Vec512<T> IfNegativeThenElse(Vec512<T> v, Vec512<T> yes, Vec512<T> no) {
 
 template <typename T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T),
           HWY_IF_T_SIZE_ONE_OF(T, (1 << 1) | (1 << 2) | (1 << 4))>
-HWY_API Vec512<T> CondNegateOrZero(Vec512<T> a, Vec512<T> b) {
-  const DFromV<decltype(a)> d;
+HWY_API Vec512<T> IfNegativeThenNegOrUndefIfZero(Vec512<T> mask, Vec512<T> v) {
   // AVX3 MaskFromVec only looks at the MSB
-  return IfThenZeroElse(Eq(b, Zero(d)),
-                        MaskedSubOr(a, MaskFromVec(b), Zero(d), a));
+  const DFromV<decltype(v)> d;
+  return MaskedSubOr(v, MaskFromVec(mask), Zero(d), v);
 }
 
 template <typename T, HWY_IF_FLOAT(T)>
@@ -1787,52 +1786,52 @@ HWY_API Vec512<float16_t> MaskedDivOr(Vec512<float16_t> no,
 // ------------------------------ MaskedSatAddOr
 
 template <typename T, HWY_IF_I8(T)>
-HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_adds_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U8(T)>
-HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_adds_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_I16(T)>
-HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m,
-                                    Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_adds_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U16(T)>
-HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m,
-                                    Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatAddOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_adds_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 // ------------------------------ MaskedSatSubOr
 
 template <typename T, HWY_IF_I8(T)>
-HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_subs_epi8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U8(T)>
-HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_subs_epu8(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_I16(T)>
-HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_subs_epi16(no.raw, m.raw, a.raw, b.raw)};
 }
 
 template <typename T, HWY_IF_U16(T)>
-HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m,
-                                 Vec512<T> a, Vec512<T> b) {
+HWY_API Vec512<T> MaskedSatSubOr(Vec512<T> no, Mask512<T> m, Vec512<T> a,
+                                 Vec512<T> b) {
   return Vec512<T>{_mm512_mask_subs_epu16(no.raw, m.raw, a.raw, b.raw)};
 }
 

--- a/hwy/tests/if_test.cc
+++ b/hwy/tests/if_test.cc
@@ -174,7 +174,7 @@ HWY_NOINLINE void TestAllIfNegative() {
   ForSignedTypes(ForPartialVectors<TestIfNegative>());
 }
 
-struct TestCondNegateOrZero {
+struct TestIfNegativeThenNegOrUndefIfZero {
   template <class D, HWY_IF_FLOAT_D(D)>
   static HWY_INLINE Vec<D> PositiveIota(D d) {
     return Iota(d, TFromD<D>{1});
@@ -186,13 +186,12 @@ struct TestCondNegateOrZero {
   }
 
   template <class D, HWY_IF_LANES_LE_D(D, 1)>
-  static HWY_INLINE void TestMoreThan1LaneCondNegateOrZero(D /*d*/,
-                                                           Vec<D> /*v1*/,
-                                                           Vec<D> /*v2*/) {}
+  static HWY_INLINE void TestMoreThan1LaneIfNegativeThenNegOrUndefIfZero(
+      D /*d*/, Vec<D> /*v1*/, Vec<D> /*v2*/) {}
 #if HWY_TARGET != HWY_SCALAR
   template <class D, HWY_IF_LANES_GT_D(D, 1)>
-  static HWY_INLINE void TestMoreThan1LaneCondNegateOrZero(D d, Vec<D> v1,
-                                                           Vec<D> v2) {
+  static HWY_INLINE void TestMoreThan1LaneIfNegativeThenNegOrUndefIfZero(
+      D d, Vec<D> v1, Vec<D> v2) {
 #if HWY_HAVE_SCALABLE
     if (Lanes(d) < 2) {
       return;
@@ -206,31 +205,25 @@ struct TestCondNegateOrZero {
     const auto v7 = InterleaveLower(d, v2, v1);
     const auto v8 = InterleaveUpper(d, v2, v1);
 
-    HWY_ASSERT_VEC_EQ(d, v3, CondNegateOrZero(v3, v3));
-    HWY_ASSERT_VEC_EQ(d, v4, CondNegateOrZero(v4, v4));
-    HWY_ASSERT_VEC_EQ(d, v3, CondNegateOrZero(v5, v5));
-    HWY_ASSERT_VEC_EQ(d, v4, CondNegateOrZero(v6, v6));
-    HWY_ASSERT_VEC_EQ(d, v3, CondNegateOrZero(v7, v7));
-    HWY_ASSERT_VEC_EQ(d, v4, CondNegateOrZero(v8, v8));
+    HWY_ASSERT_VEC_EQ(d, v3, IfNegativeThenNegOrUndefIfZero(v3, v3));
+    HWY_ASSERT_VEC_EQ(d, v4, IfNegativeThenNegOrUndefIfZero(v4, v4));
+    HWY_ASSERT_VEC_EQ(d, v3, IfNegativeThenNegOrUndefIfZero(v5, v5));
+    HWY_ASSERT_VEC_EQ(d, v4, IfNegativeThenNegOrUndefIfZero(v6, v6));
+    HWY_ASSERT_VEC_EQ(d, v3, IfNegativeThenNegOrUndefIfZero(v7, v7));
+    HWY_ASSERT_VEC_EQ(d, v4, IfNegativeThenNegOrUndefIfZero(v8, v8));
 
-    HWY_ASSERT_VEC_EQ(d, v5, CondNegateOrZero(v5, v3));
-    HWY_ASSERT_VEC_EQ(d, v6, CondNegateOrZero(v6, v4));
-    HWY_ASSERT_VEC_EQ(d, v7, CondNegateOrZero(v7, v3));
-    HWY_ASSERT_VEC_EQ(d, v8, CondNegateOrZero(v8, v4));
+    HWY_ASSERT_VEC_EQ(d, v5, IfNegativeThenNegOrUndefIfZero(v3, v5));
+    HWY_ASSERT_VEC_EQ(d, v6, IfNegativeThenNegOrUndefIfZero(v4, v6));
+    HWY_ASSERT_VEC_EQ(d, v7, IfNegativeThenNegOrUndefIfZero(v3, v7));
+    HWY_ASSERT_VEC_EQ(d, v8, IfNegativeThenNegOrUndefIfZero(v4, v8));
 
     const auto zero = Zero(d);
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v3, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v4, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v5, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v6, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v7, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v8, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v3));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v4));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v5));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v6));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v7));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v8));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v3, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v4, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v5, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v6, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v7, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v8, zero));
   }
 #endif
 
@@ -238,33 +231,32 @@ struct TestCondNegateOrZero {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const auto v1 = PositiveIota(d);
     const auto v2 = Neg(v1);
+
+    HWY_ASSERT_VEC_EQ(d, v1, IfNegativeThenNegOrUndefIfZero(v1, v1));
+    HWY_ASSERT_VEC_EQ(d, v2, IfNegativeThenNegOrUndefIfZero(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, IfNegativeThenNegOrUndefIfZero(v2, v1));
+    HWY_ASSERT_VEC_EQ(d, v1, IfNegativeThenNegOrUndefIfZero(v2, v2));
+
     const auto zero = Zero(d);
-
-    HWY_ASSERT_VEC_EQ(d, v1, CondNegateOrZero(v1, v1));
-    HWY_ASSERT_VEC_EQ(d, v2, CondNegateOrZero(v2, v1));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v1, zero));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(v2, zero));
-    HWY_ASSERT_VEC_EQ(d, v2, CondNegateOrZero(v1, v2));
-    HWY_ASSERT_VEC_EQ(d, v1, CondNegateOrZero(v2, v2));
-
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v1));
-    HWY_ASSERT_VEC_EQ(d, zero, CondNegateOrZero(zero, v2));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(zero, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v1, zero));
+    HWY_ASSERT_VEC_EQ(d, zero, IfNegativeThenNegOrUndefIfZero(v2, zero));
 
     const auto vmin = Set(d, LowestValue<T>());
     const auto vmax = Set(d, HighestValue<T>());
 
-    HWY_ASSERT_VEC_EQ(d, v2, CondNegateOrZero(v1, vmin));
-    HWY_ASSERT_VEC_EQ(d, v1, CondNegateOrZero(v2, vmin));
-    HWY_ASSERT_VEC_EQ(d, v1, CondNegateOrZero(v1, vmax));
-    HWY_ASSERT_VEC_EQ(d, v2, CondNegateOrZero(v2, vmax));
+    HWY_ASSERT_VEC_EQ(d, v2, IfNegativeThenNegOrUndefIfZero(vmin, v1));
+    HWY_ASSERT_VEC_EQ(d, v1, IfNegativeThenNegOrUndefIfZero(vmin, v2));
+    HWY_ASSERT_VEC_EQ(d, v1, IfNegativeThenNegOrUndefIfZero(vmax, v1));
+    HWY_ASSERT_VEC_EQ(d, v2, IfNegativeThenNegOrUndefIfZero(vmax, v2));
 
-    TestMoreThan1LaneCondNegateOrZero(d, v1, v2);
+    TestMoreThan1LaneIfNegativeThenNegOrUndefIfZero(d, v1, v2);
   }
 };
 
-HWY_NOINLINE void TestAllCondNegateOrZero() {
-  ForSignedTypes(ForPartialVectors<TestCondNegateOrZero>());
-  ForFloatTypes(ForPartialVectors<TestCondNegateOrZero>());
+HWY_NOINLINE void TestAllIfNegativeThenNegOrUndefIfZero() {
+  ForSignedTypes(ForPartialVectors<TestIfNegativeThenNegOrUndefIfZero>());
+  ForFloatTypes(ForPartialVectors<TestIfNegativeThenNegOrUndefIfZero>());
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -280,7 +272,7 @@ HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllIfThenElse);
 HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllIfVecThenElse);
 HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllZeroIfNegative);
 HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllIfNegative);
-HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllCondNegateOrZero);
+HWY_EXPORT_AND_TEST_P(HwyIfTest, TestAllIfNegativeThenNegOrUndefIfZero);
 }  // namespace hwy
 
 #endif


### PR DESCRIPTION
The CondNegateOrZero operation was added as SSSE3/SSE4/AVX2/AVX3 have PSIGNB/PSIGNW/PSIGND instructions that can carry out the `IfNegativeThenElse(b, Neg(a), IfThenZeroElse(Eq(b, Zero(d)), a))` operation for I8/I16/I32 vectors that are 32 bytes or smaller.

AVX3 can also more efficiently carry out the `b[i] < 0 ? (-a[i]) : (a[i])` operation for I8/I16/I32/I64 vectors using `MaskedSubOr(a, MaskFromVec(b), Zero(d), a)`.