### PR TITLE
Made fixes to I8 SumsOf8AbsDiff

### DIFF
--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -2052,16 +2052,14 @@ HWY_API V AbsDiff(V a, V b) {
 #define HWY_NATIVE_SUMS_OF_8_ABS_DIFF
 #endif
 
-template <class V, HWY_IF_U8_D(DFromV<V>),
+template <class V, HWY_IF_UI8_D(DFromV<V>),
           HWY_IF_V_SIZE_GT_D(DFromV<V>, (HWY_TARGET == HWY_SCALAR ? 0 : 4))>
-HWY_API Vec<Repartition<uint64_t, DFromV<V>>> SumsOf8AbsDiff(V a, V b) {
-  return SumsOf8(AbsDiff(a, b));
-}
+HWY_API Vec<RepartitionToWideX3<DFromV<V>>> SumsOf8AbsDiff(V a, V b) {
+  const DFromV<decltype(a)> d;
+  const RebindToUnsigned<decltype(d)> du;
+  const RepartitionToWideX3<decltype(d)> dw;
 
-template <class V, HWY_IF_I8_D(DFromV<V>),
-          HWY_IF_V_SIZE_GT_D(DFromV<V>, (HWY_TARGET == HWY_SCALAR ? 0 : 4))>
-HWY_API Vec<Repartition<int64_t, DFromV<V>>> SumsOf8AbsDiff(V a, V b) {
-  return SumsOf8(AbsDiff(a, b));
+  return BitCast(dw, SumsOf8(BitCast(du, AbsDiff(a, b))));
 }
 
 #endif  // HWY_NATIVE_SUMS_OF_8_ABS_DIFF

--- a/hwy/tests/reduction_test.cc
+++ b/hwy/tests/reduction_test.cc
@@ -378,6 +378,7 @@ struct TestSumsOf8AbsDiff {
 };
 
 HWY_NOINLINE void TestAllSumsOf8AbsDiff() {
+  ForGEVectors<64, TestSumsOf8AbsDiff>()(int8_t());
   ForGEVectors<64, TestSumsOf8AbsDiff>()(uint8_t());
 }
 


### PR DESCRIPTION
Updated I8/U8 implementation of SumsOf8AbsDiff in generic_ops-inl.h to fix a bug with I8 SumsOf8AbsDiff as the result of the I8 AbsDiff operation needs to be bitcasted to an U8 vector.

Also enabled TestSumsOf8AbsDiff for int8_t vectors that are >= 64 bits.