### PR TITLE
Add Clang 13/14/15 and GCC 11/12 to GitHub workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -94,6 +94,58 @@ jobs:
           cmake --build out
           ctest --test-dir out
 
+  cmake_ubuntu_2204:
+    name: Build and test ${{ matrix.name }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - name: Clang-13
+            extra_deps: clang-13
+            c_compiler: clang-13
+            cxx_compiler: clang++-13
+
+          - name: Clang-14
+            extra_deps: clang-14
+            c_compiler: clang-14
+            cxx_compiler: clang++-14
+
+          - name: Clang-15
+            extra_deps: clang-15
+            c_compiler: clang-15
+            cxx_compiler: clang++-15
+
+          - name: GCC-11
+            extra_deps: g++-11
+            c_compiler: gcc-11
+            cxx_compiler: g++-11
+            cxx_flags: -ftrapv
+
+          - name: GCC-12
+            extra_deps: g++-12
+            c_compiler: gcc-12
+            cxx_compiler: g++-12
+            cxx_flags: -ftrapv
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+        with:
+          egress-policy: audit  # cannot be block - runner does git checkout
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.0.0
+
+      - name: Install deps
+        run: sudo apt-get install ${{ matrix.extra_deps }}
+
+      - name: Build and test
+        run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=2
+          export CTEST_PARALLEL_LEVEL=2
+          CXXFLAGS=${{ matrix.cxx_flags }} CC=${{ matrix.c_compiler }} CXX=${{ matrix.cxx_compiler }} cmake -DHWY_WARNINGS_ARE_ERRORS=ON -B out .
+          cmake --build out
+          ctest --test-dir out
+
   bazel:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Here is an updated version of .github/workflows/build_test.yml that adds Clang 13/14/15 and GCC 11/12 to the Build/Test workflow.

The clang-13, clang-14, clang-15, g++-11, and g++-12 Build/Test steps require Ubuntu 22.04 as the clang-13, clang-14, clang-15, g++-11, and g++-12 packages are not available in the Ubuntu 20.04 repository.

Still need to use Ubuntu 20.04 to compile with Clang 6/7/8/9/10 and GCC 8 as Ubuntu 22.04 has removed the Clang 6/7/8/9/10 and GCC 8 packages.

It is possible to update .github/workflows/build_test.yml to have the Clang 11/12 and GCC 9/10 build/test steps to use Ubuntu 22.04 instead of Ubuntu 20.04.

Is it too much to add the extra Clang/GCC compilers that are available in Ubuntu 22.04 to the GitHub workflow?