### PR TITLE
Made fixes to loops in hwy/contrib/algo/copy-inl.h, find-inl.h, and transform-inl.h

### DIFF
--- a/hwy/contrib/algo/copy-inl.h
+++ b/hwy/contrib/algo/copy-inl.h
@@ -40,8 +40,10 @@ void Fill(D d, T value, size_t count, T* HWY_RESTRICT to) {
   const Vec<D> v = Set(d, value);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    StoreU(v, d, to + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      StoreU(v, d, to + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -58,9 +60,11 @@ void Copy(D d, const T* HWY_RESTRICT from, size_t count, T* HWY_RESTRICT to) {
   const size_t N = Lanes(d);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    const Vec<D> v = LoadU(d, from + idx);
-    StoreU(v, d, to + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      const Vec<D> v = LoadU(d, from + idx);
+      StoreU(v, d, to + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -89,9 +93,11 @@ T* CopyIf(D d, const T* HWY_RESTRICT from, size_t count, T* HWY_RESTRICT to,
   const size_t N = Lanes(d);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    const Vec<D> v = LoadU(d, from + idx);
-    to += CompressBlendedStore(v, func(d, v), d, to);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      const Vec<D> v = LoadU(d, from + idx);
+      to += CompressBlendedStore(v, func(d, v), d, to);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.

--- a/hwy/contrib/algo/find-inl.h
+++ b/hwy/contrib/algo/find-inl.h
@@ -35,9 +35,11 @@ size_t Find(D d, T value, const T* HWY_RESTRICT in, size_t count) {
   const Vec<D> broadcasted = Set(d, value);
 
   size_t i = 0;
-  for (; i + N <= count; i += N) {
-    const intptr_t pos = FindFirstTrue(d, Eq(broadcasted, LoadU(d, in + i)));
-    if (pos >= 0) return i + static_cast<size_t>(pos);
+  if (count >= N) {
+    for (; i <= count - N; i += N) {
+      const intptr_t pos = FindFirstTrue(d, Eq(broadcasted, LoadU(d, in + i)));
+      if (pos >= 0) return i + static_cast<size_t>(pos);
+    }
   }
 
   if (i != count) {
@@ -72,9 +74,11 @@ size_t FindIf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
   const size_t N = Lanes(d);
 
   size_t i = 0;
-  for (; i + N <= count; i += N) {
-    const intptr_t pos = FindFirstTrue(d, func(d, LoadU(d, in + i)));
-    if (pos >= 0) return i + static_cast<size_t>(pos);
+  if (count >= N) {
+    for (; i <= count - N; i += N) {
+      const intptr_t pos = FindFirstTrue(d, func(d, LoadU(d, in + i)));
+      if (pos >= 0) return i + static_cast<size_t>(pos);
+    }
   }
 
   if (i != count) {

--- a/hwy/contrib/algo/transform-inl.h
+++ b/hwy/contrib/algo/transform-inl.h
@@ -59,9 +59,11 @@ void Generate(D d, T* HWY_RESTRICT out, size_t count, const Func& func) {
 
   size_t idx = 0;
   Vec<decltype(du)> vidx = Iota(du, 0);
-  for (; idx + N <= count; idx += N) {
-    StoreU(func(d, vidx), d, out + idx);
-    vidx = Add(vidx, Set(du, static_cast<TU>(N)));
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      StoreU(func(d, vidx), d, out + idx);
+      vidx = Add(vidx, Set(du, static_cast<TU>(N)));
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -97,9 +99,11 @@ void Transform(D d, T* HWY_RESTRICT inout, size_t count, const Func& func) {
   const size_t N = Lanes(d);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    const Vec<D> v = LoadU(d, inout + idx);
-    StoreU(func(d, v), d, inout + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      const Vec<D> v = LoadU(d, inout + idx);
+      StoreU(func(d, v), d, inout + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -134,10 +138,12 @@ void Transform1(D d, T* HWY_RESTRICT inout, size_t count,
   const size_t N = Lanes(d);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    const Vec<D> v = LoadU(d, inout + idx);
-    const Vec<D> v1 = LoadU(d, in1 + idx);
-    StoreU(func(d, v, v1), d, inout + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      const Vec<D> v = LoadU(d, inout + idx);
+      const Vec<D> v1 = LoadU(d, in1 + idx);
+      StoreU(func(d, v, v1), d, inout + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -179,11 +185,13 @@ void Transform2(D d, T* HWY_RESTRICT inout, size_t count,
   const size_t N = Lanes(d);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    const Vec<D> v = LoadU(d, inout + idx);
-    const Vec<D> v1 = LoadU(d, in1 + idx);
-    const Vec<D> v2 = LoadU(d, in2 + idx);
-    StoreU(func(d, v, v1, v2), d, inout + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      const Vec<D> v = LoadU(d, inout + idx);
+      const Vec<D> v1 = LoadU(d, in1 + idx);
+      const Vec<D> v2 = LoadU(d, in2 + idx);
+      StoreU(func(d, v, v1, v2), d, inout + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -227,9 +235,11 @@ void Replace(D d, T* HWY_RESTRICT inout, size_t count, T new_t, T old_t) {
   const Vec<D> new_v = Set(d, new_t);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    Vec<D> v = LoadU(d, inout + idx);
-    StoreU(IfThenElse(Eq(v, old_v), new_v, v), d, inout + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      Vec<D> v = LoadU(d, inout + idx);
+      StoreU(IfThenElse(Eq(v, old_v), new_v, v), d, inout + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.
@@ -266,9 +276,11 @@ void ReplaceIf(D d, T* HWY_RESTRICT inout, size_t count, T new_t,
   const Vec<D> new_v = Set(d, new_t);
 
   size_t idx = 0;
-  for (; idx + N <= count; idx += N) {
-    Vec<D> v = LoadU(d, inout + idx);
-    StoreU(IfThenElse(func(d, v), new_v, v), d, inout + idx);
+  if (count >= N) {
+    for (; idx <= count - N; idx += N) {
+      Vec<D> v = LoadU(d, inout + idx);
+      StoreU(IfThenElse(func(d, v), new_v, v), d, inout + idx);
+    }
   }
 
   // `count` was a multiple of the vector length `N`: already done.


### PR DESCRIPTION
Replaced `idx + N <= count` with  `idx <= count - N` in copy-inl.h, find-inl.h, transform-inl.h in hwy/contrib/algo as it is possible for `idx + N` to overflow if `idx > LimitsMax<size_t>() - N` is true, whereas `idx <= count - N` is guaranteed to not overflow if `count >= N` is true.

Also added `if (count >= N)` checks to ensure that the `for (; idx <= count - N; idx += N)` loops in copy-inl.h, find-inl.h, transform-inl.h are only executed if `count >= N` is true.

The changes to the loops in copy-inl.h, find-inl.h, and transform-inl.h also work around `-Waggressive-loop-optimizations` warnings that were encountered when compiling hwy/contrib/matvec/matvec_test.cc on PPC with GCC.