### PR TITLE
Made fixes to SCALAR, EMU128, NEON, and PPC float to int conversions

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -3873,24 +3873,6 @@ HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<RebindToUnsigned<D>> v) {
   return VFromD<D>(vcvt_f32_u32(v.raw));
 }
 
-// Truncates (rounds toward zero).
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec128<int32_t> ConvertTo(D /* tag */, Vec128<float> v) {
-  return Vec128<int32_t>(vcvtq_s32_f32(v.raw));
-}
-template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I32_D(D)>
-HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<RebindToFloat<D>> v) {
-  return VFromD<D>(vcvt_s32_f32(v.raw));
-}
-template <class D, HWY_IF_U32_D(D)>
-HWY_API Vec128<uint32_t> ConvertTo(D /* tag */, Vec128<float> v) {
-  return Vec128<uint32_t>(vcvtq_u32_f32(ZeroIfNegative(v).raw));
-}
-template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U32_D(D)>
-HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<RebindToFloat<D>> v) {
-  return VFromD<D>(vcvt_u32_f32(ZeroIfNegative(v).raw));
-}
-
 #if HWY_HAVE_FLOAT64
 
 template <class D, HWY_IF_F64_D(D)>
@@ -3922,38 +3904,156 @@ HWY_API Vec64<double> ConvertTo(D /* tag */, Vec64<uint64_t> v) {
 #endif  // HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700
 }
 
