### PR TITLE
Fix compilation on x86+AVX2

### DIFF
--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -752,7 +752,7 @@ HWY_API MFromD<D> FirstN(D d, size_t n) {
   m.raw = static_cast<decltype(m.raw)>(_bzhi_u64(all, n));
   return m;
 #else
-  return detail::FirstN<T>(n);
+  return detail::FirstN<TFromD<D>>(n);
 #endif  // HWY_ARCH_X86_64
 }
 


### PR DESCRIPTION
Fixes compilation error:

hwy/ops/x86_512-inl.h: In function 'hwy::N_AVX3::MFromD<D> hwy::N_AVX3::FirstN(D, size_t)': hwy/ops/x86_512-inl.h:755:25: error: 'T' was not declared in this scope
  755 |   return detail::FirstN<T>(n);
      |                         ^