### PR TITLE
Made enhancements to x86 F16/F32/F64/I64 Abs

### DIFF
--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -1128,27 +1128,6 @@ HWY_API Vec512<int64_t> Abs(const Vec512<int64_t> v) {
   return Vec512<int64_t>{_mm512_abs_epi64(v.raw)};
 }
 
-// These aren't native instructions, they also involve AND with constant.
-#if HWY_HAVE_FLOAT16
-HWY_API Vec512<float16_t> Abs(const Vec512<float16_t> v) {
-  return Vec512<float16_t>{_mm512_abs_ph(v.raw)};
-}
-#endif  // HWY_HAVE_FLOAT16
-
-HWY_API Vec512<float> Abs(const Vec512<float> v) {
-  return Vec512<float>{_mm512_abs_ps(v.raw)};
-}
-HWY_API Vec512<double> Abs(const Vec512<double> v) {
-// Workaround: _mm512_abs_pd expects __m512, so implement it ourselves.
-#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 803
-  const DFromV<decltype(v)> d;
-  const RebindToUnsigned<decltype(d)> du;
-  return And(v, BitCast(d, Set(du, 0x7FFFFFFFFFFFFFFFULL)));
-#else
-  return Vec512<double>{_mm512_abs_pd(v.raw)};
-#endif
-}
-
 // ------------------------------ ShiftLeft
 
 #if HWY_TARGET <= HWY_AVX3_DL


### PR DESCRIPTION
Made the following enhancements to x86 Abs:
- Made F16/F32/F64 Abs generic for all vector lengths on SSE2/SSSE3/SSE4/AVX2/AVX3
- Made I64 Abs generic for all vector lengths on SSE2/SSSE3/SSE4/AVX2
- Reimplemented SSE2/SSSE3/SSE4/AVX2 I64 Abs to use IfNegativeThenElse