### PR TITLE
Fix for compilation error in matvec-inl.h with GCC 8 in C++17 mode

### DIFF
--- a/hwy/contrib/matvec/matvec-inl.h
+++ b/hwy/contrib/matvec/matvec-inl.h
@@ -41,6 +41,8 @@ HWY_NOINLINE void MatVecAddImpl(const T* HWY_RESTRICT mat,
                                 const T* HWY_RESTRICT vec,
                                 const T* HWY_RESTRICT add, T* HWY_RESTRICT out,
                                 hwy::ThreadPool& pool) {
+  (void)add;
+
   // Process multiple rows at a time so that we write multiples of a cache line
   // to avoid false sharing (>= 64). 128 is better than 256. 512 has too little
   // parallelization potential.


### PR DESCRIPTION
Added `(void)add` to MatVecAddImpl to work around a compilation warning with GCC 8 in C++17 mode if `kAdd` is false.