### PR TITLE
Fix FindUnit constructor in unroller_test.cc

### DIFF
--- a/hwy/contrib/unroller/unroller_test.cc
+++ b/hwy/contrib/unroller/unroller_test.cc
@@ -132,7 +132,7 @@ struct FindUnit : UnrollerUnit<FindUnit<T>, T, MakeSigned<T>> {
   using DI = RebindToSigned<D>;
   DI di;
 
-  FindUnit<T>(T find) : to_find(find) {}
+  FindUnit(T find) : to_find(find) {}
 
   hn::Vec<DI> Func(ptrdiff_t idx, const hn::Vec<D> x, const hn::Vec<DI> y) {
     const Mask<D> msk = hn::Eq(x, hn::Set(d, to_find));


### PR DESCRIPTION
Updated FindUnit constructor in unroller_test.cc, which fixes compilation errors with GCC 11 in C++20 mode.