### PR TITLE
Fixed PrintTargets in list_targets.cc

### DIFF
--- a/hwy/tests/list_targets.cc
+++ b/hwy/tests/list_targets.cc
@@ -22,8 +22,9 @@
 
 void PrintTargets(const char* msg, int64_t targets) {
   fprintf(stderr, "%s", msg);
-  // For each bit:
-  for (int64_t x = targets; x != 0; x = x & (x - 1)) {
+  // For each bit other than the sign bit:
+  for (int64_t x = targets & hwy::LimitsMax<int64_t>(); x != 0;
+       x = x & (x - 1)) {
     // Extract value of least-significant bit.
     fprintf(stderr, " %s", hwy::TargetName(x & (~x + 1)));
   }


### PR DESCRIPTION
Updated PrintTargets in list_targets.cc to avoid undefined behavior if the the parameter has the sign bit set as it is possible for HWY_BROKEN_TARGETS and HWY_DISABLED_TARGETS to have the sign bit set if the HWY_BROKEN_TARGETS or HWY_DISABLED_TARGETS macros are defined by the user prior to including hwy/highway.h.