### PR TITLE
Added HWY_ASSERT after AllocateAligned in tests

### DIFF
--- a/hwy/aligned_allocator_test.cc
+++ b/hwy/aligned_allocator_test.cc
@@ -233,6 +233,7 @@ TEST(AlignedAllocatorTest, TestAllocateAlignedObjectWithoutDestructor) {
   {
     // This doesn't call the constructor.
     auto obj = AllocateAligned<SampleObject<24>>(1);
+    HWY_ASSERT(obj);
     obj[0].counter_ = &counter;
   }
   // Destroying the unique_ptr shouldn't have called the destructor of the

--- a/hwy/contrib/math/math_test.cc
+++ b/hwy/contrib/math/math_test.cc
@@ -338,7 +338,7 @@ void Atan2TestCases(T /*unused*/, D d, size_t& padded,
   out_y = AllocateAligned<T>(padded);
   out_x = AllocateAligned<T>(padded);
   out_expected = AllocateAligned<T>(padded);
-  HWY_ASSERT(out_y && out_x);
+  HWY_ASSERT(out_y && out_x && out_expected);
   size_t i = 0;
   for (; i < kNumTestCases; ++i) {
     out_y[i] = test_cases[i].y;

--- a/hwy/contrib/matvec/matvec_test.cc
+++ b/hwy/contrib/matvec/matvec_test.cc
@@ -154,10 +154,12 @@ class TestMatVec {
     Generate(dv, av, kRows, GenerateMod());
 
     AlignedFreeUniquePtr<T[]> expected_without_add = AllocateAligned<T>(kRows);
+    HWY_ASSERT(expected_without_add);
     SimpleMatVecAdd(pm, pv, static_cast<VecT*>(nullptr), kRows, kCols,
                     expected_without_add.get(), pool);
 
     AlignedFreeUniquePtr<T[]> actual_without_add = AllocateAligned<T>(kRows);
+    HWY_ASSERT(actual_without_add);
     MatVec<kRows, kCols>(pm, pv, actual_without_add.get(), pool);
 
     const auto assert_close = [&](const AlignedFreeUniquePtr<T[]>& expected,
@@ -226,14 +228,18 @@ class TestMatVec {
 void TestMatVecAdd() {
   ThreadPool pool(1);
   auto mat = AllocateAligned<float>(8);
+  HWY_ASSERT(mat);
   CopyBytes(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8}.data(), mat.get(),
             8 * sizeof(float));
   auto vec = AllocateAligned<float>(4);
+  HWY_ASSERT(vec);
   CopyBytes(std::vector<float>{1, 2, 3, 4}.data(), vec.get(),
             4 * sizeof(float));
   auto add = AllocateAligned<float>(2);
+  HWY_ASSERT(add);
   CopyBytes(std::vector<float>{1, 2}.data(), add.get(), 2 * sizeof(float));
   auto out = AllocateAligned<float>(2);
+  HWY_ASSERT(out);
   MatVecAdd<2, 4>(mat.get(), vec.get(), add.get(), out.get(), pool);
   HWY_ASSERT_EQ(out[0], 1 * 1 + 2 * 2 + 3 * 3 + 4 * 4 + 1);
   HWY_ASSERT_EQ(out[1], 5 * 1 + 6 * 2 + 7 * 3 + 8 * 4 + 2);

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -119,6 +119,7 @@ struct TestFloatInf {
     const size_t N = Lanes(d);
     const size_t num = N * 3;
     auto in = hwy::AllocateAligned<T>(num);
+    HWY_ASSERT(in);
     Fill(d, GetLane(Inf(d)), num, in.get());
     VQSort(in.get(), num, SortAscending());
     for (size_t i = 0; i < num; i += N) {
@@ -368,6 +369,7 @@ static HWY_NOINLINE void TestPartition() {
   // left + len + align
   const size_t total = 32 + (base_case_num + 4 * HWY_MAX(N, 4)) + 2 * N;
   auto aligned_lanes = hwy::AllocateAligned<LaneType>(total);
+  HWY_ASSERT(aligned_lanes);
   HWY_ALIGN LaneType buf[SortConstants::BufBytes<LaneType, N1>(HWY_MAX_BYTES) /
                          sizeof(LaneType)];
 
@@ -544,6 +546,7 @@ class CompareResults {
   CompareResults(const LaneType* in, size_t num_lanes) {
     copy_lanes_ = num_lanes;
     copy_ = hwy::AllocateAligned<LaneType>(num_lanes);
+    HWY_ASSERT(copy_);
     CopyBytes(in, copy_.get(), num_lanes * sizeof(LaneType));
   }
 

--- a/hwy/examples/skeleton_test.cc
+++ b/hwy/examples/skeleton_test.cc
@@ -89,6 +89,8 @@ struct TestSumMulAdd {
     auto mul = hwy::AllocateAligned<T>(count);
     auto x = hwy::AllocateAligned<T>(count);
     auto add = hwy::AllocateAligned<T>(count);
+    HWY_ASSERT(mul && x && add);
+
     for (size_t i = 0; i < count; ++i) {
       mul[i] = hwy::ConvertScalarTo<T>(Random32(&rng) & 0xF);
       x[i] = hwy::ConvertScalarTo<T>(Random32(&rng) & 0xFF);

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -360,6 +360,7 @@ struct TestIntegerAbsDiff {
     auto in_lanes_a = AllocateAligned<T>(N);
     auto in_lanes_b = AllocateAligned<T>(N);
     auto out_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(in_lanes_a && in_lanes_b && out_lanes);
     constexpr size_t shift_amt_mask = sizeof(T) * 8 - 1;
     for (size_t i = 0; i < N; ++i) {
       // Need to mask out shift_amt as i can be greater than or equal to

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -74,6 +74,7 @@ struct TestPromoteTo {
     const size_t N = Lanes(from_d);
     auto from = AllocateAligned<T>(N);
     auto expected = AllocateAligned<ToT>(N);
+    HWY_ASSERT(from && expected);
 
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
@@ -154,6 +155,7 @@ struct TestPromoteUpperLowerTo {
     const size_t N = Lanes(from_d);
     auto from = AllocateAligned<T>(N);
     auto expected = AllocateAligned<ToT>(N / 2);
+    HWY_ASSERT(from && expected);
 
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
@@ -279,6 +281,7 @@ struct TestPromoteOddEvenTo {
     HWY_ASSERT(N >= 2);
     auto from = AllocateAligned<T>(N);
     auto expected = AllocateAligned<ToT>(N / 2);
+    HWY_ASSERT(from && expected);
 
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
@@ -383,6 +386,7 @@ AlignedFreeUniquePtr<float[]> F16TestCases(D d, size_t& padded) {
   padded = RoundUpTo(kNumTestCases, N);  // allow loading whole vectors
   auto in = AllocateAligned<float>(padded);
   auto expected = AllocateAligned<float>(padded);
+  HWY_ASSERT(in && expected);
   size_t i = 0;
   for (; i < kNumTestCases; ++i) {
     // Ensure the value can be exactly represented as binary16.
@@ -411,6 +415,7 @@ struct TestF16 {
     const RebindToUnsigned<decltype(df16)> du16;
     // Extra Load/Store to ensure they are usable.
     auto temp16 = AllocateAligned<TF16>(N);
+    HWY_ASSERT(temp16);
 
     // Extra Zero/BitCast to ensure they are usable. Neg is tested in
     // arithmetic_test.
@@ -523,6 +528,7 @@ AlignedFreeUniquePtr<float[]> BF16TestCases(D d, size_t& padded) {
   padded = RoundUpTo(kNumTestCases, N);  // allow loading whole vectors
   auto in = AllocateAligned<float>(padded);
   auto expected = AllocateAligned<float>(padded);
+  HWY_ASSERT(in && expected);
   size_t i = 0;
   for (; i < kNumTestCases; ++i) {
     in[i] = test_cases[i];
@@ -549,6 +555,7 @@ struct TestBF16 {
 
     HWY_ASSERT(Lanes(dbf16_half) == N);
     auto temp16 = AllocateAligned<TBF16>(N);
+    HWY_ASSERT(temp16);
 
     for (size_t i = 0; i < padded; i += N) {
       const auto loaded = Load(d32, &in[i]);
@@ -608,6 +615,7 @@ struct TestIntFromFloatHuge {
     // the expected lvalue also seems to prevent the issue.
     const size_t N = Lanes(df);
     auto expected = AllocateAligned<TI>(N);
+    HWY_ASSERT(expected);
 
     // Huge positive
     Store(Set(di, LimitsMax<TI>()), di, expected.get());
@@ -654,6 +662,7 @@ class TestIntFromFloat {
     // Also check random values.
     auto from = AllocateAligned<TF>(N);
     auto expected = AllocateAligned<TI>(N);
+    HWY_ASSERT(from && expected);
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
       for (size_t i = 0; i < N; ++i) {
@@ -1258,6 +1267,7 @@ struct TestF2IPromoteUpperLowerTo {
     const size_t N = Lanes(from_d);
     auto from = AllocateAligned<T>(N);
     auto expected = AllocateAligned<ToT>(N / 2);
+    HWY_ASSERT(from && expected);
 
     using TU = MakeUnsigned<T>;
 

--- a/hwy/tests/count_test.cc
+++ b/hwy/tests/count_test.cc
@@ -77,6 +77,7 @@ struct TestLeadingZeroCount {
     size_t N = Lanes(d);
     auto data = AllocateAligned<T>(N);
     auto lzcnt = AllocateAligned<T>(N);
+    HWY_ASSERT(data && lzcnt);
 
     constexpr T kNumOfBitsInT = static_cast<T>(sizeof(T) * 8);
     for (size_t j = 0; j < N; j++) {
@@ -155,6 +156,7 @@ struct TestTrailingZeroCount {
     size_t N = Lanes(d);
     auto data = AllocateAligned<T>(N);
     auto tzcnt = AllocateAligned<T>(N);
+    HWY_ASSERT(data && tzcnt);
 
     constexpr T kNumOfBitsInT = static_cast<T>(sizeof(T) * 8);
     for (size_t j = 0; j < N; j++) {
@@ -228,6 +230,7 @@ class TestHighestSetBitIndex {
     size_t N = Lanes(d);
     auto data = AllocateAligned<T>(N);
     auto hsb_index = AllocateAligned<T>(N);
+    HWY_ASSERT(data && hsb_index);
 
     constexpr T kNumOfBitsInT = static_cast<T>(sizeof(T) * 8);
     constexpr T kMsbIdx = static_cast<T>(kNumOfBitsInT - 1);

--- a/hwy/tests/minmax_test.cc
+++ b/hwy/tests/minmax_test.cc
@@ -127,6 +127,7 @@ struct TestMinMax128 {
     auto b_lanes = AllocateAligned<T>(N);
     auto min_lanes = AllocateAligned<T>(N);
     auto max_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(a_lanes && b_lanes && min_lanes && max_lanes);
     RandomState rng;
 
     const V v00 = Zero(d);

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -77,6 +77,7 @@ struct TestSignedMul {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const size_t N = Lanes(d);
     auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
 
     const Vec<D> v0 = Zero(d);
     const Vec<D> v1 = Set(d, static_cast<T>(1));
@@ -157,6 +158,7 @@ struct TestMulHigh {
     const size_t N = Lanes(d);
     auto in_lanes = AllocateAligned<T>(N);
     auto expected_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(in_lanes && expected_lanes);
 
     const Vec<D> vi = Iota(d, 1);
     const Vec<D> vni = Iota(d, static_cast<T>(0ULL - static_cast<uint64_t>(N)));
@@ -207,6 +209,7 @@ struct TestMulFixedPoint15 {
     auto in1 = AllocateAligned<T>(N);
     auto in2 = AllocateAligned<T>(N);
     auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(in1 && in2 && expected);
 
     // Random inputs in each lane
     RandomState rng;
@@ -276,6 +279,7 @@ struct TestMulEven {
     const size_t N = Lanes(d);
     auto in_lanes = AllocateAligned<T>(N);
     auto expected = AllocateAligned<Wide>(Lanes(d2));
+    HWY_ASSERT(in_lanes && expected);
     for (size_t i = 0; i < N; i += 2) {
       in_lanes[i + 0] =
           ConvertScalarTo<T>(LimitsMax<T>() >> (i & kShiftAmtMask));
@@ -327,6 +331,7 @@ struct TestMulOdd {
     constexpr size_t kShiftAmtMask = sizeof(T) * 8 - 1;
     auto in_lanes = AllocateAligned<T>(N);
     auto expected = AllocateAligned<Wide>(Lanes(d2));
+    HWY_ASSERT(in_lanes && expected);
     for (size_t i = 0; i < N; i += 2) {
       in_lanes[i + 0] = 1;  // unused
       in_lanes[i + 1] =
@@ -371,6 +376,7 @@ struct TestMulEvenOdd64 {
     auto in2 = AllocateAligned<T>(N);
     auto expected_even = AllocateAligned<T>(N);
     auto expected_odd = AllocateAligned<T>(N);
+    HWY_ASSERT(in1 && in2 && expected_even && expected_odd);
 
     // Random inputs in each lane
     RandomState rng;
@@ -435,6 +441,7 @@ struct TestMulAdd {
 
     const size_t N = Lanes(d);
     auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
     HWY_ASSERT_VEC_EQ(d, k0, MulAdd(k0, k0, k0));
     HWY_ASSERT_VEC_EQ(d, v2, MulAdd(k0, v1, v2));
     HWY_ASSERT_VEC_EQ(d, v2, MulAdd(v1, k0, v2));
@@ -475,6 +482,7 @@ struct TestMulSub {
     const Vec<D> v2 = Iota(d, 2);
     const size_t N = Lanes(d);
     auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
 
     // Unlike RebindToSigned, we want to leave floating-point unchanged.
     // This allows Neg for unsigned types.

--- a/hwy/tests/reduction_test.cc
+++ b/hwy/tests/reduction_test.cc
@@ -105,6 +105,7 @@ struct TestMinOfLanes {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const size_t N = Lanes(d);
     auto in_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(in_lanes);
 
     // Lane i = bit i, higher lanes = 2 (not the minimum)
     T min = HighestValue<T>();
@@ -161,6 +162,7 @@ struct TestMaxOfLanes {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const size_t N = Lanes(d);
     auto in_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(in_lanes);
 
     T max = LowestValue<T>();
     // Avoid setting sign bit and cap at double precision
@@ -228,6 +230,7 @@ struct TestSumsOf2 {
 
     auto in_lanes = AllocateAligned<T>(N);
     auto sum_lanes = AllocateAligned<TW>(N / 2);
+    HWY_ASSERT(in_lanes && sum_lanes);
 
     for (size_t rep = 0; rep < 100; ++rep) {
       for (size_t i = 0; i < N; ++i) {
@@ -279,6 +282,7 @@ struct TestSumsOf4 {
 
     auto in_lanes = AllocateAligned<T>(N);
     auto sum_lanes = AllocateAligned<TW2>(N / 4);
+    HWY_ASSERT(in_lanes && sum_lanes);
 
     for (size_t rep = 0; rep < 100; ++rep) {
       for (size_t i = 0; i < N; ++i) {
@@ -321,6 +325,7 @@ struct TestSumsOf8 {
 
     auto in_lanes = AllocateAligned<T>(N);
     auto sum_lanes = AllocateAligned<TW>(N / 8);
+    HWY_ASSERT(in_lanes && sum_lanes);
 
     for (size_t rep = 0; rep < 100; ++rep) {
       for (size_t i = 0; i < N; ++i) {

--- a/hwy/tests/sums_abs_diff_test.cc
+++ b/hwy/tests/sums_abs_diff_test.cc
@@ -39,6 +39,7 @@ struct TestSumsOf8AbsDiff {
     auto in_lanes_a = AllocateAligned<T>(N);
     auto in_lanes_b = AllocateAligned<T>(N);
     auto sum_lanes = AllocateAligned<TW>(N / 8);
+    HWY_ASSERT(in_lanes_a && in_lanes_b && sum_lanes);
 
     for (size_t rep = 0; rep < 100; ++rep) {
       for (size_t i = 0; i < N; ++i) {

--- a/hwy/tests/test_util-inl.h
+++ b/hwy/tests/test_util-inl.h
@@ -121,6 +121,7 @@ HWY_INLINE void AssertVecEqual(D d, const T* expected, Vec<D> actual,
                                const char* filename, const int line) {
   const size_t N = Lanes(d);
   auto actual_lanes = AllocateAligned<T>(N);
+  HWY_ASSERT(actual_lanes);
   Store(actual, d, actual_lanes.get());
 
   const auto info = hwy::detail::MakeTypeInfo<T>();
@@ -137,6 +138,7 @@ HWY_INLINE void AssertVecEqual(D d, Vec<D> expected, Vec<D> actual,
   const size_t N = Lanes(d);
   auto expected_lanes = AllocateAligned<T>(N);
   auto actual_lanes = AllocateAligned<T>(N);
+  HWY_ASSERT(expected_lanes && actual_lanes);
   Store(expected, d, expected_lanes.get());
   Store(actual, d, actual_lanes.get());
 
@@ -169,6 +171,7 @@ HWY_NOINLINE void AssertMaskEqual(D d, VecArg<Mask<D>> a, VecArg<Mask<D>> b,
   const size_t N8 = Lanes(d8);
   auto bits_a = AllocateAligned<uint8_t>(HWY_MAX(size_t{8}, N8));
   auto bits_b = AllocateAligned<uint8_t>(size_t{HWY_MAX(8, N8)});
+  HWY_ASSERT(bits_a && bits_b);
   memset(bits_a.get(), 0, N8);
   memset(bits_b.get(), 0, N8);
   const size_t num_bytes_a = StoreMaskBits(d, a, bits_a.get());

--- a/hwy/tests/truncate_test.cc
+++ b/hwy/tests/truncate_test.cc
@@ -72,6 +72,7 @@ struct TestOrderedTruncate2To {
     const size_t twiceN = N * 2;
     auto from = AllocateAligned<T>(twiceN);
     auto expected = AllocateAligned<TN>(twiceN);
+    HWY_ASSERT(from && expected);
 
     const T max = LimitsMax<TN>();
 

--- a/hwy/tests/widen_mul_test.cc
+++ b/hwy/tests/widen_mul_test.cc
@@ -49,6 +49,7 @@ struct TestWidenMulPairwiseAdd {
 
     // delta[p] := p all others zero.
     auto delta_w = AllocateAligned<TW>(NN);
+    HWY_ASSERT(delta_w);
     for (size_t p = 0; p < NN; ++p) {
       // Workaround for incorrect Clang wasm codegen: re-initialize the entire
       // array rather than zero-initialize once and then set lane p to p.
@@ -302,6 +303,7 @@ struct TestReorderWidenMulAccumulate {
 
     // delta[p] := 1, all others zero. For each p: Dot(delta, all-ones) == 1.
     auto delta_w = AllocateAligned<TW>(NN);
+    HWY_ASSERT(delta_w);
     for (size_t p = 0; p < NN; ++p) {
       // Workaround for incorrect Clang wasm codegen: re-initialize the entire
       // array rather than zero-initialize once and then toggle lane p.
@@ -358,6 +360,7 @@ struct TestRearrangeToOddPlusEven {
     const size_t NW = Lanes(dw);
 
     const auto expected = AllocateAligned<TW>(NW);
+    HWY_ASSERT(expected);
     for (size_t iw = 0; iw < NW; ++iw) {
       const size_t in = iw * 2;  // even, odd is +1
       const size_t a0 = 1 + in;


### PR DESCRIPTION
Added HWY_ASSERT checks after AllocateAligned that were previously missing in tests to ensure allocation was successful.