### PR TITLE
Fix for x86 _Float16 compilation errors with Clang 15

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -1011,8 +1011,8 @@ HWY_API HWY_BITCASTSCALAR_CONSTEXPR To BitCastScalar(const From& val) {
 
 // x86 compiler supports _Float16, not necessarily with operators.
 // Avoid clang-cl because it lacks __extendhfsf2.
-#if HWY_ARCH_X86 && defined(__SSE2__) &&                      \
-    ((HWY_COMPILER_CLANG >= 1500 && !HWY_COMPILER_CLANGCL) || \
+#if HWY_ARCH_X86 && defined(__SSE2__) && defined(__FLT16_MAX__) && \
+    ((HWY_COMPILER_CLANG >= 1500 && !HWY_COMPILER_CLANGCL) ||      \
      HWY_COMPILER_GCC_ACTUAL >= 1200)
 #define HWY_SSE2_HAVE_F16_TYPE 1
 #else

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -245,7 +245,8 @@
 
 #define HWY_HAVE_SCALABLE 0
 #define HWY_HAVE_INTEGER64 1
-#if HWY_TARGET == HWY_AVX3_SPR && HWY_COMPILER_GCC_ACTUAL
+#if HWY_TARGET == HWY_AVX3_SPR && HWY_COMPILER_GCC_ACTUAL && \
+    HWY_HAVE_SCALAR_F16_TYPE
 // TODO: enable F16 for AVX3_SPR target with Clang once compilation issues are
 // fixed
 #define HWY_HAVE_FLOAT16 1


### PR DESCRIPTION
This pull request fixes compilation errors on x86_64 with pre-release versions of Clang 15.

Support for _Float16 on SSE2/SSSE3/SSE4/AVX2 was added to Clang in LLVM revision [abeeae570efff38dceccf68f5352809c58ffdda2](https://github.com/llvm/llvm-project/commit/abeeae570efff38dceccf68f5352809c58ffdda2), which was integrated into the final Clang 15.0.0 release.

Both GCC and Clang define the `__FLT16_MAX__` macro if the `_Float16` type is available. The addition of the `defined(__FLT16_MAX__)` check in this pull request should prevent compilation errors with pre-release versions of Clang 15.