### PR TITLE
Fixed CallSinCos compilation error on Arm

### DIFF
--- a/hwy/contrib/math/math-inl.h
+++ b/hwy/contrib/math/math-inl.h
@@ -331,8 +331,7 @@ HWY_NOINLINE V CallTanh(const D d, VecArg<V> x) {
 template <class D, class V>
 HWY_INLINE void SinCos(D d, V x, V& s, V& c);
 template <class D, class V>
-HWY_NOINLINE void CallSinCos(const D d, VecArg<V> x, VecArg<V>& s,
-                             VecArg<V>& c) {
+HWY_NOINLINE void CallSinCos(const D d, VecArg<V> x, V& s, V& c) {
   SinCos(d, x, s, c);
 }
 


### PR DESCRIPTION
Fixed compilation error with CallSinCos on Arm by replacing `VecArg<V>&` with `V&` since `VecArg<V>&` is a typedef for `const V&` on some platforms.