### PR TITLE
Add bit_pack-inl.h to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,12 +107,13 @@ if (HWY_ENABLE_CONTRIB)
 # additional special cases.
 file(GLOB HWY_CONTRIB_SOURCES "hwy/contrib/sort/vqsort_*.cc")
 list(APPEND HWY_CONTRIB_SOURCES
+    hwy/contrib/bit_pack/bit_pack-inl.h
     hwy/contrib/dot/dot-inl.h
     hwy/contrib/image/image.cc
     hwy/contrib/image/image.h
     hwy/contrib/math/math-inl.h
     hwy/contrib/matvec/matvec-inl.h
-        hwy/contrib/random/random-inl.h
+    hwy/contrib/random/random-inl.h
     hwy/contrib/sort/order.h
     hwy/contrib/sort/shared-inl.h
     hwy/contrib/sort/sorting_networks-inl.h
@@ -615,6 +616,7 @@ if (HWY_ENABLE_CONTRIB)
 list(APPEND HWY_TEST_LIBS hwy_contrib)
 
 list(APPEND HWY_TEST_FILES
+  hwy/contrib/bit_pack/bit_pack_test.cc
   hwy/contrib/dot/dot_test.cc
   hwy/contrib/matvec/matvec_test.cc
   hwy/contrib/image/image_test.cc

--- a/hwy/contrib/bit_pack/bit_pack_test.cc
+++ b/hwy/contrib/bit_pack/bit_pack_test.cc
@@ -121,7 +121,8 @@ struct TestPack {
                  i += num_per_loop, pi += num_packed_per_loop) {
               func.Pack(d, raw.get() + i, packed.get() + pi);
             }
-            packed.get()[Random32(&rng) % num_packed] += static_cast<T>(Unpredictable1() - 1);
+            T& val = packed.get()[Random32(&rng) % num_packed];
+            val = static_cast<T>(val + Unpredictable1() - 1);
             for (size_t i = 0, pi = 0; i < num;
                  i += num_per_loop, pi += num_packed_per_loop) {
               func.Unpack(d, packed.get() + pi, raw2.get() + i);
@@ -148,7 +149,8 @@ struct TestPack {
            i += num_per_loop, pi += num_packed_per_loop) {
         func.Pack(d, raw.get() + i, packed.get() + pi);
       }
-      packed.get()[Random32(&rng) % num_packed] += static_cast<T>(Unpredictable1() - 1);
+      T& val = packed.get()[Random32(&rng) % num_packed];
+      val = static_cast<T>(val + Unpredictable1() - 1);
       for (size_t i = 0, pi = 0; i < num;
            i += num_per_loop, pi += num_packed_per_loop) {
         func.Unpack(d, packed.get() + pi, raw2.get() + i);

--- a/hwy/contrib/bit_pack/bit_pack_test.cc
+++ b/hwy/contrib/bit_pack/bit_pack_test.cc
@@ -121,7 +121,7 @@ struct TestPack {
                  i += num_per_loop, pi += num_packed_per_loop) {
               func.Pack(d, raw.get() + i, packed.get() + pi);
             }
-            packed.get()[Random32(&rng) % num_packed] += Unpredictable1() - 1;
+            packed.get()[Random32(&rng) % num_packed] += static_cast<T>(Unpredictable1() - 1);
             for (size_t i = 0, pi = 0; i < num;
                  i += num_per_loop, pi += num_packed_per_loop) {
               func.Unpack(d, packed.get() + pi, raw2.get() + i);
@@ -148,7 +148,7 @@ struct TestPack {
            i += num_per_loop, pi += num_packed_per_loop) {
         func.Pack(d, raw.get() + i, packed.get() + pi);
       }
-      packed.get()[Random32(&rng) % num_packed] += Unpredictable1() - 1;
+      packed.get()[Random32(&rng) % num_packed] += static_cast<T>(Unpredictable1() - 1);
       for (size_t i = 0, pi = 0; i < num;
            i += num_per_loop, pi += num_packed_per_loop) {
         func.Unpack(d, packed.get() + pi, raw2.get() + i);

--- a/hwy/contrib/bit_pack/bit_pack_test.cc
+++ b/hwy/contrib/bit_pack/bit_pack_test.cc
@@ -136,7 +136,7 @@ struct TestPack {
       // Print throughput for pack+unpack round trip
       for (size_t i = 0; i < num_results; ++i) {
         const size_t bytes_per_element = (kBits + 7) / 8;
-        const double bytes = results[i].input * bytes_per_element;
+        const double bytes = static_cast<double>(results[i].input * bytes_per_element);
         const double seconds =
             results[i].ticks / platform::InvariantTicksPerSecond();
         printf("Bits:%2d elements:%3d GB/s:%4.1f (+/-%3.1f%%)\n",


### PR DESCRIPTION
Add the corresponding test as well.
Test with `run_tests.bat`

Verify with `cmake --install . --prefix=install` in the build_win directory.

Fix warnings as errors for gcc and clang using explicit casts.

#2011 