### PR TITLE
Added additional mask conversion/combine/split/creation ops

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -402,6 +402,8 @@ HWY_TESTS = [
     ("hwy/tests/", "if_test"),
     ("hwy/tests/", "interleaved_test"),
     ("hwy/tests/", "logical_test"),
+    ("hwy/tests/", "mask_combine_test"),
+    ("hwy/tests/", "mask_convert_test"),
     ("hwy/tests/", "mask_mem_test"),
     ("hwy/tests/", "mask_test"),
     ("hwy/tests/", "masked_arithmetic_test"),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,8 @@ set(HWY_TEST_FILES
   hwy/tests/if_test.cc
   hwy/tests/interleaved_test.cc
   hwy/tests/logical_test.cc
+  hwy/tests/mask_combine_test.cc
+  hwy/tests/mask_convert_test.cc
   hwy/tests/mask_mem_test.cc
   hwy/tests/mask_test.cc
   hwy/tests/masked_arithmetic_test.cc

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -903,6 +903,10 @@ using If = typename IfT<Condition, Then, Else>::type;
 // bits explicitly (0x14) instead of attempting to 'negate' 0x102.
 #define HWY_IF_T_SIZE_ONE_OF(T, bit_array) \
   hwy::EnableIf<((size_t{1} << sizeof(T)) & (bit_array)) != 0>* = nullptr
+#define HWY_IF_T_SIZE_LE(T, bytes) \
+  hwy::EnableIf<(sizeof(T) <= (bytes))>* = nullptr
+#define HWY_IF_T_SIZE_GT(T, bytes) \
+  hwy::EnableIf<(sizeof(T) > (bytes))>* = nullptr
 
 #define HWY_IF_U8(T) hwy::EnableIf<IsSame<T, uint8_t>()>* = nullptr
 #define HWY_IF_U16(T) hwy::EnableIf<IsSame<T, uint16_t>()>* = nullptr

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -7410,6 +7410,15 @@ HWY_API MFromD<D> LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
   return detail::LoadMaskBits(d, mask_bits);
 }
 
+// ------------------------------ Dup128MaskFromMaskBits
+
+template <class D>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  constexpr size_t kN = MaxLanes(d);
+  if (kN < 8) mask_bits &= (1u << kN) - 1;
+  return detail::LoadMaskBits(d, mask_bits);
+}
+
 // ------------------------------ Mask
 
 namespace detail {

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -2420,6 +2420,15 @@ HWY_API MFromD<D> LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
   return m;
 }
 