+#endif  // HWY_HAVE_FLOAT64
+
+namespace detail {
 // Truncates (rounds toward zero).
-template <class D, HWY_IF_I64_D(D)>
-HWY_API Vec128<int64_t> ConvertTo(D /* tag */, Vec128<double> v) {
-  return Vec128<int64_t>(vcvtq_s64_f64(v.raw));
-}
-template <class D, HWY_IF_I64_D(D)>
-HWY_API Vec64<int64_t> ConvertTo(D di, Vec64<double> v) {
-  // GCC 6.5 and earlier are missing the 64-bit (non-q) intrinsic. Use the
-  // 128-bit version to avoid UB from casting double -> int64_t.
-#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700
-  const Full128<double> ddt;
-  const Twice<decltype(di)> dit;
-  return LowerHalf(di, ConvertTo(dit, Combine(ddt, v, v)));
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_I32_D(D)>
+HWY_INLINE Vec128<int32_t> ConvertFToI(D /* tag */, Vec128<float> v) {
+#if HWY_COMPILER_CLANG && \
+    ((HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200) || HWY_ARCH_ARM_V7)
+  // If compiling for AArch64 NEON with Clang 11 or earlier or if compiling for
+  // Armv7 NEON, use inline assembly to avoid undefined behavior if v[i] is
+  // outside of the range of an int32_t.
+
+  int32x4_t raw_result;
+  __asm__(
+#if HWY_ARCH_ARM_A64
+      "fcvtzs %0.4s, %1.4s"
 #else
-  (void)di;
+      "vcvt.s32.f32 %0, %1"
+#endif
+      : "=w"(raw_result)
+      : "w"(v.raw));
+  return Vec128<int32_t>(raw_result);
+#else
+  return Vec128<int32_t>(vcvtq_s32_f32(v.raw));
+#endif
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I32_D(D)>
+HWY_INLINE VFromD<D> ConvertFToI(D /* tag */, VFromD<RebindToFloat<D>> v) {
+#if HWY_COMPILER_CLANG && \
+    ((HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200) || HWY_ARCH_ARM_V7)
+  // If compiling for AArch64 NEON with Clang 11 or earlier or if compiling for
+  // Armv7 NEON, use inline assembly to avoid undefined behavior if v[i] is
+  // outside of the range of an int32_t.
+
+  int32x2_t raw_result;
+  __asm__(
+#if HWY_ARCH_ARM_A64
+      "fcvtzs %0.2s, %1.2s"
+#else
+      "vcvt.s32.f32 %0, %1"
+#endif
+      : "=w"(raw_result)
+      : "w"(v.raw));
+  return VFromD<D>(raw_result);
+#else
+  return VFromD<D>(vcvt_s32_f32(v.raw));
+#endif
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_U32_D(D)>
+HWY_INLINE Vec128<uint32_t> ConvertFToU(D /* tag */, Vec128<float> v) {
+#if HWY_COMPILER_CLANG && \
+    ((HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200) || HWY_ARCH_ARM_V7)
+  // If compiling for AArch64 NEON with Clang 11 or earlier or if compiling for
+  // Armv7 NEON, use inline assembly to avoid undefined behavior if v[i] is
+  // outside of the range of an uint32_t.
+
+  uint32x4_t raw_result;
+  __asm__(
+#if HWY_ARCH_ARM_A64
+      "fcvtzu %0.4s, %1.4s"
+#else
+      "vcvt.u32.f32 %0, %1"
+#endif
+      : "=w"(raw_result)
+      : "w"(v.raw));
+  return Vec128<uint32_t>(raw_result);
+#else
+  return Vec128<uint32_t>(vcvtq_u32_f32(v.raw));
+#endif
+}
+template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U32_D(D)>
+HWY_INLINE VFromD<D> ConvertFToU(D /* tag */, VFromD<RebindToFloat<D>> v) {
+#if HWY_COMPILER_CLANG && \
+    ((HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200) || HWY_ARCH_ARM_V7)
+  // If compiling for AArch64 NEON with Clang 11 or earlier or if compiling for
+  // Armv7 NEON, use inline assembly to avoid undefined behavior if v[i] is
+  // outside of the range of an uint32_t.
+
+  uint32x2_t raw_result;
+  __asm__(
+#if HWY_ARCH_ARM_A64
+      "fcvtzu %0.2s, %1.2s"
+#else
+      "vcvt.u32.f32 %0, %1"
+#endif
+      : "=w"(raw_result)
+      : "w"(v.raw));
+  return VFromD<D>(raw_result);
+#else
+  return VFromD<D>(vcvt_u32_f32(v.raw));
+#endif
+}
+
+#if HWY_HAVE_FLOAT64
+
+// Truncates (rounds toward zero).
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_I64_D(D)>
+HWY_INLINE Vec128<int64_t> ConvertFToI(D /* tag */, Vec128<double> v) {
+#if HWY_COMPILER_CLANG && HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an int64_t.
+  int64x2_t raw_result;
+  __asm__("fcvtzs %0.2d, %1.2d" : "=w"(raw_result) : "w"(v.raw));
+  return Vec128<int64_t>(raw_result);
+#else
+  return Vec128<int64_t>(vcvtq_s64_f64(v.raw));
+#endif
+}
+template <class D, HWY_IF_V_SIZE_D(D, 8), HWY_IF_I64_D(D)>
+HWY_INLINE Vec64<int64_t> ConvertFToI(D /* tag */, Vec64<double> v) {
+#if HWY_ARCH_ARM_A64 &&                                            \
+    ((HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700) || \
+     (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200))
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an int64_t.
+  // If compiling for AArch64 NEON with GCC 6 or earlier, use inline assembly to
+  // work around the missing vcvt_s64_f64 intrinsic.
+  int64x1_t raw_result;
+  __asm__("fcvtzs %d0, %d1" : "=w"(raw_result) : "w"(v.raw));
+  return Vec64<int64_t>(raw_result);
+#else
   return Vec64<int64_t>(vcvt_s64_f64(v.raw));
 #endif
 }
-template <class D, HWY_IF_U64_D(D)>
-HWY_API Vec128<uint64_t> ConvertTo(D /* tag */, Vec128<double> v) {
-  return Vec128<uint64_t>(vcvtq_u64_f64(v.raw));
-}
-template <class D, HWY_IF_U64_D(D)>
-HWY_API Vec64<uint64_t> ConvertTo(D du, Vec64<double> v) {
-  // GCC 6.5 and earlier are missing the 64-bit (non-q) intrinsic. Use the
-  // 128-bit version to avoid UB from casting double -> uint64_t.
-#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700
-  const Full128<double> ddt;
-  const Twice<decltype(du)> du_t;
-  return LowerHalf(du, ConvertTo(du_t, Combine(ddt, v, v)));
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_U64_D(D)>
+HWY_INLINE Vec128<uint64_t> ConvertFToU(D /* tag */, Vec128<double> v) {
+#if HWY_COMPILER_CLANG && HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an uint64_t.
+  uint64x2_t raw_result;
+  __asm__("fcvtzu %0.2d, %1.2d" : "=w"(raw_result) : "w"(v.raw));
+  return Vec128<uint64_t>(raw_result);
 #else
-  (void)du;
+  return Vec128<uint64_t>(vcvtq_u64_f64(v.raw));
+#endif
+}
+template <class D, HWY_IF_V_SIZE_D(D, 8), HWY_IF_U64_D(D)>
+HWY_INLINE Vec64<uint64_t> ConvertFToU(D /* tag */, Vec64<double> v) {
+#if HWY_ARCH_ARM_A64 &&                                            \
+    ((HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700) || \
+     (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200))
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an uint64_t.
+
+  // Inline assembly is also used if compiling for AArch64 NEON with GCC 6 or
+  // earlier to work around the issue of the missing vcvt_u64_f64 intrinsic.
+  uint64x1_t raw_result;
+  __asm__("fcvtzu %d0, %d1" : "=w"(raw_result) : "w"(v.raw));
+  return Vec64<uint64_t>(raw_result);
+#else
   return Vec64<uint64_t>(vcvt_u64_f64(v.raw));
 #endif
 }
@@ -3963,25 +4063,76 @@ HWY_API Vec64<uint64_t> ConvertTo(D du, Vec64<double> v) {
 #if HWY_ARCH_ARM_A64 && HWY_HAVE_FLOAT16
 
 // Truncates (rounds toward zero).
-template <class D, HWY_IF_I16_D(D)>
-HWY_API Vec128<int16_t> ConvertTo(D /* tag */, Vec128<float16_t> v) {
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_I16_D(D)>
+HWY_INLINE Vec128<int16_t> ConvertFToI(D /* tag */, Vec128<float16_t> v) {
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an int16_t.
+  int16x8_t raw_result;
+  __asm__("fcvtzs %0.8h, %1.8h" : "=w"(raw_result) : "w"(v.raw));
+  return Vec128<int16_t>(raw_result);
+#else
   return Vec128<int16_t>(vcvtq_s16_f16(v.raw));
+#endif
 }
 template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_I16_D(D)>
-HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<Rebind<float16_t, D>> v) {
+HWY_INLINE VFromD<D> ConvertFToI(D /* tag */, VFromD<Rebind<float16_t, D>> v) {
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an int16_t.
+  int16x4_t raw_result;
+  __asm__("fcvtzs %0.4h, %1.4h" : "=w"(raw_result) : "w"(v.raw));
+  return VFromD<D>(raw_result);
+#else
   return VFromD<D>(vcvt_s16_f16(v.raw));
+#endif
 }
 
-template <class D, HWY_IF_U16_D(D)>
-HWY_API Vec128<uint16_t> ConvertTo(D /* tag */, Vec128<float16_t> v) {
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_U16_D(D)>
+HWY_INLINE Vec128<uint16_t> ConvertFToU(D /* tag */, Vec128<float16_t> v) {
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an uint16_t.
+  uint16x8_t raw_result;
+  __asm__("fcvtzu %0.8h, %1.8h" : "=w"(raw_result) : "w"(v.raw));
+  return Vec128<uint16_t>(raw_result);
+#else
   return Vec128<uint16_t>(vcvtq_u16_f16(v.raw));
+#endif
 }
 template <class D, HWY_IF_V_SIZE_LE_D(D, 8), HWY_IF_U16_D(D)>
-HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<Rebind<float16_t, D>> v) {
+HWY_INLINE VFromD<D> ConvertFToU(D /* tag */, VFromD<Rebind<float16_t, D>> v) {
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1200
+  // If compiling for AArch64 NEON with Clang 11 or earlier, use inline assembly
+  // to avoid undefined behavior if v[i] is outside of the range of an uint16_t.
+  uint16x4_t raw_result;
+  __asm__("fcvtzu %0.4h, %1.4h" : "=w"(raw_result) : "w"(v.raw));
+  return VFromD<D>(raw_result);
+#else
   return VFromD<D>(vcvt_u16_f16(v.raw));
+#endif
 }
 
 #endif  // HWY_ARCH_ARM_A64 && HWY_HAVE_FLOAT16
+}  // namespace detail
+
+template <class D, HWY_IF_SIGNED_D(D),
+          HWY_IF_T_SIZE_ONE_OF_D(
+              D, (1 << 4) |
+                     ((HWY_ARCH_ARM_A64 && HWY_HAVE_FLOAT16) ? (1 << 2) : 0) |
+                     (HWY_HAVE_FLOAT64 ? (1 << 8) : 0))>
+HWY_API VFromD<D> ConvertTo(D di, VFromD<RebindToFloat<D>> v) {
+  return detail::ConvertFToI(di, v);
+}
+
+template <class D, HWY_IF_UNSIGNED_D(D),
+          HWY_IF_T_SIZE_ONE_OF_D(
+              D, (1 << 4) |
+                     ((HWY_ARCH_ARM_A64 && HWY_HAVE_FLOAT16) ? (1 << 2) : 0) |
+                     (HWY_HAVE_FLOAT64 ? (1 << 8) : 0))>
+HWY_API VFromD<D> ConvertTo(D du, VFromD<RebindToFloat<D>> v) {
+  return detail::ConvertFToU(du, v);
+}
 
 // ------------------------------ PromoteTo (ConvertTo)
 
@@ -4516,32 +4667,10 @@ HWY_API Vec32<float> DemoteTo(D /* tag */, Vec64<double> v) {
   return Vec32<float>(vcvt_f32_f64(vcombine_f64(v.raw, v.raw)));
 }
 
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec64<int32_t> DemoteTo(D /* tag */, Vec128<double> v) {
-  const int64x2_t i64 = vcvtq_s64_f64(v.raw);
-  return Vec64<int32_t>(vqmovn_s64(i64));
-}
-template <class D, HWY_IF_I32_D(D)>
-HWY_API Vec32<int32_t> DemoteTo(D /* tag */, Vec64<double> v) {
-  // There is no i64x1 -> i32x1 narrow, so Combine to 128-bit. Do so with the
-  // f64 input already to also avoid the missing vcvt_s64_f64 in GCC 6.4.
-  const Full128<double> ddt;
-  const Full128<int64_t> dit;
-  return Vec32<int32_t>(vqmovn_s64(ConvertTo(dit, Combine(ddt, v, v)).raw));
-}
-
-template <class D, HWY_IF_U32_D(D)>
-HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<double> v) {
-  const uint64x2_t u64 = vcvtq_u64_f64(v.raw);
-  return Vec64<uint32_t>(vqmovn_u64(u64));
-}
-template <class D, HWY_IF_U32_D(D)>
-HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<double> v) {
-  // There is no i64x1 -> i32x1 narrow, so Combine to 128-bit. Do so with the
-  // f64 input already to also avoid the missing vcvt_s64_f64 in GCC 6.4.
-  const Full128<double> ddt;
-  const Full128<uint64_t> du_t;
-  return Vec32<uint32_t>(vqmovn_u64(ConvertTo(du_t, Combine(ddt, v, v)).raw));
+template <class D, HWY_IF_UI32_D(D)>
+HWY_API VFromD<D> DemoteTo(D d32, VFromD<Rebind<double, D>> v) {
+  const Rebind<MakeWide<TFromD<D>>, D> d64;
+  return DemoteTo(d32, ConvertTo(d64, v));
 }
 
 #endif  // HWY_HAVE_FLOAT64

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -1562,52 +1562,42 @@ HWY_API void Stream(VFromD<D> v, D d, TFromD<D>* HWY_RESTRICT aligned) {
 namespace detail {
 
 template <class ToT, class FromT>
-HWY_INLINE ToT CastValueForF2IConv(hwy::UnsignedTag /* to_type_tag */,
-                                   FromT val) {
+HWY_INLINE ToT CastValueForF2IConv(FromT val) {
   // Prevent ubsan errors when converting float to narrower integer
 
-  // If LimitsMax<ToT>() can be exactly represented in FromT,
-  // kSmallestOutOfToTRangePosVal is equal to LimitsMax<ToT>().
+  using FromTU = MakeUnsigned<FromT>;
+  using ToTU = MakeUnsigned<ToT>;
 
-  // Otherwise, if LimitsMax<ToT>() cannot be exactly represented in FromT,
-  // kSmallestOutOfToTRangePosVal is equal to LimitsMax<ToT>() + 1, which can
-  // be exactly represented in FromT.
-  constexpr FromT kSmallestOutOfToTRangePosVal =
-      (sizeof(ToT) * 8 <= static_cast<size_t>(MantissaBits<FromT>()) + 1)
-          ? static_cast<FromT>(LimitsMax<ToT>())
-          : static_cast<FromT>(
-                static_cast<FromT>(ToT{1} << (sizeof(ToT) * 8 - 1)) * FromT(2));
+  constexpr unsigned kMaxExpField =
+      static_cast<unsigned>(MaxExponentField<FromT>());
+  constexpr unsigned kExpBias = kMaxExpField >> 1;
+  constexpr unsigned kMinOutOfRangeExpField = static_cast<unsigned>(HWY_MIN(
+      kExpBias + sizeof(ToT) * 8 - static_cast<unsigned>(IsSigned<ToT>()),
+      kMaxExpField));
 
-  if (ScalarSignBit(val)) {
-    return ToT{0};
-  } else if (ScalarIsInf(val) || val >= kSmallestOutOfToTRangePosVal) {
-    return LimitsMax<ToT>();
-  } else {
-    return static_cast<ToT>(val);
-  }
-}
+  // If ToT is signed, compare only the exponent bits of val against
+  // kMinOutOfRangeExpField.
+  //
+  // Otherwise, if ToT is unsigned, compare the sign bit plus exponent bits of
+  // val against kMinOutOfRangeExpField as a negative value is outside of the
+  // range of an unsigned integer type.
+  const FromT val_to_compare =
+      static_cast<FromT>(IsSigned<ToT>() ? ScalarAbs(val) : val);
 
-template <class ToT, class FromT>
-HWY_INLINE ToT CastValueForF2IConv(hwy::SignedTag /* to_type_tag */,
-                                   FromT val) {
-  // Prevent ubsan errors when converting float to narrower integer
+  // val is within the range of ToT if
+  // (BitCastScalar<FromTU>(val_to_compare) >> MantissaBits<FromT>()) is less
+  // than kMinOutOfRangeExpField
+  //
+  // Otherwise, val is either outside of the range of ToT or equal to
+  // LimitsMin<ToT>() if
+  // (BitCastScalar<FromTU>(val_to_compare) >> MantissaBits<FromT>()) is greater
+  // than or equal to kMinOutOfRangeExpField.
 
-  // If LimitsMax<ToT>() can be exactly represented in FromT,
-  // kSmallestOutOfToTRangePosVal is equal to LimitsMax<ToT>().
-
-  // Otherwise, if LimitsMax<ToT>() cannot be exactly represented in FromT,
-  // kSmallestOutOfToTRangePosVal is equal to -LimitsMin<ToT>(), which can
-  // be exactly represented in FromT.
-  constexpr FromT kSmallestOutOfToTRangePosVal =
-      (sizeof(ToT) * 8 <= static_cast<size_t>(MantissaBits<FromT>()) + 2)
-          ? static_cast<FromT>(LimitsMax<ToT>())
-          : static_cast<FromT>(-static_cast<FromT>(LimitsMin<ToT>()));
-
-  if (ScalarIsInf(val) || ScalarAbs(val) >= kSmallestOutOfToTRangePosVal) {
-    return ScalarSignBit(val) ? LimitsMin<ToT>() : LimitsMax<ToT>();
-  } else {
-    return static_cast<ToT>(val);
-  }
+  return (static_cast<unsigned>(BitCastScalar<FromTU>(val_to_compare) >>
+                                MantissaBits<FromT>()) < kMinOutOfRangeExpField)
+             ? static_cast<ToT>(val)
+             : static_cast<ToT>(static_cast<ToTU>(LimitsMax<ToT>()) +
+                                static_cast<ToTU>(ScalarSignBit(val)));
 }
 
 template <class ToT, class ToTypeTag, class FromT>
@@ -1616,13 +1606,15 @@ HWY_INLINE ToT CastValueForPromoteTo(ToTypeTag /* to_type_tag */, FromT val) {
 }
 
 template <class ToT>
-HWY_INLINE ToT CastValueForPromoteTo(hwy::SignedTag to_type_tag, float val) {
-  return CastValueForF2IConv<ToT>(to_type_tag, val);
+HWY_INLINE ToT CastValueForPromoteTo(hwy::SignedTag /*to_type_tag*/,
+                                     float val) {
+  return CastValueForF2IConv<ToT>(val);
 }
 
 template <class ToT>
-HWY_INLINE ToT CastValueForPromoteTo(hwy::UnsignedTag to_type_tag, float val) {
-  return CastValueForF2IConv<ToT>(to_type_tag, val);
+HWY_INLINE ToT CastValueForPromoteTo(hwy::UnsignedTag /*to_type_tag*/,
+                                     float val) {
+  return CastValueForF2IConv<ToT>(val);
 }
 
 }  // namespace detail
@@ -1661,8 +1653,7 @@ HWY_API VFromD<D> DemoteTo(D d, VFromD<Rebind<double, D>> from) {
   VFromD<D> ret;
   for (size_t i = 0; i < MaxLanes(d); ++i) {
     // Prevent ubsan errors when converting double to narrower integer/int32_t
-    ret.raw[i] = detail::CastValueForF2IConv<TFromD<D>>(
-        hwy::TypeTag<TFromD<D>>(), from.raw[i]);
+    ret.raw[i] = detail::CastValueForF2IConv<TFromD<D>>(from.raw[i]);
   }
   return ret;
 }
@@ -1829,7 +1820,7 @@ HWY_API VFromD<DTo> ConvertTo(hwy::FloatTag /*tag*/, DTo /*tag*/,
 
   for (size_t i = 0; i < N; ++i) {
     // float## -> int##: return closest representable value
-    ret.raw[i] = CastValueForF2IConv<ToT>(hwy::TypeTag<ToT>(), from.raw[i]);
+    ret.raw[i] = CastValueForF2IConv<ToT>(from.raw[i]);
   }
   return ret;
 }

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -3163,10 +3163,25 @@ HWY_API VFromD<D> PromoteTo(D /* tag */, VFromD<Rebind<uint32_t, D>> v) {
 #endif
 }
 
+namespace detail {
+
+template <class V>
+static HWY_INLINE V VsxF2INormalizeSrcVals(V v) {
+#if !defined(HWY_DISABLE_PPC_VSX_QEMU_F2I_WORKAROUND)
+  // Workaround for QEMU 7/8 VSX float to int conversion bug
+  return IfThenElseZero(v == v, v);
+#else
+  return v;
+#endif
+}
+
+}  // namespace detail
+
 template <class D, HWY_IF_I64_D(D)>
 HWY_API VFromD<D> PromoteTo(D di64, VFromD<Rebind<float, D>> v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspsxds)
-  const __vector float raw_v = InterleaveLower(v, v).raw;
+  const __vector float raw_v =
+      detail::VsxF2INormalizeSrcVals(InterleaveLower(v, v)).raw;
   return VFromD<decltype(di64)>{__builtin_vsx_xvcvspsxds(raw_v)};
 #else
   const RebindToFloat<decltype(di64)> df64;
@@ -3177,7 +3192,8 @@ HWY_API VFromD<D> PromoteTo(D di64, VFromD<Rebind<float, D>> v) {
 template <class D, HWY_IF_U64_D(D)>
 HWY_API VFromD<D> PromoteTo(D du64, VFromD<Rebind<float, D>> v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspuxds)
-  const __vector float raw_v = InterleaveLower(v, v).raw;
+  const __vector float raw_v =
+      detail::VsxF2INormalizeSrcVals(InterleaveLower(v, v)).raw;
   return VFromD<decltype(du64)>{reinterpret_cast<__vector unsigned long long>(
       __builtin_vsx_xvcvspuxds(raw_v))};
 #else
@@ -3273,7 +3289,9 @@ HWY_API VFromD<D> PromoteUpperTo(D /*tag*/, Vec128<uint32_t> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_I64_D(D)>
 HWY_API VFromD<D> PromoteUpperTo(D di64, Vec128<float> v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspsxds)
-  const __vector float raw_v = InterleaveUpper(Full128<float>(), v, v).raw;
+  const __vector float raw_v =
+      detail::VsxF2INormalizeSrcVals(InterleaveUpper(Full128<float>(), v, v))
+          .raw;
   return VFromD<decltype(di64)>{__builtin_vsx_xvcvspsxds(raw_v)};
 #else
   const RebindToFloat<decltype(di64)> df64;
@@ -3284,7 +3302,9 @@ HWY_API VFromD<D> PromoteUpperTo(D di64, Vec128<float> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_U64_D(D)>
 HWY_API VFromD<D> PromoteUpperTo(D du64, Vec128<float> v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspuxds)
-  const __vector float raw_v = InterleaveUpper(Full128<float>(), v, v).raw;
+  const __vector float raw_v =
+      detail::VsxF2INormalizeSrcVals(InterleaveUpper(Full128<float>(), v, v))
+          .raw;
   return VFromD<decltype(du64)>{reinterpret_cast<__vector unsigned long long>(
       __builtin_vsx_xvcvspuxds(raw_v))};
 #else
@@ -3359,15 +3379,17 @@ HWY_INLINE VFromD<D> PromoteEvenTo(hwy::SignedTag /*to_type_tag*/,
                                    V v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspsxds)
   (void)d_to;
+  const auto normalized_v = detail::VsxF2INormalizeSrcVals(v);
 #if HWY_IS_LITTLE_ENDIAN
   // __builtin_vsx_xvcvspsxds expects the source values to be in the odd lanes
   // on little-endian PPC, and the vec_sld operation below will shift the even
-  // lanes of v into the odd lanes.
-  return VFromD<D>{__builtin_vsx_xvcvspsxds(vec_sld(v.raw, v.raw, 4))};
+  // lanes of normalized_v into the odd lanes.
+  return VFromD<D>{
+      __builtin_vsx_xvcvspsxds(vec_sld(normalized_v.raw, normalized_v.raw, 4))};
 #else
   // __builtin_vsx_xvcvspsxds expects the source values to be in the even lanes
   // on big-endian PPC.
-  return VFromD<D>{__builtin_vsx_xvcvspsxds(v.raw)};
+  return VFromD<D>{__builtin_vsx_xvcvspsxds(normalized_v.raw)};
 #endif
 #else
   const RebindToFloat<decltype(d_to)> df64;
@@ -3384,17 +3406,19 @@ HWY_INLINE VFromD<D> PromoteEvenTo(hwy::UnsignedTag /*to_type_tag*/,
                                    V v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspuxds)
   (void)d_to;
+  const auto normalized_v = detail::VsxF2INormalizeSrcVals(v);
 #if HWY_IS_LITTLE_ENDIAN
   // __builtin_vsx_xvcvspuxds expects the source values to be in the odd lanes
   // on little-endian PPC, and the vec_sld operation below will shift the even
-  // lanes of v into the odd lanes.
-  return VFromD<D>{reinterpret_cast<__vector unsigned long long>(
-      __builtin_vsx_xvcvspuxds(vec_sld(v.raw, v.raw, 4)))};
+  // lanes of normalized_v into the odd lanes.
+  return VFromD<D>{
+      reinterpret_cast<__vector unsigned long long>(__builtin_vsx_xvcvspuxds(
+          vec_sld(normalized_v.raw, normalized_v.raw, 4)))};
 #else
   // __builtin_vsx_xvcvspuxds expects the source values to be in the even lanes
   // on big-endian PPC.
   return VFromD<D>{reinterpret_cast<__vector unsigned long long>(
-      __builtin_vsx_xvcvspuxds(v.raw))};
+      __builtin_vsx_xvcvspuxds(normalized_v.raw))};
 #endif
 #else
   const RebindToFloat<decltype(d_to)> df64;
@@ -3420,15 +3444,17 @@ HWY_INLINE VFromD<D> PromoteOddTo(hwy::SignedTag /*to_type_tag*/,
                                   V v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspsxds)
   (void)d_to;
+  const auto normalized_v = detail::VsxF2INormalizeSrcVals(v);
 #if HWY_IS_LITTLE_ENDIAN
   // __builtin_vsx_xvcvspsxds expects the source values to be in the odd lanes
   // on little-endian PPC
-  return VFromD<D>{__builtin_vsx_xvcvspsxds(v.raw)};
+  return VFromD<D>{__builtin_vsx_xvcvspsxds(normalized_v.raw)};
 #else
   // __builtin_vsx_xvcvspsxds expects the source values to be in the even lanes
   // on big-endian PPC, and the vec_sld operation below will shift the odd lanes
-  // of v into the even lanes.
-  return VFromD<D>{__builtin_vsx_xvcvspsxds(vec_sld(v.raw, v.raw, 4))};
+  // of normalized_v into the even lanes.
+  return VFromD<D>{
+      __builtin_vsx_xvcvspsxds(vec_sld(normalized_v.raw, normalized_v.raw, 4))};
 #endif
 #else
   const RebindToFloat<decltype(d_to)> df64;
@@ -3445,17 +3471,19 @@ HWY_INLINE VFromD<D> PromoteOddTo(hwy::UnsignedTag /*to_type_tag*/,
                                   V v) {
 #if HWY_COMPILER_GCC_ACTUAL || HWY_HAS_BUILTIN(__builtin_vsx_xvcvspuxds)
   (void)d_to;
+  const auto normalized_v = detail::VsxF2INormalizeSrcVals(v);
 #if HWY_IS_LITTLE_ENDIAN
   // __builtin_vsx_xvcvspuxds expects the source values to be in the odd lanes
   // on little-endian PPC
   return VFromD<D>{reinterpret_cast<__vector unsigned long long>(
-      __builtin_vsx_xvcvspuxds(v.raw))};
+      __builtin_vsx_xvcvspuxds(normalized_v.raw))};
 #else
   // __builtin_vsx_xvcvspuxds expects the source values to be in the even lanes
   // on big-endian PPC, and the vec_sld operation below will shift the odd lanes
-  // of v into the even lanes.
-  return VFromD<D>{reinterpret_cast<__vector unsigned long long>(
-      __builtin_vsx_xvcvspuxds(vec_sld(v.raw, v.raw, 4)))};
+  // of normalized_v into the even lanes.
+  return VFromD<D>{
+      reinterpret_cast<__vector unsigned long long>(__builtin_vsx_xvcvspuxds(
+          vec_sld(normalized_v.raw, normalized_v.raw, 4)))};
 #endif
 #else
   const RebindToFloat<decltype(d_to)> df64;
@@ -3699,15 +3727,17 @@ HWY_API Vec64<float> DemoteTo(D d, Vec128<double> v) {
 
 template <class D, HWY_IF_V_SIZE_D(D, 4), HWY_IF_I32_D(D)>
 HWY_API Vec32<int32_t> DemoteTo(D /* tag */, Vec64<double> v) {
-  return Vec32<int32_t>{vec_signede(v.raw)};
+  return Vec32<int32_t>{vec_signede(detail::VsxF2INormalizeSrcVals(v).raw)};
 }
 
 template <class D, HWY_IF_V_SIZE_D(D, 8), HWY_IF_I32_D(D)>
 HWY_API Vec64<int32_t> DemoteTo(D /* tag */, Vec128<double> v) {
 #if HWY_IS_LITTLE_ENDIAN
-  const Vec128<int32_t> f64_to_i32{vec_signede(v.raw)};
+  const Vec128<int32_t> f64_to_i32{
+      vec_signede(detail::VsxF2INormalizeSrcVals(v).raw)};
 #else
-  const Vec128<int32_t> f64_to_i32{vec_signedo(v.raw)};
+  const Vec128<int32_t> f64_to_i32{
+      vec_signedo(detail::VsxF2INormalizeSrcVals(v).raw)};
 #endif
 
   const Rebind<int64_t, D> di64;
@@ -3717,15 +3747,17 @@ HWY_API Vec64<int32_t> DemoteTo(D /* tag */, Vec128<double> v) {
 
 template <class D, HWY_IF_V_SIZE_D(D, 4), HWY_IF_U32_D(D)>
 HWY_API Vec32<uint32_t> DemoteTo(D /* tag */, Vec64<double> v) {
-  return Vec32<uint32_t>{vec_unsignede(v.raw)};
+  return Vec32<uint32_t>{vec_unsignede(detail::VsxF2INormalizeSrcVals(v).raw)};
 }
 
 template <class D, HWY_IF_V_SIZE_D(D, 8), HWY_IF_U32_D(D)>
 HWY_API Vec64<uint32_t> DemoteTo(D /* tag */, Vec128<double> v) {
 #if HWY_IS_LITTLE_ENDIAN
-  const Vec128<uint32_t> f64_to_u32{vec_unsignede(v.raw)};
+  const Vec128<uint32_t> f64_to_u32{
+      vec_unsignede(detail::VsxF2INormalizeSrcVals(v).raw)};
 #else
-  const Vec128<uint32_t> f64_to_u32{vec_unsignedo(v.raw)};
+  const Vec128<uint32_t> f64_to_u32{
+      vec_unsignedo(detail::VsxF2INormalizeSrcVals(v).raw)};
 #endif
 
   const Rebind<uint64_t, D> du64;
@@ -3806,6 +3838,31 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
 template <class D, HWY_IF_I32_D(D)>
 HWY_API VFromD<D> ConvertTo(D /* tag */,
                             Vec128<float, Rebind<float, D>().MaxLanes()> v) {
+#if defined(__OPTIMIZE__)
+  if (detail::IsConstantRawAltivecVect(v.raw)) {
+    constexpr int32_t kMinI32 = LimitsMin<int32_t>();
+    constexpr int32_t kMaxI32 = LimitsMax<int32_t>();
+    return Dup128VecFromValues(
+        D(),
+        (v.raw[0] >= -2147483648.0f)
+            ? ((v.raw[0] < 2147483648.0f) ? static_cast<int32_t>(v.raw[0])
+                                          : kMaxI32)
+            : ((v.raw[0] < 0) ? kMinI32 : 0),
+        (v.raw[1] >= -2147483648.0f)
+            ? ((v.raw[1] < 2147483648.0f) ? static_cast<int32_t>(v.raw[1])
+                                          : kMaxI32)
+            : ((v.raw[1] < 0) ? kMinI32 : 0),
+        (v.raw[2] >= -2147483648.0f)
+            ? ((v.raw[2] < 2147483648.0f) ? static_cast<int32_t>(v.raw[2])
+                                          : kMaxI32)
+            : ((v.raw[2] < 0) ? kMinI32 : 0),
+        (v.raw[3] >= -2147483648.0f)
+            ? ((v.raw[3] < 2147483648.0f) ? static_cast<int32_t>(v.raw[3])
+                                          : kMaxI32)
+            : ((v.raw[3] < 0) ? kMinI32 : 0));
+  }
+#endif
+
   HWY_DIAGNOSTICS(push)
 #if HWY_COMPILER_CLANG
   HWY_DIAGNOSTICS_OFF(disable : 5219, ignored "-Wdeprecate-lax-vec-conv-all")
@@ -3817,50 +3874,31 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
 template <class D, HWY_IF_I64_D(D)>
 HWY_API VFromD<D> ConvertTo(D /* tag */,
                             Vec128<double, Rebind<double, D>().MaxLanes()> v) {
-  HWY_DIAGNOSTICS(push)
-#if HWY_COMPILER_CLANG
-  HWY_DIAGNOSTICS_OFF(disable : 5219, ignored "-Wdeprecate-lax-vec-conv-all")
-#endif
-
 #if defined(__OPTIMIZE__)
   if (detail::IsConstantRawAltivecVect(v.raw)) {
     constexpr int64_t kMinI64 = LimitsMin<int64_t>();
     constexpr int64_t kMaxI64 = LimitsMax<int64_t>();
-    const __vector signed long long raw_result = {
-        (v.raw[0] >= -9223372036854775808.0)
-            ? ((v.raw[0] < 9223372036854775808.0)
-                   ? static_cast<int64_t>(v.raw[0])
-                   : kMaxI64)
-            : ((v.raw[0] < 0) ? kMinI64 : 0LL),
-        (v.raw[1] >= -9223372036854775808.0)
-            ? ((v.raw[1] < 9223372036854775808.0)
-                   ? static_cast<int64_t>(v.raw[1])
-                   : kMaxI64)
-            : ((v.raw[1] < 0) ? kMinI64 : 0LL)};
-    return VFromD<D>{raw_result};
+    return Dup128VecFromValues(D(),
+                               (v.raw[0] >= -9223372036854775808.0)
+                                   ? ((v.raw[0] < 9223372036854775808.0)
+                                          ? static_cast<int64_t>(v.raw[0])
+                                          : kMaxI64)
+                                   : ((v.raw[0] < 0) ? kMinI64 : 0LL),
+                               (v.raw[1] >= -9223372036854775808.0)
+                                   ? ((v.raw[1] < 9223372036854775808.0)
+                                          ? static_cast<int64_t>(v.raw[1])
+                                          : kMaxI64)
+                                   : ((v.raw[1] < 0) ? kMinI64 : 0LL));
   }
 #endif
 
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // optimizing out the F64->I64 conversion if the values of any lanes of v are
-  // outside of the range of an int64_t.
-  __asm__("" : "+wa"(v.raw)::);
-#if HWY_COMPILER_CLANG && HWY_HAS_BUILTIN(__builtin_convertvector)
-  // Use the __builtin_convertvector intrinsic on Clang if the
-  // __builtin_convertvector intrinsic is available as vec_cts incorrectly
-  // converts values using xvcvdpsxws instead of xvcvdpsxds if
-  // __XL_COMPAT_ALTIVEC__ is defined
-  VFromD<D> result{__builtin_convertvector(v.raw, __vector signed long long)};
-#else
-  VFromD<D> result{vec_cts(v.raw, 0)};
-#endif
-  HWY_DIAGNOSTICS(pop)
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // assuming that result[i] is always less than or equal to 9223372036854774784
-  // as the VSX xvcvdpsxds instruction can return 9223372036854775807 if
-  // v[i] >= 9223372036854775808 is true.
-  __asm__("" : "+wa"(result.raw)::);
-  return result;
+  // Use inline assembly to avoid undefined behavior if v[i] is not within the
+  // range of an int64_t
+  __vector signed long long raw_result;
+  __asm__("xvcvdpsxds %x0,%x1"
+          : "=wa"(raw_result)
+          : "wa"(detail::VsxF2INormalizeSrcVals(v).raw));
+  return VFromD<D>{raw_result};
 }
 
 template <class D, HWY_IF_U32_D(D)>
@@ -3869,7 +3907,8 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
 #if defined(__OPTIMIZE__)
   if (detail::IsConstantRawAltivecVect(v.raw)) {
     constexpr uint32_t kMaxU32 = LimitsMax<uint32_t>();
-    const __vector unsigned int raw_result = {
+    return Dup128VecFromValues(
+        D(),
         (v.raw[0] >= 0.0f)
             ? ((v.raw[0] < 4294967296.0f) ? static_cast<uint32_t>(v.raw[0])
                                           : kMaxU32)
@@ -3885,27 +3924,16 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
         (v.raw[3] >= 0.0f)
             ? ((v.raw[3] < 4294967296.0f) ? static_cast<uint32_t>(v.raw[3])
                                           : kMaxU32)
-            : 0,
-    };
-    return VFromD<D>{raw_result};
+            : 0);
   }
 #endif
 
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // optimizing out the F32->U32 conversion if the values of any lanes of v are
-  // outside of the range of an uint32_t.
-  __asm__("" : "+v"(v.raw)::);
   HWY_DIAGNOSTICS(push)
 #if HWY_COMPILER_CLANG
   HWY_DIAGNOSTICS_OFF(disable : 5219, ignored "-Wdeprecate-lax-vec-conv-all")
 #endif
   VFromD<D> result{vec_ctu(v.raw, 0)};
   HWY_DIAGNOSTICS(pop)
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // assuming that result[i] is always less than or equal to 4294967040 as the
-  // Altivec vctuxs instruction or VSX xvcvspuxws instruction can return
-  // 4294967295 if v[i] >= 4294967296 is true.
-  __asm__("" : "+wa"(result.raw)::);
   return result;
 }
 
@@ -3920,7 +3948,8 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
 #if defined(__OPTIMIZE__)
   if (detail::IsConstantRawAltivecVect(v.raw)) {
     constexpr uint64_t kMaxU64 = LimitsMax<uint64_t>();
-    const __vector unsigned long long raw_result = {
+    return Dup128VecFromValues(
+        D(),
         (v.raw[0] >= 0.0) ? ((v.raw[0] < 18446744073709551616.0)
                                  ? static_cast<uint64_t>(v.raw[0])
                                  : kMaxU64)
@@ -3928,42 +3957,17 @@ HWY_API VFromD<D> ConvertTo(D /* tag */,
         (v.raw[1] >= 0.0) ? ((v.raw[1] < 18446744073709551616.0)
                                  ? static_cast<uint64_t>(v.raw[1])
                                  : kMaxU64)
-                          : 0,
-    };
-    return VFromD<D>{raw_result};
+                          : 0);
   }
 #endif
 
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // optimizing out the F64->U64 conversion if the values of any lanes of v are
-  // outside of the range of an uint64_t.
-  __asm__("" : "+wa"(v.raw)::);
-#if HWY_COMPILER_CLANG && HWY_HAS_BUILTIN(__builtin_convertvector)
-  // Use the __builtin_convertvector intrinsic on Clang if the
-  // __builtin_convertvector intrinsic is available as vec_ctu incorrectly
-  // converts values using xvcvdpuxws instead of xvcvdpuxds if
-  // __XL_COMPAT_ALTIVEC__ is defined
-  VFromD<D> result{__builtin_convertvector(v.raw, __vector unsigned long long)};
-#else
-  VFromD<D> result{vec_ctu(v.raw, 0)};
-#endif
-  HWY_DIAGNOSTICS(pop)
-  // The inline assembly statement below prevents the compiler from incorrectly
-  // assuming that result[i] is always less than or equal to
-  // 18446744073709549568 as the VSX xvcvdpuxds instruction can return
-  // 18446744073709551615 if v[i] >= 18446744073709551616 is true.
-  __asm__("" : "+wa"(result.raw)::);
-  return result;
-}
-
-template <size_t N>
-HWY_API Vec128<int32_t, N> NearestInt(Vec128<float, N> v) {
-  HWY_DIAGNOSTICS(push)
-#if HWY_COMPILER_CLANG
-  HWY_DIAGNOSTICS_OFF(disable : 5219, ignored "-Wdeprecate-lax-vec-conv-all")
-#endif
-  return Vec128<int32_t, N>{vec_cts(vec_round(v.raw), 0)};
-  HWY_DIAGNOSTICS(pop)
+  // Use inline assembly to avoid undefined behavior if v[i] is not within the
+  // range of an uint64_t
+  __vector unsigned long long raw_result;
+  __asm__("xvcvdpuxds %x0,%x1"
+          : "=wa"(raw_result)
+          : "wa"(detail::VsxF2INormalizeSrcVals(v).raw));
+  return VFromD<D>{raw_result};
 }
 
 // ------------------------------ Floating-point rounding (ConvertTo)
@@ -3977,6 +3981,13 @@ HWY_API Vec128<float, N> Round(Vec128<float, N> v) {
 template <size_t N>
 HWY_API Vec128<double, N> Round(Vec128<double, N> v) {
   return Vec128<double, N>{vec_rint(v.raw)};
+}
+
+template <size_t N>
+HWY_API Vec128<int32_t, N> NearestInt(Vec128<float, N> v) {
+  const DFromV<decltype(v)> d;
+  const RebindToSigned<decltype(d)> di;
+  return ConvertTo(di, Round(v));
 }
 
 // Toward zero, aka truncate

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -21,6 +21,7 @@
 #define HWY_TARGET_INCLUDE "tests/convert_test.cc"
 #include "hwy/foreach_target.h"  // IWYU pragma: keep
 #include "hwy/highway.h"
+#include "hwy/nanobenchmark.h"
 #include "hwy/tests/test_util-inl.h"
 
 HWY_BEFORE_NAMESPACE();
@@ -832,6 +833,215 @@ HWY_NOINLINE void TestAllFloatFromUint() {
   ForFloatTypes(ForPartialVectors<TestFloatFromUint>());
 }
 
+template <class TTo>
+class TestNonFiniteF2IConvertTo {
+ private:
+  static_assert(IsIntegerLaneType<TTo>() && IsSame<TTo, RemoveCvRef<TTo>>(),
+                "TTo must be an integer type");
+
+  template <class DF, HWY_IF_T_SIZE_LE_D(DF, sizeof(TTo) - 1)>
+  static HWY_INLINE VFromD<Rebind<TTo, DF>> DoF2IConvVec(DF /*df*/,
+                                                         VFromD<DF> v) {
+    return PromoteTo(Rebind<TTo, DF>(), v);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_D(DF, sizeof(TTo))>
+  static HWY_INLINE VFromD<Rebind<TTo, DF>> DoF2IConvVec(DF /*df*/,
+                                                         VFromD<DF> v) {
+    return ConvertTo(Rebind<TTo, DF>(), v);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_GT_D(DF, sizeof(TTo))>
+  static HWY_INLINE VFromD<Rebind<TTo, DF>> DoF2IConvVec(DF /*df*/,
+                                                         VFromD<DF> v) {
+    return DemoteTo(Rebind<TTo, DF>(), v);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_LE_D(DF, sizeof(TTo) - 1)>
+  static HWY_INLINE Mask<Rebind<TTo, DF>> DoF2IConvMask(DF df, Mask<DF> m) {
+    return PromoteMaskTo(Rebind<TTo, DF>(), df, m);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_D(DF, sizeof(TTo))>
+  static HWY_INLINE Mask<Rebind<TTo, DF>> DoF2IConvMask(DF /*df*/, Mask<DF> m) {
+    return RebindMask(Rebind<TTo, DF>(), m);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_GT_D(DF, sizeof(TTo))>
+  static HWY_INLINE Mask<Rebind<TTo, DF>> DoF2IConvMask(DF df, Mask<DF> m) {
+    return DemoteMaskTo(Rebind<TTo, DF>(), df, m);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_LE_D(DF, sizeof(TTo) - 1)>
+  static HWY_INLINE Vec<Rebind<MakeSigned<TTo>, DF>> DoF2IConvMsbMaskVec(
+      DF /*df*/, Vec<DF> v) {
+    return PromoteTo(Rebind<MakeSigned<TTo>, DF>(),
+                     BitCast(RebindToSigned<DF>(), v));
+  }
+
+  template <class DF, HWY_IF_T_SIZE_D(DF, sizeof(TTo))>
+  static HWY_INLINE Vec<Rebind<MakeSigned<TTo>, DF>> DoF2IConvMsbMaskVec(
+      DF /*df*/, Vec<DF> v) {
+    return BitCast(Rebind<MakeSigned<TTo>, DF>(), v);
+  }
+
+  template <class DF, HWY_IF_T_SIZE_GT_D(DF, sizeof(TTo))>
+  static HWY_INLINE Vec<Rebind<MakeSigned<TTo>, DF>> DoF2IConvMsbMaskVec(
+      DF /*df*/, Vec<DF> v) {
+    return DemoteTo(Rebind<MakeSigned<TTo>, DF>(),
+                    BitCast(RebindToSigned<DF>(), v));
+  }
+
+  template <class DF>
+  static HWY_NOINLINE void VerifyNonFiniteF2I(DF df, const VecArg<VFromD<DF>> v,
+                                              const char* filename,
+                                              const int line) {
+    using TF = TFromD<DF>;
+    using TU = MakeUnsigned<TF>;
+    using TTo_I = MakeSigned<TTo>;
+
+    constexpr TF kMinOutOfRangePosVal =
+        static_cast<TF>((-static_cast<TF>(LimitsMin<TTo_I>())) *
+                        static_cast<TF>(IsSigned<TTo>() ? 1 : 2));
+    static_assert(kMinOutOfRangePosVal > static_cast<TF>(0),
+                  "kMinOutOfRangePosVal > 0 must be true");
+
+    const Rebind<TTo, DF> d_to;
+    const RebindToSigned<decltype(d_to)> di_to;
+    const RebindToUnsigned<DF> du;
+
+    const auto non_elided_zero =
+        BitCast(df, Set(du, static_cast<TU>(Unpredictable1() - 1)));
+
+    const auto v2 = Or(non_elided_zero, v);
+    const auto is_nan_mask = IsNaN(v2);
+    const auto is_in_range_mask =
+        AndNot(is_nan_mask, Lt(Abs(IfThenZeroElse(is_nan_mask, v2)),
+                               Set(df, kMinOutOfRangePosVal)));
+
+    const auto is_nan_vmask = VecFromMask(d_to, DoF2IConvMask(df, is_nan_mask));
+
+    const auto expected_in_range =
+        DoF2IConvVec(df, IfThenElseZero(is_in_range_mask, v2));
+    const auto expected_out_of_range =
+        Or(is_nan_vmask,
+           BitCast(d_to, IfNegativeThenElse(
+                             DoF2IConvMsbMaskVec(df, v2),
+                             BitCast(di_to, Set(d_to, LimitsMin<TTo>())),
+                             BitCast(di_to, Set(d_to, LimitsMax<TTo>())))));
+
+    const auto expected = IfThenElse(DoF2IConvMask(df, is_in_range_mask),
+                                     expected_in_range, expected_out_of_range);
+
+    AssertVecEqual(d_to, expected, Or(DoF2IConvVec(df, v), is_nan_vmask),
+                   filename, line);
+    AssertVecEqual(d_to, expected, Or(DoF2IConvVec(df, v2), is_nan_vmask),
+                   filename, line);
+  }
+
+ public:
+  template <typename TF, class DF>
+  HWY_NOINLINE void operator()(TF /*unused*/, const DF df) {
+    using TI = MakeSigned<TF>;
+    using TU = MakeUnsigned<TF>;
+    const RebindToSigned<DF> di;
+
+    // TODO(janwas): workaround for QEMU 7.2 crash on vfwcvt_rtz_x_f_v:
+    // target/riscv/translate.c:213 in void decode_save_opc(DisasContext *):
+    // ctx->insn_start != NULL.
+#if HWY_TARGET == HWY_RVV || (HWY_ARCH_RVV && HWY_TARGET == HWY_EMU128)
+    if (sizeof(TTo) > sizeof(TF)) {
+      return;
+    }
+#endif
+
+    const auto pos_nan = BitCast(df, Set(di, LimitsMax<TI>()));
+    const auto neg_nan = BitCast(df, Set(di, static_cast<TI>(-1)));
+    const auto pos_inf =
+        BitCast(df, Set(di, static_cast<TI>(ExponentMask<TF>())));
+    const auto neg_inf = Neg(pos_inf);
+
+    VerifyNonFiniteF2I(df, pos_nan, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, neg_nan, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, pos_inf, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, neg_inf, __FILE__, __LINE__);
+
+    const TI non_elided_one = static_cast<TI>(Unpredictable1());
+
+    const auto iota1 = Iota(df, ConvertScalarTo<TF>(non_elided_one));
+    VerifyNonFiniteF2I(df, iota1, __FILE__, __LINE__);
+
+    const size_t N = Lanes(df);
+
+#if HWY_TARGET != HWY_SCALAR
+    if (N > 1) {
+      VerifyNonFiniteF2I(df, OddEven(pos_nan, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, pos_nan), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(neg_nan, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, neg_nan), __FILE__, __LINE__);
+
+      VerifyNonFiniteF2I(df, OddEven(pos_inf, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, pos_inf), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(neg_inf, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, neg_inf), __FILE__, __LINE__);
+    }
+#endif
+
+    auto in_lanes = AllocateAligned<TF>(N);
+    HWY_ASSERT(in_lanes);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        in_lanes[i] = BitCastScalar<TF>(static_cast<TU>(rng()));
+      }
+
+      const auto v = Load(df, in_lanes.get());
+      VerifyNonFiniteF2I(df, v, __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, Or(v, pos_inf), __FILE__, __LINE__);
+
+#if HWY_TARGET != HWY_SCALAR
+      if (N > 1) {
+        VerifyNonFiniteF2I(df, OddEven(pos_nan, v), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(v, pos_nan), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(neg_nan, v), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(v, neg_nan), __FILE__, __LINE__);
+
+        VerifyNonFiniteF2I(df, OddEven(pos_inf, v), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(v, pos_inf), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(neg_inf, v), __FILE__, __LINE__);
+        VerifyNonFiniteF2I(df, OddEven(v, neg_inf), __FILE__, __LINE__);
+      }
+#endif
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllNonFiniteF2IConvertTo() {
+#if HWY_HAVE_FLOAT16
+  ForPartialVectors<TestNonFiniteF2IConvertTo<int16_t>>()(hwy::float16_t());
+  ForPartialVectors<TestNonFiniteF2IConvertTo<uint16_t>>()(hwy::float16_t());
+#endif
+
+  ForPartialVectors<TestNonFiniteF2IConvertTo<int32_t>>()(float());
+  ForPartialVectors<TestNonFiniteF2IConvertTo<uint32_t>>()(float());
+
+#if HWY_HAVE_FLOAT64
+  ForPartialVectors<TestNonFiniteF2IConvertTo<int64_t>>()(double());
+  ForPartialVectors<TestNonFiniteF2IConvertTo<uint64_t>>()(double());
+#endif
+
+#if HWY_HAVE_INTEGER64
+  ForPromoteVectors<TestNonFiniteF2IConvertTo<int64_t>>()(float());
+  ForPromoteVectors<TestNonFiniteF2IConvertTo<uint64_t>>()(float());
+#endif
+
+#if HWY_HAVE_FLOAT64
+  ForDemoteVectors<TestNonFiniteF2IConvertTo<int32_t>>()(double());
+  ForDemoteVectors<TestNonFiniteF2IConvertTo<uint32_t>>()(double());
+#endif
+}
+
 struct TestI32F64 {
   template <typename TF, class DF>
   HWY_NOINLINE void operator()(TF /*unused*/, const DF df) {
@@ -1070,6 +1280,101 @@ HWY_NOINLINE void TestAllF2IPromoteUpperLowerTo() {
 #endif
 }
 
+template <bool kConvToUnsigned>
+class TestNonFiniteF2IPromoteUpperLowerTo {
+  template <class DF>
+  static HWY_NOINLINE void VerifyNonFiniteF2I(DF df, const VecArg<VFromD<DF>> v,
+                                              const char* filename,
+                                              const int line) {
+    using TF = TFromD<DF>;
+    using TI = MakeSigned<TF>;
+    using TU = MakeUnsigned<TF>;
+    using TW_I = MakeWide<TI>;
+    using TW_U = MakeWide<TU>;
+    using TW = If<kConvToUnsigned, TW_U, TW_I>;
+
+    constexpr TF kMinOutOfRangePosVal =
+        static_cast<TF>((-static_cast<TF>(LimitsMin<TW_I>())) *
+                        static_cast<TF>(kConvToUnsigned ? 2 : 1));
+    static_assert(kMinOutOfRangePosVal > static_cast<TF>(0),
+                  "kMinOutOfRangePosVal > 0 must be true");
+
+    const TU scalar_non_elided_zero = static_cast<TU>(Unpredictable1() - 1);
+
+    const Half<DF> dh;
+    const RebindToUnsigned<DF> du;
+    const Repartition<TW, decltype(df)> dw;
+
+    const auto non_elided_zero = BitCast(df, Set(du, scalar_non_elided_zero));
+    const auto v2 = Or(non_elided_zero, v);
+
+    const auto promoted_lo = PromoteTo(dw, LowerHalf(dh, v2));
+    const auto promoted_hi = PromoteTo(dw, UpperHalf(dh, v2));
+    const auto promoted_even = PromoteTo(dw, LowerHalf(ConcatEven(df, v2, v2)));
+    const auto promoted_odd = PromoteTo(dw, LowerHalf(ConcatOdd(df, v2, v2)));
+
+    AssertVecEqual(dw, promoted_lo, PromoteLowerTo(dw, v), filename, line);
+    AssertVecEqual(dw, promoted_hi, PromoteUpperTo(dw, v), filename, line);
+    AssertVecEqual(dw, promoted_even, PromoteEvenTo(dw, v), filename, line);
+    AssertVecEqual(dw, promoted_odd, PromoteOddTo(dw, v), filename, line);
+
+    AssertVecEqual(dw, promoted_lo, PromoteLowerTo(dw, v2), filename, line);
+    AssertVecEqual(dw, promoted_hi, PromoteUpperTo(dw, v2), filename, line);
+    AssertVecEqual(dw, promoted_even, PromoteEvenTo(dw, v2), filename, line);
+    AssertVecEqual(dw, promoted_odd, PromoteOddTo(dw, v2), filename, line);
+  }
+
+ public:
+  template <typename TF, class DF>
+  HWY_NOINLINE void operator()(TF /*unused*/, const DF df) {
+    using TI = MakeSigned<TF>;
+    const RebindToSigned<DF> di;
+
+    // TODO(janwas): workaround for QEMU 7.2 crash on vfwcvt_rtz_x_f_v:
+    // target/riscv/translate.c:213 in void decode_save_opc(DisasContext *):
+    // ctx->insn_start != NULL.
+#if HWY_TARGET == HWY_RVV || (HWY_ARCH_RVV && HWY_TARGET == HWY_EMU128)
+    return;
+#endif
+
+    const auto pos_nan = BitCast(df, Set(di, LimitsMax<TI>()));
+    const auto neg_nan = BitCast(df, Set(di, static_cast<TI>(-1)));
+    const auto pos_inf =
+        BitCast(df, Set(di, static_cast<TI>(ExponentMask<TF>())));
+    const auto neg_inf = Neg(pos_inf);
+
+    VerifyNonFiniteF2I(df, pos_nan, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, neg_nan, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, pos_inf, __FILE__, __LINE__);
+    VerifyNonFiniteF2I(df, neg_inf, __FILE__, __LINE__);
+
+    const TI non_elided_one = static_cast<TI>(Unpredictable1());
+    const auto iota1 = Iota(df, ConvertScalarTo<TF>(non_elided_one));
+    VerifyNonFiniteF2I(df, iota1, __FILE__, __LINE__);
+
+#if HWY_TARGET != HWY_SCALAR
+    if (Lanes(df) > 1) {
+      VerifyNonFiniteF2I(df, OddEven(pos_nan, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, pos_nan), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(neg_nan, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, neg_nan), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(pos_inf, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, pos_inf), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(neg_inf, iota1), __FILE__, __LINE__);
+      VerifyNonFiniteF2I(df, OddEven(iota1, neg_inf), __FILE__, __LINE__);
+    }
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllNonFiniteF2IPromoteUpperLowerTo() {
+#if HWY_HAVE_INTEGER64
+  ForShrinkableVectors<TestNonFiniteF2IPromoteUpperLowerTo<false>, 1>()(
+      float());
+  ForShrinkableVectors<TestNonFiniteF2IPromoteUpperLowerTo<true>, 1>()(float());
+#endif
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -1090,9 +1395,11 @@ HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllIntFromFloat);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllUintFromFloat);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllFloatFromInt);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllFloatFromUint);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllNonFiniteF2IConvertTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllI32F64);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllF2IPromoteTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllF2IPromoteUpperLowerTo);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllNonFiniteF2IPromoteUpperLowerTo);
 }  // namespace hwy
 
 #endif


### PR DESCRIPTION
Updated SCALAR/EMU128 F->UI PromoteTo/ConvertTo/DemoteTo to ensure that undefined behavior does not occur if the source vector contains any NaN values.

On PPC8/PPC9/PPC10, also updated F->UI PromoteTo/ConvertTo/DemoteTo operations that use VSX F->UI conversion instructions to zero out any NaN source values unless HWY_DISABLE_PPC_VSX_QEMU_F2I_WORKAROUND is defined to work around a bug in QEMU 7/8 where a NaN value in the source floating-point vector can cause subsequent lanes to be incorrectly converted to an integer.

Also updated NEON F->UI PromoteTo/ConvertTo/DemoteTo operations to use inline assembly when compiled for ArmV7 with Clang or when compiled for AArch64 with Clang 11 or earlier to avoid undefined behavior if any of the source values are outside of the range of the result type.