### PR TITLE
Fixes for compilation warnings in NextAlignedOffset, MatVec, and ThreadPool

### DIFF
--- a/hwy/aligned_allocator.cc
+++ b/hwy/aligned_allocator.cc
@@ -58,9 +58,9 @@ size_t NextAlignedOffset() {
   static_assert(kAlias % kAlignment == 0, "kAlias must be a multiple");
   constexpr uint64_t kGroups = kAlias / kAlignment;
   const uint64_t group = next.fetch_add(1, std::memory_order_relaxed) % kGroups;
-  const size_t offset = kAlignment * group;
+  const uint64_t offset = kAlignment * group;
   HWY_DASSERT((offset % kAlignment == 0) && offset <= kAlias);
-  return offset;
+  return static_cast<size_t>(offset);
 }
 
 }  // namespace

--- a/hwy/contrib/matvec/matvec-inl.h
+++ b/hwy/contrib/matvec/matvec-inl.h
@@ -44,7 +44,7 @@ HWY_NOINLINE void MatVec(const T* HWY_RESTRICT mat, const T* HWY_RESTRICT vec,
   // Required for Stream loop, otherwise we might have partial vectors.
   HWY_DASSERT(kChunkSize >= N);
   pool.Run(0, num_chunks, &hwy::ThreadPool::NoInit,
-           [&](const uint32_t chunk, size_t /*thread*/) HWY_ATTR {
+           [&](const uint64_t chunk, size_t /*thread*/) HWY_ATTR {
              // MSVC workaround: duplicate to ensure constexpr.
              constexpr size_t kChunkSize = 64 / sizeof(T);
              // Software write-combining to avoid cache pollution from out.
@@ -54,7 +54,7 @@ HWY_NOINLINE void MatVec(const T* HWY_RESTRICT mat, const T* HWY_RESTRICT vec,
 
              // Only handle entire chunks here because the Stream is not masked.
              // Remaining rows are handled after the pool.Run.
-             const size_t begin = chunk * kChunkSize;
+             const size_t begin = static_cast<size_t>(chunk * kChunkSize);
              for (size_t idx_row = 0; idx_row < kChunkSize; ++idx_row) {
                auto sum0 = Zero(d);
                auto sum1 = Zero(d);
@@ -101,7 +101,7 @@ HWY_NOINLINE void MatVec(const T* HWY_RESTRICT mat, const T* HWY_RESTRICT vec,
                sum0 = Add(sum0, sum1);
                sum0 = Add(sum0, sum2);
                buf[idx_row] = ReduceSum(d, sum0);
-             }  // idx_row
+             }              // idx_row
              HWY_UNROLL(4)  // 1..4 iterations
              for (size_t i = 0; i != kChunkSize; i += N) {
                Stream(Load(d, buf + i), d, out + begin + i);
@@ -158,7 +158,7 @@ HWY_NOINLINE void MatVec(const hwy::bfloat16_t* HWY_RESTRICT mat,
   // Required for Stream loop, otherwise we might have partial vectors.
   HWY_DASSERT(kChunkSize >= N);
   pool.Run(0, num_chunks, &hwy::ThreadPool::NoInit,
-           [&](const uint32_t chunk, size_t /*thread*/) HWY_ATTR {
+           [&](const uint64_t chunk, size_t /*thread*/) HWY_ATTR {
              // MSVC workaround: duplicate to ensure constexpr.
              constexpr size_t kChunkSize = 64 / sizeof(float);
              // Software write-combining to avoid cache pollution from out.
@@ -168,7 +168,7 @@ HWY_NOINLINE void MatVec(const hwy::bfloat16_t* HWY_RESTRICT mat,
 
              // Only handle entire chunks here because the Stream is not masked.
              // Remaining rows are handled after the pool.Run.
-             const size_t begin = chunk * kChunkSize;
+             const size_t begin = static_cast<size_t>(chunk * kChunkSize);
              for (size_t idx_row = 0; idx_row < kChunkSize; ++idx_row) {
                auto sum0 = Zero(d);
                auto sum1 = Zero(d);
@@ -222,8 +222,8 @@ HWY_NOINLINE void MatVec(const hwy::bfloat16_t* HWY_RESTRICT mat,
                sum0 = Add(sum0, sum1);
                sum0 = Add(sum0, sum2);
                buf[idx_row] = ReduceSum(d, sum0);
-             }                   // idx_row
-             HWY_UNROLL(4)       // 1..4 iterations
+             }              // idx_row
+             HWY_UNROLL(4)  // 1..4 iterations
              for (size_t i = 0; i != kChunkSize; i += N) {
                Stream(Load(d, buf + i), d, out + begin + i);
              }
@@ -272,7 +272,7 @@ HWY_NOINLINE void MatVec(const hwy::bfloat16_t* HWY_RESTRICT mat,
   // Required for Stream loop, otherwise we might have partial vectors.
   HWY_DASSERT(kChunkSize >= N);
   pool.Run(0, num_chunks, &hwy::ThreadPool::NoInit,
-           [&](const uint32_t chunk, size_t /*thread*/) HWY_ATTR {
+           [&](const uint64_t chunk, size_t /*thread*/) HWY_ATTR {
              // MSVC workaround: duplicate to ensure constexpr.
              constexpr size_t kChunkSize = 64 / sizeof(bfloat16_t);
              // Software write-combining to avoid cache pollution from out.
@@ -282,7 +282,7 @@ HWY_NOINLINE void MatVec(const hwy::bfloat16_t* HWY_RESTRICT mat,
 
              // Only handle entire chunks here because the Stream is not masked.
              // Remaining rows are handled after the pool.Run.
-             const size_t begin = chunk * kChunkSize;
+             const size_t begin = static_cast<size_t>(chunk * kChunkSize);
              for (size_t idx_row = 0; idx_row < kChunkSize; ++idx_row) {
                auto sum0 = Zero(df);
                auto sum1 = Zero(df);

--- a/hwy/contrib/matvec/matvec_test.cc
+++ b/hwy/contrib/matvec/matvec_test.cc
@@ -38,7 +38,7 @@ template <typename MatT, typename T>
 HWY_NOINLINE void SimpleMatVec(const MatT* mat, const T* vec, size_t rows,
                                size_t cols, T* out, ThreadPool& pool) {
   pool.Run(0, static_cast<uint32_t>(rows), &ThreadPool::NoInit,
-           [=](uint32_t r, size_t /*thread*/) {
+           [=](uint64_t r, size_t /*thread*/) {
              T dot = ConvertScalarTo<T>(0);
              for (size_t c = 0; c < cols; c++) {
                // For reasons unknown, fp16 += does not compile on clang (Arm).
@@ -52,7 +52,7 @@ HWY_NOINLINE void SimpleMatVec(const hwy::bfloat16_t* mat, const float* vec,
                                size_t rows, size_t cols, float* out,
                                ThreadPool& pool) {
   pool.Run(0, static_cast<uint32_t>(rows), &ThreadPool::NoInit,
-           [=](uint32_t r, size_t /*thread*/) {
+           [=](uint64_t r, size_t /*thread*/) {
              float dot = 0.0f;
              for (size_t c = 0; c < cols; c++) {
                dot += F32FromBF16(mat[r * cols + c]) * vec[c];
@@ -65,7 +65,7 @@ HWY_NOINLINE void SimpleMatVec(const hwy::bfloat16_t* mat,
                                const hwy::bfloat16_t* vec, size_t rows,
                                size_t cols, float* out, ThreadPool& pool) {
   pool.Run(0, static_cast<uint32_t>(rows), &ThreadPool::NoInit,
-           [=](uint32_t r, size_t /*thread*/) {
+           [=](uint64_t r, size_t /*thread*/) {
              float dot = 0.0f;
              for (size_t c = 0; c < cols; c++) {
                dot += F32FromBF16(mat[r * cols + c]) * F32FromBF16(vec[c]);

--- a/hwy/contrib/thread_pool/thread_pool.cc
+++ b/hwy/contrib/thread_pool/thread_pool.cc
@@ -35,7 +35,7 @@ namespace hwy {
 ThreadPool::ThreadPool(const size_t num_worker_threads)
     : num_worker_threads_(num_worker_threads),
       num_threads_(HWY_MAX(num_worker_threads, size_t{1})),
-      prime_(FindCoprime(num_worker_threads)),
+      prime_(static_cast<size_t>(FindCoprime(num_worker_threads))),
       ranges_(num_worker_threads) {
   threads_.reserve(num_worker_threads_);
 
@@ -86,7 +86,7 @@ void ThreadPool::StartWorkers(const WorkerCommand worker_command) {
 
 void ThreadPool::DoWork(size_t thread) {
   // Special case for <= 1 task per worker - avoid any shared state.
-  const size_t num_tasks = end_ - begin_;
+  const size_t num_tasks = static_cast<size_t>(end_ - begin_);
   const size_t num_workers = num_worker_threads_;
   if (num_tasks <= num_workers) {
     if (thread < num_tasks) {
@@ -134,7 +134,7 @@ void ThreadPool::DoWork(size_t thread) {
       run_func_(opaque_, task, thread);
     }
 
-    thread = PermutationNext(thread, num_workers, prime);
+    thread = static_cast<size_t>(PermutationNext(thread, num_workers, prime));
   }
 }
 

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -53,7 +53,7 @@ class TaskRanges {
   }
 
   void Assign(uint64_t begin, uint64_t end, size_t num_worker_threads) {
-    const size_t num_tasks = end - begin;
+    const size_t num_tasks = static_cast<size_t>(end - begin);
     // Only called if we have tasks and workers.
     HWY_DASSERT(num_tasks != 0 && num_worker_threads != 0);
 


### PR DESCRIPTION
Changes were made to hwy/aligned_allocator.cc, hwy/contrib/matvec/matvec-inl.h, hwy/contrib/matvec/matvec_test.cc, hwy/contrib/thread_pool/thread_pool.cc, hwy/contrib/thread_pool/thread_pool.h, and hwy/contrib/thread_pool/thread_pool_test.cc to fix compilation warnings.