+template <class D>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  MFromD<D> m;
+  for (size_t i = 0; i < MaxLanes(d); ++i) {
+    m.bits[i] = MFromD<D>::FromBool(((mask_bits >> i) & 1u) != 0);
+  }
+  return m;
+}
+
 // `p` points to at least 8 writable bytes.
 template <class D>
 HWY_API size_t StoreMaskBits(D d, MFromD<D> mask, uint8_t* bits) {

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -221,11 +221,15 @@ HWY_API V BitwiseIfThenElse(V mask, V yes, V no) {
 #define HWY_NATIVE_PROMOTE_MASK_TO
 #endif
 
-template <class DTo, class DFrom,
-          HWY_IF_T_SIZE_GT_D(DTo, sizeof(TFromD<DFrom>)),
-          class DFrom_2 = Rebind<TFromD<DFrom>, DTo>,
-          hwy::EnableIf<IsSame<Mask<DFrom>, Mask<DFrom_2>>()>* = nullptr>
+template <class DTo, class DFrom>
 HWY_API Mask<DTo> PromoteMaskTo(DTo d_to, DFrom d_from, Mask<DFrom> m) {
+  static_assert(
+      sizeof(TFromD<DTo>) > sizeof(TFromD<DFrom>),
+      "sizeof(TFromD<DTo>) must be greater than sizeof(TFromD<DFrom>)");
+  static_assert(
+      IsSame<Mask<DFrom>, Mask<Rebind<TFromD<DFrom>, DTo>>>(),
+      "Mask<DFrom> must be the same type as Mask<Rebind<TFromD<DFrom>, DTo>>");
+
   const RebindToSigned<decltype(d_to)> di_to;
   const RebindToSigned<decltype(d_from)> di_from;
 
@@ -244,11 +248,14 @@ HWY_API Mask<DTo> PromoteMaskTo(DTo d_to, DFrom d_from, Mask<DFrom> m) {
 #define HWY_NATIVE_DEMOTE_MASK_TO
 #endif
 
-template <class DTo, class DFrom,
-          HWY_IF_T_SIZE_LE_D(DTo, sizeof(TFromD<DFrom>) - 1),
-          class DFrom_2 = Rebind<TFromD<DFrom>, DTo>,
-          hwy::EnableIf<IsSame<Mask<DFrom>, Mask<DFrom_2>>()>* = nullptr>
+template <class DTo, class DFrom>
 HWY_API Mask<DTo> DemoteMaskTo(DTo d_to, DFrom d_from, Mask<DFrom> m) {
+  static_assert(sizeof(TFromD<DTo>) < sizeof(TFromD<DFrom>),
+                "sizeof(TFromD<DTo>) must be less than sizeof(TFromD<DFrom>)");
+  static_assert(
+      IsSame<Mask<DFrom>, Mask<Rebind<TFromD<DFrom>, DTo>>>(),
+      "Mask<DFrom> must be the same type as Mask<Rebind<TFromD<DFrom>, DTo>>");
+
   const RebindToSigned<decltype(d_to)> di_to;
   const RebindToSigned<decltype(d_from)> di_from;
 
@@ -324,12 +331,16 @@ HWY_API Mask<D> UpperHalfOfMask(D d, Mask<Twice<D>> m) {
 #endif
 
 #if HWY_TARGET != HWY_SCALAR
-template <class DTo, class DFrom,
-          HWY_IF_T_SIZE_D(DTo, sizeof(TFromD<DFrom>) / 2),
-          class DTo_2 = Repartition<TFromD<DTo>, DFrom>,
-          hwy::EnableIf<IsSame<Mask<DTo>, Mask<DTo_2>>()>* = nullptr>
+template <class DTo, class DFrom>
 HWY_API Mask<DTo> OrderedDemote2MasksTo(DTo d_to, DFrom d_from, Mask<DFrom> a,
                                         Mask<DFrom> b) {
+  static_assert(
+      sizeof(TFromD<DTo>) == sizeof(TFromD<DFrom>) / 2,
+      "sizeof(TFromD<DTo>) must be equal to sizeof(TFromD<DFrom>) / 2");
+  static_assert(IsSame<Mask<DTo>, Mask<Repartition<TFromD<DTo>, DFrom>>>(),
+                "Mask<DTo> must be the same type as "
+                "Mask<Repartition<TFromD<DTo>, DFrom>>>()");
+
   const RebindToSigned<decltype(d_from)> di_from;
   const RebindToSigned<decltype(d_to)> di_to;
 

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -4152,6 +4152,15 @@ struct CompressIsPartition {
   enum { value = (sizeof(T) != 1) };
 };
 
+// ------------------------------ Dup128MaskFromMaskBits
+
+template <class D>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  constexpr size_t kN = MaxLanes(d);
+  if (kN < 8) mask_bits &= (1u << kN) - 1;
+  return detail::LoadMaskBits128(d, mask_bits);
+}
+
 // ------------------------------ StoreMaskBits
 
 namespace detail {

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -407,6 +407,19 @@ HWY_API Mask1<T> SetAtOrBeforeFirst(Mask1<T> /*mask*/) {
   return Mask1<T>::FromBool(true);
 }
 
+// ------------------------------ LowerHalfOfMask
+
+#ifdef HWY_NATIVE_LOWER_HALF_OF_MASK
+#undef HWY_NATIVE_LOWER_HALF_OF_MASK
+#else
+#define HWY_NATIVE_LOWER_HALF_OF_MASK
+#endif
+
+template <class D>
+HWY_API MFromD<D> LowerHalfOfMask(D /*d*/, MFromD<D> m) {
+  return m;
+}
+
 // ================================================== SHIFTS
 
 // ------------------------------ ShiftLeft/ShiftRight (BroadcastSignBit)
@@ -1816,6 +1829,11 @@ HWY_API bool AllTrue(D /* tag */, const Mask1<T> mask) {
 template <class D, HWY_IF_LANES_D(D, 1), typename T = TFromD<D>>
 HWY_API Mask1<T> LoadMaskBits(D /* tag */, const uint8_t* HWY_RESTRICT bits) {
   return Mask1<T>::FromBool((bits[0] & 1) != 0);
+}
+
+template <class D, HWY_IF_LANES_D(D, 1)>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D /*d*/, unsigned mask_bits) {
+  return MFromD<D>::FromBool((mask_bits & 1) != 0);
 }
 
 // `p` points to at least 8 writable bytes.

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -480,6 +480,8 @@ using BlockDFromD =
 #define HWY_IF_NOT_T_SIZE_D(D, bytes) HWY_IF_NOT_T_SIZE(TFromD<D>, bytes)
 #define HWY_IF_T_SIZE_ONE_OF_D(D, bit_array) \
   HWY_IF_T_SIZE_ONE_OF(TFromD<D>, bit_array)
+#define HWY_IF_T_SIZE_LE_D(D, bytes) HWY_IF_T_SIZE_LE(TFromD<D>, bytes)
+#define HWY_IF_T_SIZE_GT_D(D, bytes) HWY_IF_T_SIZE_GT(TFromD<D>, bytes)
 
 #define HWY_IF_LANES_D(D, lanes) HWY_IF_LANES(HWY_MAX_LANES_D(D), lanes)
 #define HWY_IF_LANES_LE_D(D, lanes) HWY_IF_LANES_LE(HWY_MAX_LANES_D(D), lanes)

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -4756,6 +4756,15 @@ HWY_API MFromD<D> LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
   return detail::LoadMaskBits(d, mask_bits);
 }
 
+// ------------------------------ Dup128MaskFromMaskBits
+
+template <class D, HWY_IF_V_SIZE_LE_D(D, 16)>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  constexpr size_t kN = MaxLanes(d);
+  if (kN < 8) mask_bits &= (1u << kN) - 1;
+  return detail::LoadMaskBits(d, mask_bits);
+}
+
 // ------------------------------ Mask
 
 namespace detail {

--- a/hwy/ops/wasm_256-inl.h
+++ b/hwy/ops/wasm_256-inl.h
@@ -1954,6 +1954,14 @@ HWY_API MFromD<D> LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
   return ret;
 }
 
+template <class D, HWY_IF_V_SIZE_D(D, 32)>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  const Half<decltype(d)> dh;
+  MFromD<D> ret;
+  ret.m0 = ret.m1 = Dup128MaskFromMaskBits(dh, mask_bits);
+  return ret;
+}
+
 // ------------------------------ Mask
 
 // `p` points to at least 8 writable bytes.

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -1919,6 +1919,208 @@ HWY_API Mask128<double, N> MaskFromVec(const Vec128<double, N> v) {
 template <class D>
 using MFromD = decltype(MaskFromVec(VFromD<D>()));
 
+// ------------------------------ PromoteMaskTo (MFromD)
+
+#ifdef HWY_NATIVE_PROMOTE_MASK_TO
+#undef HWY_NATIVE_PROMOTE_MASK_TO
+#else
+#define HWY_NATIVE_PROMOTE_MASK_TO
+#endif
+
+// AVX3 PromoteMaskTo is generic for all vector lengths
+template <class DTo, class DFrom,
+          HWY_IF_T_SIZE_GT_D(DTo, sizeof(TFromD<DFrom>)),
+          class DFrom_2 = Rebind<TFromD<DFrom>, DTo>,
+          hwy::EnableIf<IsSame<MFromD<DFrom>, MFromD<DFrom_2>>()>* = nullptr>
+HWY_API MFromD<DTo> PromoteMaskTo(DTo /*d_to*/, DFrom /*d_from*/,
+                                  MFromD<DFrom> m) {
+  return MFromD<DTo>{static_cast<decltype(MFromD<DTo>().raw)>(m.raw)};
+}
+
+// ------------------------------ DemoteMaskTo (MFromD)
+
+#ifdef HWY_NATIVE_DEMOTE_MASK_TO
+#undef HWY_NATIVE_DEMOTE_MASK_TO
+#else
+#define HWY_NATIVE_DEMOTE_MASK_TO
+#endif
+
+// AVX3 DemoteMaskTo is generic for all vector lengths
+template <class DTo, class DFrom,
+          HWY_IF_T_SIZE_LE_D(DTo, sizeof(TFromD<DFrom>) - 1),
+          class DFrom_2 = Rebind<TFromD<DFrom>, DTo>,
+          hwy::EnableIf<IsSame<MFromD<DFrom>, MFromD<DFrom_2>>()>* = nullptr>
+HWY_API MFromD<DTo> DemoteMaskTo(DTo /*d_to*/, DFrom /*d_from*/,
+                                 MFromD<DFrom> m) {
+  return MFromD<DTo>{static_cast<decltype(MFromD<DTo>().raw)>(m.raw)};
+}
+
+// ------------------------------ CombineMasks (MFromD)
+
+#ifdef HWY_NATIVE_COMBINE_MASKS
+#undef HWY_NATIVE_COMBINE_MASKS
+#else
+#define HWY_NATIVE_COMBINE_MASKS
+#endif
+
+template <class D, HWY_IF_LANES_D(D, 2)>
+HWY_API MFromD<D> CombineMasks(D /*d*/, MFromD<Half<D>> hi,
+                               MFromD<Half<D>> lo) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const __mmask8 combined_mask = _kor_mask8(
+      _kshiftli_mask8(static_cast<__mmask8>(hi.raw), 1),
+      _kand_mask8(static_cast<__mmask8>(lo.raw), static_cast<__mmask8>(1)));
+#else
+  const auto combined_mask =
+      (static_cast<unsigned>(hi.raw) << 1) | (lo.raw & 1);
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(combined_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 4)>
+HWY_API MFromD<D> CombineMasks(D /*d*/, MFromD<Half<D>> hi,
+                               MFromD<Half<D>> lo) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const __mmask8 combined_mask = _kor_mask8(
+      _kshiftli_mask8(static_cast<__mmask8>(hi.raw), 2),
+      _kand_mask8(static_cast<__mmask8>(lo.raw), static_cast<__mmask8>(3)));
+#else
+  const auto combined_mask =
+      (static_cast<unsigned>(hi.raw) << 2) | (lo.raw & 3);
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(combined_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 8)>
+HWY_API MFromD<D> CombineMasks(D /*d*/, MFromD<Half<D>> hi,
+                               MFromD<Half<D>> lo) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const __mmask8 combined_mask = _kor_mask8(
+      _kshiftli_mask8(static_cast<__mmask8>(hi.raw), 4),
+      _kand_mask8(static_cast<__mmask8>(lo.raw), static_cast<__mmask8>(15)));
+#else
+  const auto combined_mask =
+      (static_cast<unsigned>(hi.raw) << 4) | (lo.raw & 15u);
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(combined_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 16)>
+HWY_API MFromD<D> CombineMasks(D /*d*/, MFromD<Half<D>> hi,
+                               MFromD<Half<D>> lo) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const __mmask16 combined_mask = _mm512_kunpackb(
+      static_cast<__mmask16>(hi.raw), static_cast<__mmask16>(lo.raw));
+#else
+  const auto combined_mask =
+      ((static_cast<unsigned>(hi.raw) << 8) | (lo.raw & 0xFFu));
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(combined_mask)};
+}
+
+// ------------------------------ LowerHalfOfMask (MFromD)
+
+#ifdef HWY_NATIVE_LOWER_HALF_OF_MASK
+#undef HWY_NATIVE_LOWER_HALF_OF_MASK
+#else
+#define HWY_NATIVE_LOWER_HALF_OF_MASK
+#endif
+
+// Generic for all vector lengths
+template <class D>
+HWY_API MFromD<D> LowerHalfOfMask(D d, MFromD<Twice<D>> m) {
+  using RawM = decltype(MFromD<D>().raw);
+  constexpr size_t kN = MaxLanes(d);
+  constexpr size_t kNumOfBitsInRawMask = sizeof(RawM) * 8;
+
+  MFromD<D> result_mask{static_cast<RawM>(m.raw)};
+
+  if (kN < kNumOfBitsInRawMask) {
+    result_mask =
+        And(result_mask, MFromD<D>{static_cast<RawM>((1ULL << kN) - 1)});
+  }
+
+  return result_mask;
+}
+
+// ------------------------------ UpperHalfOfMask (MFromD)
+
+#ifdef HWY_NATIVE_UPPER_HALF_OF_MASK
+#undef HWY_NATIVE_UPPER_HALF_OF_MASK
+#else
+#define HWY_NATIVE_UPPER_HALF_OF_MASK
+#endif
+
+template <class D, HWY_IF_LANES_D(D, 1)>
+HWY_API MFromD<D> UpperHalfOfMask(D /*d*/, MFromD<Twice<D>> m) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const auto shifted_mask = _kshiftri_mask8(static_cast<__mmask8>(m.raw), 1);
+#else
+  const auto shifted_mask = static_cast<unsigned>(m.raw) >> 1;
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(shifted_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 2)>
+HWY_API MFromD<D> UpperHalfOfMask(D /*d*/, MFromD<Twice<D>> m) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const auto shifted_mask = _kshiftri_mask8(static_cast<__mmask8>(m.raw), 2);
+#else
+  const auto shifted_mask = static_cast<unsigned>(m.raw) >> 2;
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(shifted_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 4)>
+HWY_API MFromD<D> UpperHalfOfMask(D /*d*/, MFromD<Twice<D>> m) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const auto shifted_mask = _kshiftri_mask8(static_cast<__mmask8>(m.raw), 4);
+#else
+  const auto shifted_mask = static_cast<unsigned>(m.raw) >> 4;
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(shifted_mask)};
+}
+
+template <class D, HWY_IF_LANES_D(D, 8)>
+HWY_API MFromD<D> UpperHalfOfMask(D /*d*/, MFromD<Twice<D>> m) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const auto shifted_mask = _kshiftri_mask16(static_cast<__mmask16>(m.raw), 8);
+#else
+  const auto shifted_mask = static_cast<unsigned>(m.raw) >> 8;
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(shifted_mask)};
+}
+
+// ------------------------------ OrderedDemote2MasksTo (MFromD, CombineMasks)
+
+#ifdef HWY_NATIVE_ORDERED_DEMOTE_2_MASKS_TO
+#undef HWY_NATIVE_ORDERED_DEMOTE_2_MASKS_TO
+#else
+#define HWY_NATIVE_ORDERED_DEMOTE_2_MASKS_TO
+#endif
+
+// Generic for all vector lengths
+template <class DTo, class DFrom,
+          HWY_IF_T_SIZE_D(DTo, sizeof(TFromD<DFrom>) / 2),
+          class DTo_2 = Repartition<TFromD<DTo>, DFrom>,
+          hwy::EnableIf<IsSame<MFromD<DTo>, MFromD<DTo_2>>()>* = nullptr>
+HWY_API MFromD<DTo> OrderedDemote2MasksTo(DTo d_to, DFrom /*d_from*/,
+                                          MFromD<DFrom> a, MFromD<DFrom> b) {
+  using MH = MFromD<Half<DTo>>;
+  using RawMH = decltype(MH().raw);
+
+  return CombineMasks(d_to, MH{static_cast<RawMH>(b.raw)},
+                      MH{static_cast<RawMH>(a.raw)});
+}
+
 // ------------------------------ VecFromMask
 
 template <typename T, size_t N, HWY_IF_T_SIZE(T, 1)>
