### PR TITLE
Fixed PPC InsertLane

### DIFF
--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2104,7 +2104,7 @@ template <typename T, size_t N>
 HWY_API Vec128<T, N> InsertLane(Vec128<T, N> v, size_t i, T t) {
 #if HWY_IS_LITTLE_ENDIAN
   typename detail::Raw128<T>::type raw_result = v.raw;
-  hwy::CopySameSize(&t, &raw_result[i]);  // for bfloat16_t
+  raw_result[i] = BitCastScalar<typename detail::Raw128<T>::RawT>(t);
   return Vec128<T, N>{raw_result};
 #else
   // On ppc64be without this, mul_test fails, but swizzle_test passes.


### PR DESCRIPTION
Replaced hwy::CopySameSize with BitCastScalar in PPC InsertLane op to fix compilation error.