### PR TITLE
Make MaskFalse available to non-test code on all targets

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1002,6 +1002,15 @@ encoding depends on the platform).
     a mask with lane `i` set to
     `((mask_bits >> (i & (16 / sizeof(T) - 1))) & 1) != 0`.
 
+*   <code>M **MaskFalse(D)**</code>: returns an all-false mask.
+    `MaskFalse(D())` is equivalent to `MaskFromVec(Zero(D()))`, but
+    `MaskFalse(D())` is more efficient than `MaskFromVec(Zero(D()))` on AVX3,
+    RVV, and SVE.
+
+    `MaskFalse(D())` is also equivalent to `FirstN(D(), 0)` or
+    `Dup128MaskFromMaskBits(D(), 0)`, but `MaskFalse(D())` is usually more
+    efficient.
+
 #### Convert mask
 
 *   <code>M1 **RebindMask**(D, M2 m)</code>: returns same mask bits as `m`, but

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -343,6 +343,17 @@ svbool_t MakeMask(D d) {
 
 }  // namespace detail
 
+#ifdef HWY_NATIVE_MASK_FALSE
+#undef HWY_NATIVE_MASK_FALSE
+#else
+#define HWY_NATIVE_MASK_FALSE
+#endif
+
+template <class D>
+HWY_API svbool_t MaskFalse(const D /*d*/) {
+  return detail::PFalse();
+}
+
 // ================================================== INIT
 
 // ------------------------------ Set

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -197,6 +197,21 @@ HWY_API void SafeCopyN(const size_t num, D d, const T* HWY_RESTRICT from,
 #endif
 }
 
+// ------------------------------ MaskFalse
+#if (defined(HWY_NATIVE_MASK_FALSE) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MASK_FALSE
+#undef HWY_NATIVE_MASK_FALSE
+#else
+#define HWY_NATIVE_MASK_FALSE
+#endif
+
+template <class D>
+HWY_API Mask<D> MaskFalse(D d) {
+  return MaskFromVec(Zero(d));
+}
+
+#endif  // HWY_NATIVE_MASK_FALSE
+
 // ------------------------------ BitwiseIfThenElse
 #if (defined(HWY_NATIVE_BITWISE_IF_THEN_ELSE) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_BITWISE_IF_THEN_ELSE

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -1316,8 +1316,14 @@ HWY_RVV_FOREACH_F(HWY_RVV_FMA, NegMulSub, fnmacc, _ALL)
 #define HWY_RVV_IF_MLEN_D(D, MLEN) \
   hwy::EnableIf<MLenFromD(D()) == MLEN>* = nullptr
 
-// Specialized for RVV instead of the generic test_util-inl.h implementation
+// Specialized for RVV instead of the generic generic_ops-inl.h implementation
 // because more efficient, and helps implement MFromD.
+
+#ifdef HWY_NATIVE_MASK_FALSE
+#undef HWY_NATIVE_MASK_FALSE
+#else
+#define HWY_NATIVE_MASK_FALSE
+#endif
 
 #define HWY_RVV_MASK_FALSE(SEW, SHIFT, MLEN, NAME, OP) \
   template <class D, HWY_RVV_IF_MLEN_D(D, MLEN)>       \

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -856,6 +856,20 @@ HWY_API Mask128<double, N> MaskFromVec(const Vec128<double, N> v) {
 template <class D>
 using MFromD = decltype(MaskFromVec(VFromD<D>()));
 
+// ------------------------------ MaskFalse (MFromD)
+
+#ifdef HWY_NATIVE_MASK_FALSE
+#undef HWY_NATIVE_MASK_FALSE
+#else
+#define HWY_NATIVE_MASK_FALSE
+#endif
+
+// Generic for all vector lengths
+template <class D>
+HWY_API MFromD<D> MaskFalse(D /*d*/) {
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(0)};
+}
+
 // ------------------------------ PromoteMaskTo (MFromD)
 
 #ifdef HWY_NATIVE_PROMOTE_MASK_TO

