### PR TITLE
Enable warnings as errors for cl.exe and clang-cl on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,24 @@ if (MSVC)
   set(HWY_FLAGS
     # fix build error C1128 in blockwise*_test & arithmetic_test
     /bigobj
+
+    # Warnings
+    /W4
+    # Disable some W4 warnings.  Enable them individually after they are cleaned up.
+    /wd4100
+    /wd4127
+    /wd4324
+    /wd4456
+    /wd4701
+    /wd4702
+    /wd4723
+
   )
+
+
+  if (HWY_WARNINGS_ARE_ERRORS)
+    list(APPEND HWY_FLAGS /WX)
+  endif()
 else()
   set(HWY_FLAGS
     # Avoid changing binaries based on the current time and date.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,29 @@ if (MSVC)
     -D_HAS_EXCEPTIONS=0
   )
 
+  # This adds extra warnings for the clang-cl compiler on Windows.
+  # This is the same as the sections in the else part.
+  # These could be refactored.
+  if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    list(APPEND HWY_FLAGS
+      # These are not included in Wall nor Wextra:
+      -Wconversion
+      -Wsign-conversion
+      -Wvla
+      -Wnon-virtual-dtor
+
+      -Wfloat-overflow-conversion
+      -Wfloat-zero-conversion
+      -Wfor-loop-analysis
+      -Wgnu-redeclared-enum
+      -Winfinite-recursion
+      -Wself-assign
+      -Wstring-conversion
+      -Wtautological-overlap-compare
+      -Wthread-safety-analysis
+      -Wundefined-func-template
+    )
+  endif()
 
   if (HWY_WARNINGS_ARE_ERRORS)
     list(APPEND HWY_FLAGS /WX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,11 @@ if (MSVC)
     /wd4702
     /wd4723
 
+    # CMake automatically adds exception handling flags.  Remove them.
+    /GR-
+    /EHs-c-
+    # Disable exceptions in STL code.
+    -D_HAS_EXCEPTIONS=0
   )
 
 


### PR DESCRIPTION
Some warnings were not detected when making changes on a Windows development machine.

These were detected later during the CI tests for the pull request.
These changes makes warnings easier to detect in the development process.

#2011 
