### PR TITLE
Reimplemented AddSub and MulAddSub on SVE/SVE2

### DIFF
--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -782,10 +782,11 @@ HWY_API V AddSub(V a, V b) {
 
 // AddSub for F32x8 and F64x4 vectors is implemented in x86_256-inl.h on
 // AVX2/AVX3
-template <class V, HWY_IF_V_SIZE_GT_V(V, ((HWY_TARGET <= HWY_SSSE3 &&
-                                           hwy::IsFloat3264<TFromV<V>>())
-                                              ? 32
-                                              : sizeof(TFromV<V>)))>
+
+// AddSub for F16/F32/F64 vectors on SVE is implemented in arm_sve-inl.h
+
+// AddSub for integer vectors on SVE2 is implemented in arm_sve-inl.h
+template <class V, HWY_IF_ADDSUB_V(V)>
 HWY_API V AddSub(V a, V b) {
   using D = DFromV<decltype(a)>;
   using T = TFromD<D>;
@@ -4432,12 +4433,11 @@ HWY_API V MulAddSub(V mul, V x, V sub_or_add) {
 // MulAddSub for F16/F32/F64 vectors with 2 or more lanes on
 // SSSE3/SSE4/AVX2/AVX3 is implemented in x86_128-inl.h, x86_256-inl.h, and
 // x86_512-inl.h
-template <class V, HWY_IF_LANES_GT_D(DFromV<V>, 1),
-          HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | ((HWY_TARGET <= HWY_SSSE3 &&
-                                                 hwy::IsFloat<TFromV<V>>())
-                                                    ? 0
-                                                    : ((1 << 2) | (1 << 4) |
-                                                       (1 << 8))))>
+
+// MulAddSub for F16/F32/F64 vectors on SVE is implemented in arm_sve-inl.h
+
+// MulAddSub for integer vectors on SVE2 is implemented in arm_sve-inl.h
+template <class V, HWY_IF_MULADDSUB_V(V)>
 HWY_API V MulAddSub(V mul, V x, V sub_or_add) {
   using D = DFromV<V>;
   using T = TFromD<D>;

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -650,6 +650,12 @@ HWY_API bool IsAligned(D d, T* ptr) {
 #undef HWY_IF_MINMAX_OF_LANES_D
 #define HWY_IF_MINMAX_OF_LANES_D(D) HWY_IF_LANES_GT_D(D, 1)
 
+#undef HWY_IF_ADDSUB_V
+#define HWY_IF_ADDSUB_V(V) HWY_IF_LANES_GT_D(DFromV<V>, 1)
+
+#undef HWY_IF_MULADDSUB_V
+#define HWY_IF_MULADDSUB_V(V) HWY_IF_LANES_GT_D(DFromV<V>, 1)
+
 // HWY_IF_U2I_DEMOTE_FROM_LANE_SIZE_V is used to disable the default
 // implementation of unsigned to signed DemoteTo/ReorderDemote2To in
 // generic_ops-inl.h for at least some of the unsigned to signed demotions on

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -3796,6 +3796,12 @@ HWY_API Vec128<double, N> operator-(const Vec128<double, N> a,
 // ------------------------------ AddSub
 
 #if HWY_TARGET <= HWY_SSSE3
+
+#undef HWY_IF_ADDSUB_V
+#define HWY_IF_ADDSUB_V(V) \
+  HWY_IF_V_SIZE_GT_V(      \
+      V, ((hwy::IsFloat3264<TFromV<V>>()) ? 32 : sizeof(TFromV<V>)))
+
 template <size_t N, HWY_IF_LANES_GT(N, 1)>
 HWY_API Vec128<float, N> AddSub(Vec128<float, N> a, Vec128<float, N> b) {
   return Vec128<float, N>{_mm_addsub_ps(a.raw, b.raw)};
@@ -5415,6 +5421,14 @@ HWY_API Vec128<double, N> NegMulSub(Vec128<double, N> mul, Vec128<double, N> x,
 }
 
 #if HWY_TARGET <= HWY_SSSE3
+
+#undef HWY_IF_MULADDSUB_V
+#define HWY_IF_MULADDSUB_V(V)                        \
+  HWY_IF_LANES_GT_D(DFromV<V>, 1),                   \
+      HWY_IF_T_SIZE_ONE_OF_V(                        \
+          V, (1 << 1) | ((hwy::IsFloat<TFromV<V>>()) \
+                             ? 0                     \
+                             : ((1 << 2) | (1 << 4) | (1 << 8))))
 
 #if HWY_HAVE_FLOAT16
 template <size_t N, HWY_IF_LANES_GT(N, 1)>


### PR DESCRIPTION
SVE has instructions that can do the `AddSub(a, Reverse2(DFromV<decltype(b)>(), b))` op for floating-point vectors.

SVE2 also has instructions that can do the  `AddSub(a, Reverse2(DFromV<decltype(b)>(), b))` op for integer vectors.

This pull request re-implements F16/F32/F64 AddSub on SVE using `svcadd_f*_x(HWY_SVE_PTRUE(BITS), a, Reverse2(d, b), 90)` and re-implements integer AddSub on SVE2 using `svcadd_s*(a, Reverse2(d, b), 90)` and `svcadd_u*(a, Reverse2(d, b), 90)`.

Also reimplemented F16/F32/F64 MulAddSub on SVE to negate the even lanes of `sub_or_add` using `AddSub(Set(d, neg_zero), sub_or_add)`, where `neg_zero` is equal to `ConvertScalarTo<T>(-0.0f)`. Negating the even lanes of `sub_or_add` using `-0.0 - sub_or_add[i]` ensures that positive zero values in even lanes are negated to `-0.0`, and adding `-0.0` to the even lanes of `sub_or_add` ensures that any odd lanes of `sub_or_add[i]` that are equal to `-0.0` are unchanged.

Also reimplemented integer MulAddSub on SVE2 to negate the even lanes of `sub_or_add` using `AddSub(Zero(d), sub_or_add)`.