### PR TITLE
Mention in `README.md` that sometimes MSVC would generate VEX-encoded SSE, but not always

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ For MSVC, we recommend compiling with `/Gv` to allow non-inlined functions to
 pass vector arguments in registers. If intending to use the AVX2 target together
 with half-width vectors (e.g. for `PromoteTo`), it is also important to compile
 with `/arch:AVX2`. This seems to be the only way to reliably generate VEX-encoded
-SSE instructions on MSVC. Sometimes MSVC generates VEX-encided SSE instructions,
+SSE instructions on MSVC. Sometimes MSVC generates VEX-encoded SSE instructions,
 if they are mixed with AVX, but not always, see 
 [DevCom-10618264](https://developercommunity.visualstudio.com/t/10618264)
 Otherwise, mixing VEX-encoded AVX2 instructions and non-VEX SSE may cause severe 

--- a/README.md
+++ b/README.md
@@ -321,9 +321,12 @@ generally sufficient.
 For MSVC, we recommend compiling with `/Gv` to allow non-inlined functions to
 pass vector arguments in registers. If intending to use the AVX2 target together
 with half-width vectors (e.g. for `PromoteTo`), it is also important to compile
-with `/arch:AVX2`. This seems to be the only way to generate VEX-encoded SSE4
-instructions on MSVC. Otherwise, mixing VEX-encoded AVX2 instructions and
-non-VEX SSE4 may cause severe performance degradation. Unfortunately, the
+with `/arch:AVX2`. This seems to be the only way to reliably generate VEX-encoded
+SSE instructions on MSVC. Sometimes MSVC generates VEX-encided SSE instructions,
+if they are mixed with AVX, but not always, see 
+[DevCom-10618264](https://developercommunity.visualstudio.com/t/10618264)
+Otherwise, mixing VEX-encoded AVX2 instructions and non-VEX SSE may cause severe 
+performance degradation. Unfortunately, with `/arch:AVX2` option, the
 resulting binary will then require AVX2. Note that no such flag is needed for
 clang and GCC because they support target-specific attributes, which we use to
 ensure proper VEX code generation for AVX2 targets.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ with half-width vectors (e.g. for `PromoteTo`), it is also important to compile
 with `/arch:AVX2`. This seems to be the only way to reliably generate VEX-encoded
 SSE instructions on MSVC. Sometimes MSVC generates VEX-encoded SSE instructions,
 if they are mixed with AVX, but not always, see 
-[DevCom-10618264](https://developercommunity.visualstudio.com/t/10618264)
+[DevCom-10618264](https://developercommunity.visualstudio.com/t/10618264).
 Otherwise, mixing VEX-encoded AVX2 instructions and non-VEX SSE may cause severe 
 performance degradation. Unfortunately, with `/arch:AVX2` option, the
 resulting binary will then require AVX2. Note that no such flag is needed for


### PR DESCRIPTION
Resolves #2029