@@ -10085,6 +10287,20 @@ HWY_API MFromD<D> LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
     mask_bits &= (1ull << kN) - 1;
   }
 
+  return detail::LoadMaskBits128(d, mask_bits);
+#endif
+}
+
+// ------------------------------ Dup128MaskFromMaskBits
+
+template <class D, HWY_IF_V_SIZE_LE_D(D, 16)>
+HWY_API MFromD<D> Dup128MaskFromMaskBits(D d, unsigned mask_bits) {
+  constexpr size_t kN = MaxLanes(d);
+  if (kN < 8) mask_bits &= (1u << kN) - 1;
+
+#if HWY_TARGET <= HWY_AVX3
+  return MFromD<D>::FromBits(mask_bits);
+#else
   return detail::LoadMaskBits128(d, mask_bits);
 #endif
 }

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -2565,6 +2565,31 @@ HWY_API Mask512<T> ExclusiveNeither(Mask512<T> a, Mask512<T> b) {
   return detail::ExclusiveNeither(hwy::SizeTag<sizeof(T)>(), a, b);
 }
 
+template <class D, HWY_IF_LANES_D(D, 64)>
+HWY_API MFromD<D> CombineMasks(D /*d*/, MFromD<Half<D>> hi,
+                               MFromD<Half<D>> lo) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const __mmask64 combined_mask = _mm512_kunpackd(
+      static_cast<__mmask64>(hi.raw), static_cast<__mmask64>(lo.raw));
+#else
+  const __mmask64 combined_mask = static_cast<__mmask64>(
+      ((static_cast<uint64_t>(hi.raw) << 32) | (lo.raw & 0xFFFFFFFFULL)));
+#endif
+
+  return MFromD<D>{combined_mask};
+}
+
+template <class D, HWY_IF_LANES_D(D, 32)>
+HWY_API MFromD<D> UpperHalfOfMask(D /*d*/, MFromD<Twice<D>> m) {
+#if HWY_COMPILER_HAS_MASK_INTRINSICS
+  const auto shifted_mask = _kshiftri_mask64(static_cast<__mmask64>(m.raw), 32);
+#else
+  const auto shifted_mask = static_cast<uint64_t>(m.raw) >> 32;
+#endif
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(shifted_mask)};
+}
+
 // ------------------------------ BroadcastSignBit (ShiftRight, compare, mask)
 
 HWY_API Vec512<int8_t> BroadcastSignBit(Vec512<int8_t> v) {

--- a/hwy/tests/mask_combine_test.cc
+++ b/hwy/tests/mask_combine_test.cc
@@ -1,0 +1,187 @@
+// Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/mask_combine_test.cc"
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/tests/test_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+
+struct TestLowerAndUpperHalvesOfMask {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    using TI = MakeSigned<T>;
+
+    const Half<decltype(d)> dh;
+    const RebindToSigned<decltype(d)> di;
+    const RebindToSigned<decltype(dh)> dh_i;
+
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected = AllocateAligned<TI>(N);
+    HWY_ASSERT(bool_lanes && expected);
+
+    ZeroBytes(bool_lanes.get(), N * sizeof(TI));
+
+    // For all combinations of zero/nonzero state of subset of lanes:
+    const size_t max_lanes = AdjustedLog2Reps(HWY_MIN(N, size_t(6)));
+    for (size_t code = 0; code < (1ull << max_lanes); ++code) {
+      for (size_t i = 0; i < max_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      for (size_t i = 0; i < N; ++i) {
+        expected[i] = static_cast<TI>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto in_mask =
+          RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+
+      const auto expected_vec = Load(di, expected.get());
+      const auto expected_lo_mask =
+          RebindMask(dh, MaskFromVec(LowerHalf(dh_i, expected_vec)));
+      const auto expected_hi_mask =
+          RebindMask(dh, MaskFromVec(UpperHalf(dh_i, expected_vec)));
+
+      HWY_ASSERT_MASK_EQ(dh, expected_lo_mask, LowerHalfOfMask(dh, in_mask));
+      HWY_ASSERT_MASK_EQ(dh, expected_hi_mask, UpperHalfOfMask(dh, in_mask));
+    }
+
+    HWY_ASSERT_MASK_EQ(dh, FirstN(dh, 1), LowerHalfOfMask(dh, FirstN(d, 1)));
+    HWY_ASSERT_MASK_EQ(dh, FirstN(dh, (N / 2) - 1),
+                       LowerHalfOfMask(dh, FirstN(d, (N / 2) - 1)));
+
+    const size_t hi_N = HWY_MAX(HWY_MIN((N / 2) - 1, 5), 1);
+    HWY_ASSERT_MASK_EQ(dh, Not(FirstN(dh, (N / 2) - hi_N)),
+                       UpperHalfOfMask(dh, Not(FirstN(d, N - hi_N))));
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllLowerAndUpperHalvesOfMask() {
+  ForAllTypes(ForShrinkableVectors<TestLowerAndUpperHalvesOfMask>());
+}
+
+struct TestCombineMasks {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    using TI = MakeSigned<T>;
+
+    const Twice<decltype(d)> dt;
+    const RebindToSigned<decltype(d)> di;
+    const RebindToSigned<decltype(dt)> dt_i;
+
+    const size_t N = Lanes(di);
+    auto bool_lanes = AllocateAligned<TI>(N * 2);
+    auto expected = AllocateAligned<TI>(N * 2);
+    HWY_ASSERT(bool_lanes && expected);
+
+    ZeroBytes(bool_lanes.get(), N * 2 * sizeof(TI));
+
+    // For all combinations of zero/nonzero state of subset of lanes:
+    const size_t max_lanes = AdjustedLog2Reps(HWY_MIN(N * 2, size_t(6)));
+    for (size_t code = 0; code < (1ull << max_lanes); ++code) {
+      for (size_t i = 0; i < max_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      for (size_t i = 0; i < N * 2; ++i) {
+        expected[i] = static_cast<TI>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto m0 = RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+      const auto m1 =
+          RebindMask(d, Gt(Load(di, bool_lanes.get() + N), Zero(di)));
+
+      const auto combined_mask = CombineMasks(dt, m1, m0);
+      const auto expected_mask =
+          RebindMask(dt, MaskFromVec(Load(dt_i, expected.get())));
+
+      HWY_ASSERT_VEC_EQ(dt_i, expected.get(),
+                        BitCast(dt_i, VecFromMask(dt, combined_mask)));
+      HWY_ASSERT_VEC_EQ(dt_i, expected.get(),
+                        Combine(dt_i, BitCast(di, VecFromMask(d, m1)),
+                                BitCast(di, VecFromMask(d, m0))));
+      HWY_ASSERT_MASK_EQ(dt, expected_mask, combined_mask);
+    }
+
+    const size_t max_hi_lanes = HWY_MIN(max_lanes, N);
+    for (size_t code = 0; code < (1ull << max_hi_lanes); ++code) {
+      for (size_t i = 0; i < max_hi_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      const size_t lo_lane_count = (code + 1) & (N - 1);
+
+      for (size_t i = 0; i < N; ++i) {
+        expected[i] = static_cast<TI>((i < lo_lane_count) ? TI(-1) : TI(0));
+        expected[N + i] = static_cast<TI>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto m0 = FirstN(d, lo_lane_count);
+      const auto m1 = RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+
+      const auto combined_mask = CombineMasks(dt, m1, m0);
+      const auto expected_mask =
+          RebindMask(dt, MaskFromVec(Load(dt_i, expected.get())));
+
+      HWY_ASSERT_VEC_EQ(dt_i, expected.get(),
+                        BitCast(dt_i, VecFromMask(dt, combined_mask)));
+      HWY_ASSERT_VEC_EQ(dt_i, expected.get(),
+                        Combine(dt_i, BitCast(di, VecFromMask(d, m1)),
+                                BitCast(di, VecFromMask(d, m0))));
+      HWY_ASSERT_MASK_EQ(dt, expected_mask, combined_mask);
+    }
+
+    HWY_ASSERT_MASK_EQ(dt, FirstN(dt, N - 1),
+                       CombineMasks(dt, FirstN(d, 0), FirstN(d, N - 1)));
+    HWY_ASSERT_MASK_EQ(dt, FirstN(dt, N),
+                       CombineMasks(dt, FirstN(d, 0), FirstN(d, N)));
+    HWY_ASSERT_MASK_EQ(dt, FirstN(dt, 2 * N - 1),
+                       CombineMasks(dt, FirstN(d, N - 1), FirstN(d, N)));
+    HWY_ASSERT_MASK_EQ(dt, FirstN(dt, 2 * N),
+                       CombineMasks(dt, FirstN(d, N), FirstN(d, N)));
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllCombineMasks() {
+  ForAllTypes(ForExtendableVectors<TestCombineMasks>());
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace hwy {
+HWY_BEFORE_TEST(HwyMaskCombineTest);
+HWY_EXPORT_AND_TEST_P(HwyMaskCombineTest, TestAllLowerAndUpperHalvesOfMask);
+HWY_EXPORT_AND_TEST_P(HwyMaskCombineTest, TestAllCombineMasks);
+}  // namespace hwy
+
+#endif

--- a/hwy/tests/mask_convert_test.cc
+++ b/hwy/tests/mask_convert_test.cc
@@ -1,0 +1,347 @@
+// Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/mask_convert_test.cc"
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/tests/test_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+
+template <class TTo>
+struct TestPromoteMaskTo {
+  using TTo_I = MakeSigned<TTo>;
+
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    using TI = MakeSigned<T>;
+
+    const Rebind<TTo, decltype(d)> d_to;
+    const RebindToSigned<decltype(d)> di;
+    const RebindToSigned<decltype(d_to)> di_to;
+
+    const size_t N = Lanes(di);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected = AllocateAligned<TTo_I>(N);
+    HWY_ASSERT(bool_lanes && expected);
+
+    ZeroBytes(bool_lanes.get(), N * sizeof(TI));
+
+    // For all combinations of zero/nonzero state of subset of lanes:
+    const size_t max_lanes = AdjustedLog2Reps(HWY_MIN(N, size_t(6)));
+    for (size_t code = 0; code < (1ull << max_lanes); ++code) {
+      for (size_t i = 0; i < max_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      for (size_t i = 0; i < N; ++i) {
+        expected[i] = static_cast<TTo_I>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto m = RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+      const auto promoted_mask = PromoteMaskTo(d_to, d, m);
+
+      const auto expected_mask =
+          RebindMask(d_to, MaskFromVec(Load(di_to, expected.get())));
+
+      HWY_ASSERT_VEC_EQ(di_to, expected.get(),
+                        BitCast(di_to, VecFromMask(d_to, promoted_mask)));
+      HWY_ASSERT_MASK_EQ(d_to, expected_mask, promoted_mask);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllPromoteMaskTo() {
+  const ForPromoteVectors<TestPromoteMaskTo<int16_t>, 1> to_i16div2;
+  to_i16div2(int8_t());
+  to_i16div2(uint8_t());
+
+  const ForPromoteVectors<TestPromoteMaskTo<uint16_t>, 1> to_u16div2;
+  to_u16div2(int8_t());
+  to_u16div2(uint8_t());
+
+  const ForPromoteVectors<TestPromoteMaskTo<int32_t>, 1> to_i32div2;
+  to_i32div2(int16_t());
+  to_i32div2(uint16_t());
+#if HWY_HAVE_FLOAT16
+  to_i32div2(float16_t());
+#endif
+
+  const ForPromoteVectors<TestPromoteMaskTo<int32_t>, 1> to_u32div2;
+  to_u32div2(int16_t());
+  to_u32div2(uint16_t());
+#if HWY_HAVE_FLOAT16
+  to_u32div2(float16_t());
+#endif
+
+  const ForPromoteVectors<TestPromoteMaskTo<int32_t>, 2> to_i32div4;
+  to_i32div4(int8_t());
+
+#if HWY_HAVE_INTEGER64
+  const ForPromoteVectors<TestPromoteMaskTo<int64_t>, 1> to_i64div2;
+  to_i64div2(int32_t());
+  to_i64div2(uint32_t());
+  to_i64div2(float());
+
+  const ForPromoteVectors<TestPromoteMaskTo<uint64_t>, 1> to_u64div2;
+  to_u64div2(int32_t());
+  to_u64div2(uint32_t());
+  to_u64div2(float());
+
+  const ForPromoteVectors<TestPromoteMaskTo<int64_t>, 2> to_i64div4;
+  to_i64div4(int16_t());
+
+  const ForPromoteVectors<TestPromoteMaskTo<int64_t>, 3> to_i64div8;
+  to_i64div8(int8_t());
+#endif
+
+#if HWY_HAVE_FLOAT64
+  const ForPromoteVectors<TestPromoteMaskTo<double>, 1> to_f64div2;
+  to_f64div2(int32_t());
+  to_f64div2(uint32_t());
+  to_f64div2(float());
+
+#if HWY_HAVE_FLOAT16
+  const ForPromoteVectors<TestPromoteMaskTo<double>, 2> to_f64div4;
+  to_f64div4(float16_t());
+#endif  // HWY_HAVE_FLOAT16
+#endif  // HWY_HAVE_FLOAT64
+}
+
+template <class TTo>
+struct TestDemoteMaskTo {
+  using TTo_I = MakeSigned<TTo>;
+
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    using TI = MakeSigned<T>;
+
+    const Rebind<TTo, decltype(d)> d_to;
+    const RebindToSigned<decltype(d)> di;
+    const RebindToSigned<decltype(d_to)> di_to;
+
+    const size_t N = Lanes(di);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected = AllocateAligned<TTo_I>(N);
+    HWY_ASSERT(bool_lanes && expected);
+
+    ZeroBytes(bool_lanes.get(), N * sizeof(TI));
+
+    // For all combinations of zero/nonzero state of subset of lanes:
+    const size_t max_lanes = AdjustedLog2Reps(HWY_MIN(N, size_t(6)));
+    for (size_t code = 0; code < (1ull << max_lanes); ++code) {
+      for (size_t i = 0; i < max_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      for (size_t i = 0; i < N; ++i) {
+        expected[i] = static_cast<TTo_I>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto m = RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+      const auto demoted_mask = DemoteMaskTo(d_to, d, m);
+
+      const auto expected_mask =
+          RebindMask(d_to, MaskFromVec(Load(di_to, expected.get())));
+
+      HWY_ASSERT_VEC_EQ(di_to, expected.get(),
+                        BitCast(di_to, VecFromMask(d_to, demoted_mask)));
+      HWY_ASSERT_MASK_EQ(d_to, expected_mask, demoted_mask);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllDemoteMaskTo() {
+  const ForDemoteVectors<TestDemoteMaskTo<int8_t>> from_uif16_to_i8;
+  from_uif16_to_i8(int16_t());
+  from_uif16_to_i8(uint16_t());
+#if HWY_HAVE_FLOAT16
+  from_uif16_to_i8(float16_t());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<uint8_t>> from_uif16_to_u8;
+  from_uif16_to_u8(int16_t());
+  from_uif16_to_u8(uint16_t());
+#if HWY_HAVE_FLOAT16
+  from_uif16_to_u8(float16_t());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<int16_t>> from_uif32_to_i16;
+  from_uif32_to_i16(int32_t());
+  from_uif32_to_i16(uint32_t());
+#if HWY_HAVE_FLOAT16
+  from_uif32_to_i16(float());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<uint16_t>> from_uif32_to_u16;
+  from_uif32_to_u16(int32_t());
+  from_uif32_to_u16(uint32_t());
+  from_uif32_to_u16(float());
+
+#if HWY_HAVE_FLOAT16
+  const ForDemoteVectors<TestDemoteMaskTo<float16_t>> from_uif32_to_f16;
+  from_uif32_to_f16(int32_t());
+  from_uif32_to_f16(uint32_t());
+  from_uif32_to_f16(float());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<int8_t>, 2> from_i32_to_i8;
+  from_i32_to_i8(int32_t());
+
+#if HWY_HAVE_INTEGER64
+  const ForDemoteVectors<TestDemoteMaskTo<int32_t>> from_uif64_to_i32;
+  from_uif64_to_i32(int64_t());
+  from_uif64_to_i32(uint64_t());
+#if HWY_HAVE_FLOAT64
+  from_uif64_to_i32(double());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<uint32_t>> from_uif64_to_u32;
+  from_uif64_to_u32(int64_t());
+  from_uif64_to_u32(uint64_t());
+#if HWY_HAVE_FLOAT64
+  from_uif64_to_u32(double());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<float>> from_uif64_to_f32;
+  from_uif64_to_f32(int64_t());
+  from_uif64_to_f32(uint64_t());
+#if HWY_HAVE_FLOAT64
+  from_uif64_to_f32(double());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<int16_t>, 2> from_i64_to_i16;
+  from_i64_to_i16(int64_t());
+
+#if HWY_HAVE_FLOAT64 && HWY_HAVE_FLOAT16
+  const ForDemoteVectors<TestDemoteMaskTo<float16_t>, 2> from_f64_to_f16;
+  from_f64_to_f16(double());
+#endif
+
+  const ForDemoteVectors<TestDemoteMaskTo<int8_t>, 3> from_i64_to_i8;
+  from_i64_to_i8(int64_t());
+#endif
+}
+
+struct TestOrderedDemote2MasksTo {
+#if HWY_TARGET != HWY_SCALAR
+  template <class DTo, class D>
+  static HWY_NOINLINE void DoTestOrderedDemote2Masks(DTo d_to, D d) {
+    using T = TFromD<D>;
+    using TTo = TFromD<DTo>;
+    using TI = MakeSigned<T>;
+    using TTo_I = MakeSigned<TTo>;
+
+    const RebindToSigned<decltype(d)> di;
+    const RebindToSigned<decltype(d_to)> di_to;
+
+    const size_t N = Lanes(di);
+    auto bool_lanes = AllocateAligned<TI>(N * 2);
+    auto expected = AllocateAligned<TTo_I>(N * 2);
+    HWY_ASSERT(bool_lanes && expected);
+
+    ZeroBytes(bool_lanes.get(), N * 2 * sizeof(TI));
+    ZeroBytes(expected.get(), N * 2 * sizeof(TTo_I));
+
+    // For all combinations of zero/nonzero state of subset of lanes:
+    const size_t max_lanes = AdjustedLog2Reps(HWY_MIN(N * 2, size_t(6)));
+    for (size_t code = 0; code < (1ull << max_lanes); ++code) {
+      for (size_t i = 0; i < max_lanes; ++i) {
+        bool_lanes[i] = (code & (1ull << i)) ? TI(1) : TI(0);
+      }
+
+      const size_t idx2 = N + (code & (N - 1));
+      bool_lanes[idx2] = TI(1);
+
+      for (size_t i = 0; i < N * 2; ++i) {
+        expected[i] = static_cast<TTo_I>(-static_cast<TI>(bool_lanes[i]));
+      }
+
+      const auto m0 = RebindMask(d, Gt(Load(di, bool_lanes.get()), Zero(di)));
+      const auto m1 =
+          RebindMask(d, Gt(Load(di, bool_lanes.get() + N), Zero(di)));
+      const auto expected_mask =
+          RebindMask(d_to, MaskFromVec(Load(di_to, expected.get())));
+
+      HWY_ASSERT_MASK_EQ(d_to, expected_mask,
+                         OrderedDemote2MasksTo(d_to, d, m0, m1));
+
+      bool_lanes[idx2] = TI(0);
+    }
+
+    HWY_ASSERT_MASK_EQ(
+        d_to, FirstN(d_to, N - 1),
+        OrderedDemote2MasksTo(d_to, d, FirstN(d, N - 1), FirstN(d, 0)));
+    HWY_ASSERT_MASK_EQ(
+        d_to, FirstN(d_to, N),
+        OrderedDemote2MasksTo(d_to, d, FirstN(d, N), FirstN(d, 0)));
+    HWY_ASSERT_MASK_EQ(
+        d_to, FirstN(d_to, 2 * N - 1),
+        OrderedDemote2MasksTo(d_to, d, FirstN(d, N), FirstN(d, N - 1)));
+    HWY_ASSERT_MASK_EQ(
+        d_to, FirstN(d_to, 2 * N),
+        OrderedDemote2MasksTo(d_to, d, FirstN(d, N), FirstN(d, N)));
+  }
+
+  template <class D, HWY_IF_T_SIZE_ONE_OF_D(
+                         D, (HWY_HAVE_FLOAT16 ? (1 << 4) : 0) | (1 << 8))>
+  static HWY_INLINE void DoTestOrderedDemote2MasksToFloat(D d) {
+    using TF = MakeFloat<MakeNarrow<MakeUnsigned<TFromD<D>>>>;
+    DoTestOrderedDemote2Masks(Repartition<TF, decltype(d)>(), d);
+  }
+
+  template <class D,
+            HWY_IF_T_SIZE_ONE_OF_D(D, (1 << 1) | (1 << 2) |
+                                          (HWY_HAVE_FLOAT16 ? 0 : (1 << 4)))>
+  static HWY_INLINE void DoTestOrderedDemote2MasksToFloat(D /*d*/) {}
+#endif  // HWY_TARGET != HWY_SCALAR
+
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const RebindToSigned<decltype(d)> di;
+    const RebindToUnsigned<decltype(d)> du;
+
+    DoTestOrderedDemote2Masks(RepartitionToNarrow<decltype(di)>(), d);
+    DoTestOrderedDemote2Masks(RepartitionToNarrow<decltype(du)>(), d);
+    DoTestOrderedDemote2MasksToFloat(d);
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllOrderedDemote2MasksTo() {
+  ForUIF163264(ForShrinkableVectors<TestOrderedDemote2MasksTo>());
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace hwy {
+HWY_BEFORE_TEST(HwyMaskConvertTest);
+HWY_EXPORT_AND_TEST_P(HwyMaskConvertTest, TestAllPromoteMaskTo);
+HWY_EXPORT_AND_TEST_P(HwyMaskConvertTest, TestAllDemoteMaskTo);
+HWY_EXPORT_AND_TEST_P(HwyMaskConvertTest, TestAllOrderedDemote2MasksTo);
+}  // namespace hwy
+
+#endif


### PR DESCRIPTION
Added the following mask operations:
- Dup128MaskFromMaskBits - creates a mask from mask bits, broadcasted to each 16-byte block if `d.MaxBytes() > 16` is true
- PromoteMaskTo - promotes a mask to a mask with a larger lane type
- DemoteMaskTo - demotes a mask to a mask with a smaller lane type
- OrderedDemote2MasksTo - demotes two masks to a single mask with a smaller lane type
- CombineMask - combines two masks
- LowerHalfOfMask - returns lower half of a mask
- UpperHalfOfMask - returns upper half of a mask