--- a/hwy/tests/mask_test.cc
+++ b/hwy/tests/mask_test.cc
@@ -28,6 +28,79 @@ namespace hwy {
 namespace HWY_NAMESPACE {
 
 // All types.
+struct TestMaskFalse {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || \
+    HWY_TARGET == HWY_SVE2_128 || HWY_TARGET == HWY_SCALAR
+    const DFromV<Vec<D>> d2;
+#else
+    constexpr size_t kMinD2Lanes =
+        ((HWY_TARGET == HWY_NEON || HWY_TARGET == HWY_NEON_WITHOUT_AES) ? 8
+                                                                        : 16) /
+        sizeof(T);
+    const FixedTag<T, HWY_MAX(HWY_MAX_LANES_D(D), kMinD2Lanes)> d2;
+#endif
+
+    static_assert(d2.MaxBytes() >= d.MaxBytes(),
+                  "d2.MaxBytes() >= d.MaxBytes() should be true");
+
+    const size_t N = Lanes(d);
+    const size_t N2 = Lanes(d2);
+    HWY_ASSERT(N2 >= N);
+
+    auto expected1 = AllocateAligned<T>(N);
+    auto expected2 = AllocateAligned<T>(N2);
+    auto actual1 = AllocateAligned<T>(N);
+    auto actual2 = AllocateAligned<T>(N2);
+    HWY_ASSERT(expected1 && expected2 && actual1 && actual2);
+
+    ZeroBytes(expected1.get(), sizeof(T) * N);
+    ZeroBytes(expected2.get(), sizeof(T) * N2);
+
+    memset(actual1.get(), 0xFF, sizeof(T) * N);
+    memset(actual2.get(), 0xFF, sizeof(T) * N2);
+
+    // If possible, use a compiler memory barrier to prevent the compiler from
+    // reordering the above ZeroBytes and memset operations with the Store
+    // operations below
+
+#if HWY_COMPILER_MSVC && !defined(HWY_NO_LIBCXX)
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+#elif HWY_COMPILER_GCC || HWY_COMPILER_CLANG
+    asm volatile("" ::: "memory");
+#endif
+
+    Store(VecFromMask(d, MaskFalse(d)), d, actual1.get());
+    HWY_ASSERT_ARRAY_EQ(expected1.get(), actual1.get(), N);
+
+    // All of the bits of MaskFalse(d) should be zero, including any bits past
+    // the first N lanes of MaskFalse(d)
+    Store(ResizeBitCast(d2, VecFromMask(d, MaskFalse(d))), d2, actual2.get());
+    HWY_ASSERT_ARRAY_EQ(expected2.get(), actual2.get(), N2);
+
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+    HWY_ASSERT_VEC_EQ(d2, expected2.get(), VecFromMask(d2, MaskFalse(d)));
+#endif
+
+    HWY_ASSERT(AllFalse(d, MaskFalse(d)));
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+    // Check that AllFalse(d2, MaskFalse(d)) is true on RVV/SVE targets
+    HWY_ASSERT(AllFalse(d2, MaskFalse(d)));
+#endif
+
+    HWY_ASSERT_EQ(0, CountTrue(d, MaskFalse(d)));
+#if HWY_HAVE_SCALABLE || HWY_TARGET == HWY_SVE_256 || HWY_TARGET == HWY_SVE2_128
+    // Check that CountTrue(d2, MaskFalse(d)) returns true on RVV/SVE targets
+    HWY_ASSERT_EQ(0, CountTrue(d2, MaskFalse(d)));
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllMaskFalse() {
+  ForAllTypes(ForPartialVectors<TestMaskFalse>());
+}
+
 struct TestFromVec {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -511,6 +584,7 @@ HWY_AFTER_NAMESPACE();
 
 namespace hwy {
 HWY_BEFORE_TEST(HwyMaskTest);
+HWY_EXPORT_AND_TEST_P(HwyMaskTest, TestAllMaskFalse);
 HWY_EXPORT_AND_TEST_P(HwyMaskTest, TestAllFromVec);
 HWY_EXPORT_AND_TEST_P(HwyMaskTest, TestAllFirstN);
 HWY_EXPORT_AND_TEST_P(HwyMaskTest, TestAllMaskVec);

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -210,18 +210,8 @@ HWY_INLINE Mask<D> MaskTrue(const D d) {
   return FirstN(d, Lanes(d));
 }
 
-// Defined in rvv-inl.h for slightly better codegen.
-#if HWY_TARGET != HWY_RVV
-
-template <class D>
-HWY_INLINE Mask<D> MaskFalse(const D d) {
-  // Signed comparisons are cheaper on x86.
-  const RebindToSigned<D> di;
-  const Vec<decltype(di)> zero = Zero(di);
-  return RebindMask(d, Lt(zero, zero));
-}
-
-#endif  // HWY_TARGET != HWY_RVV
+// MaskFalse is now implemented in x86_128-inl.h on AVX3, arm_sve-inl.h on SVE,
+// rvv-inl.h on RVV, and generic_ops-inl.h on all other targets
 
 #ifndef HWY_ASSERT_EQ
 


### PR DESCRIPTION
This pull request makes the `MaskFalse(d)` op available to non-test code on all targets.

Also reimplemented the `MaskFalse(d)` op on targets other than RVV.

Also added the TestAllMaskFalse test that checks that all of the bits of `MaskFalse(d)` are false, including any bits past the first `Lanes(d)` lanes of `MaskFalse(d)`.