### PR TITLE
Fix build error about variable 'third' is uninitialized when used here

### DIFF
--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -1774,7 +1774,7 @@ HWY_NOINLINE void Recurse(D d, Traits st, T* HWY_RESTRICT keys,
     MaybePrintVector(d, "pivot", pivot, 0, st.LanesPerKey());
     MaybePrintVector(d, "second", second, 0, st.LanesPerKey());
 
-    Vec<D> third;
+    Vec<D> third = Zero(d);
     // Not supported for key-value types because two 'keys' may be equivalent
     // but not interchangeable (their values may differ).
     if (HWY_UNLIKELY(!st.IsKV() &&

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -555,7 +555,7 @@
 #define HWY_HAVE_RUNTIME_DISPATCH 1
 // On Arm/PPC, GCC and Clang 16+ do, and we require Linux to detect CPU
 // capabilities. Currently require opt-in for Clang because it is experimental.
-#elif (HWY_ARCH_ARM || HWY_ARCH_PPC || HWY_ARCH_S390X) &&                    \
+#elif (HWY_ARCH_ARM || HWY_ARCH_PPC || HWY_ARCH_S390X || HWY_ARCH_RVV) &&  \
     (HWY_COMPILER_GCC_ACTUAL || (HWY_COMPILER_CLANG >= 1600 &&               \
                                  defined(HWY_ENABLE_CLANG_ARM_DISPATCH))) && \
     HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -502,6 +502,17 @@ int64_t DetectTargets() {
   return bits;
 }
 }  // namespace s390x
+#elif HWY_ARCH_RVV && HWY_HAVE_RUNTIME_DISPATCH
+namespace riscv {
+int64_t DetectTargets() {
+  int64_t bits = 0;               // return value of supported targets.
+  int32_t misa;
+  //Read the ISA supported by the hart from misa CSR
+  __asm__ volatile("csrr %0, misa" : "=r" (misa));
+  if(misa & (0x1 << 21)) bits |= HWY_RVV;
+  return bits;
+}
+}  // namespace riscv
 #endif  // HWY_ARCH_X86
 
 // Returns targets supported by the CPU, independently of DisableTargets.
@@ -520,7 +531,8 @@ int64_t DetectTargets() {
   bits |= ppc::DetectTargets();
 #elif HWY_ARCH_S390X && HWY_HAVE_RUNTIME_DISPATCH
   bits |= s390x::DetectTargets();
-
+#elif HWY_ARCH_RVV && HWY_HAVE_RUNTIME_DISPATCH
+  bits |= riscv::DetectTargets();
 #else
   // TODO(janwas): detect support for WASM/RVV.
   // This file is typically compiled without HWY_IS_TEST, but targets_test has


### PR DESCRIPTION
toolchain version
```
luyahan@plct-c7:~/source/highway$ clang -v
clang version 17.0.2 (https://github.com/llvm/llvm-project.git b2417f51dbbd7435eb3aaf203de24de6754da50e)
Target: riscv64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/luyahan/toolchain/llvm/bin
Found candidate GCC installation: /home/luyahan/toolchain/llvm/bin/../lib/gcc/riscv64-unknown-linux-gnu/13.2.0
Selected GCC installation: /home/luyahan/toolchain/llvm/bin/../lib/gcc/riscv64-unknown-linux-gnu/13.2.0
```