### PR TITLE
Made enhancements to BitCastScalar and fixed F16 compare operators

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -1378,8 +1378,9 @@ HWY_F16_CONSTEXPR inline std::partial_ordering operator<=>(
 
 // x86 compiler supports __bf16, not necessarily with operators.
 #ifndef HWY_SSE2_HAVE_SCALAR_BF16_TYPE
-#if HWY_ARCH_X86 && defined(__SSE2__) && \
-    (HWY_COMPILER_CLANG >= 1700 || HWY_COMPILER_GCC_ACTUAL >= 1300)
+#if HWY_ARCH_X86 && defined(__SSE2__) &&                      \
+    ((HWY_COMPILER_CLANG >= 1700 && !HWY_COMPILER_CLANGCL) || \
+     HWY_COMPILER_GCC_ACTUAL >= 1300)
 #define HWY_SSE2_HAVE_SCALAR_BF16_TYPE 1
 #else
 #define HWY_SSE2_HAVE_SCALAR_BF16_TYPE 0


### PR DESCRIPTION
Updated BitCastScalar to allow constexpr bit casts from hwy::float16_t and hwy::bfloat16_t if the __builtin_bit_cast intrinsic is available and To is either (a) a floating-point type (including hwy::float16_t and hwy::bfloat16_t), (b) an integer type, or (c) a class or struct type that does not contain any union, pointer, reference, or volatile-qualified subobjects.

Also updated BitCastScalar to allow constexpr bit casts to hwy::float16_t or hwy::bfloat16_t from integer types, floating-point types, or class/struct types that do not contain any union, pointer, reference, or volatile-qualified subobjects if the __builtin_bit_cast intrinsic is available.

Also added a hwy::float16_t::FromBits static member function that bit casts a uint16_t to hwy::float16_t, and also added a hwy::bfloat16_t::FromBits static member function that bit casts a uint16_t to hwy::bfloat16_t.

hwy::float16_t::FromBits and hwy::bfloat16_t::FromBits are both guaranteed to be constexpr if the __builtin_bit_cast intrinsic is available.

Also updated F16FromF32 to be constexpr if either (a) HWY_HAVE_SCALAR_F16_OPERATORS is 1 or (b) the __builtin_bit_cast intrinsic is available and C++14/C++17/C++20/C++23 mode is enabled.

Also replaced HWY_DASSERT with HWY_F16_FROM_F32_DASSERT, which only does a HWY_DASSERT if F16FromF32 is known to be called from a non-constant-evaluated context or the __builtin_bit_cast intrinsic is not available to avoid compilation errors if F16FromF32 is called from a constant-evaluated context.

Also updated F16FromF32, BF16FromF32, F16/BF16 LowestValue, F16/BF16 HighestValue, F16/BF16 Epsilon, and F16/BF16 MantissaEnd to use hwy::float16::FromBits or hwy::bfloat16_t::FromBits instead of BitCastScalar.

Also fixed compilation errors with the hwy::float16_t comparison operators.