### PR TITLE
Fixed endianness bug in U16/I16/F16/BF16 Expand in generic_ops-inl.h

### DIFF
--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -5252,7 +5252,9 @@ HWY_API Vec128<T, N> Expand(Vec128<T, N> v, Mask128<T, N> mask) {
       BitCast(du, InterleaveLower(du8x2, indices8, indices8));
   // TableLookupBytesOr0 operates on bytes. To convert u16 lane indices to byte
   // indices, add 0 to even and 1 to odd byte lanes.
-  const Vec128<uint16_t, N> byte_indices = Add(indices16, Set(du, 0x0100));
+  const Vec128<uint16_t, N> byte_indices = Add(
+      indices16,
+      Set(du, static_cast<uint16_t>(HWY_IS_LITTLE_ENDIAN ? 0x0100 : 0x0001)));
   return BitCast(d, TableLookupBytesOr0(v, byte_indices));
 }
 


### PR DESCRIPTION
Fixed endianness bug in U16/I16/F16/BF16 Expand implementation in generic_ops-inl.h.

The U16/I16/F16/BF16 Expand implementation in generic_ops-inl.h now has correct behavior on both big-endian targets and little-endian targets with the fix in this pull request.