### PR TITLE
Fix SVE LoadDup128 compilation error if HWY_SVE_HAVE_BFLOAT16 is 1

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -1519,6 +1519,9 @@ HWY_SVE_FOREACH_BF16(HWY_SVE_BLENDED_STORE, BlendedStore, st1)
 #if HWY_TARGET != HWY_SVE2_128
 namespace detail {
 HWY_SVE_FOREACH(HWY_SVE_LOAD_DUP128, LoadDupFull128, ld1rq)
+#if HWY_SVE_HAVE_BFLOAT16
+HWY_SVE_FOREACH_BF16(HWY_SVE_LOAD_DUP128, LoadDupFull128, ld1rq)
+#endif
 }  // namespace detail
 #endif  // HWY_TARGET != HWY_SVE2_128
 


### PR DESCRIPTION
Added missing detail::LoadDupFull128 for BF16 vectors to hwy/ops/arm_sve-inl.h if HWY_SVE_HAVE_BFLOAT16 is 1.