### PR TITLE
Added Hypot op

### DIFF
--- a/hwy/contrib/math/math-inl.h
+++ b/hwy/contrib/math/math-inl.h
@@ -336,6 +336,21 @@ HWY_NOINLINE void CallSinCos(const D d, VecArg<V> x, VecArg<V>& s,
   SinCos(d, x, s, c);
 }
 
+/**
+ * Highway SIMD version of Hypot
+ *
+ * Valid Lane Types: float32, float64
+ *        Max Error: ULP = 4
+ *      Valid Range: float32[-FLT_MAX, +FLT_MAX], float64[-DBL_MAX, +DBL_MAX]
+ * @return hypotenuse of a and b
+ */
+template <class D, class V>
+HWY_INLINE V Hypot(D d, V a, V b);
+template <class D, class V>
+HWY_NOINLINE V CallHypot(const D d, VecArg<V> a, VecArg<V> b) {
+  return Hypot(d, a, b);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation
 ////////////////////////////////////////////////////////////////////////////////
@@ -1543,6 +1558,128 @@ HWY_INLINE void SinCos(const D d, V x, V& s, V& c) {
   using T = TFromD<D>;
   impl::SinCosImpl<T> impl;
   impl.SinCos(d, x, s, c);
+}
+
+template <class D, class V>
+HWY_INLINE V Hypot(const D d, V a, V b) {
+  using T = TFromD<D>;
+  using TI = MakeSigned<T>;
+  const RebindToUnsigned<decltype(d)> du;
+  const RebindToSigned<decltype(d)> di;
+
+  constexpr int kMaxBiasedExp = static_cast<int>(MaxExponentField<T>());
+  static_assert(kMaxBiasedExp > 0, "kMaxBiasedExp > 0 must be true");
+
+  constexpr int kNumOfMantBits = MantissaBits<T>();
+  static_assert(kNumOfMantBits > 0, "kNumOfMantBits > 0 must be true");
+
+  constexpr int kExpBias = kMaxBiasedExp / 2;
+
+  static_assert(
+      static_cast<unsigned>(kExpBias) + static_cast<unsigned>(kNumOfMantBits) <
+          static_cast<unsigned>(kMaxBiasedExp),
+      "kExpBias + kNumOfMantBits < kMaxBiasedExp must be true");
+
+  // kMinValToSquareBiasedExp is the smallest biased exponent such that
+  // pow(pow(2, kMinValToSquareBiasedExp - kExpBias) * x, 2) is either a normal
+  // floating-point value or infinity if x is a non-zero, non-NaN value
+  constexpr int kMinValToSquareBiasedExp = (kExpBias / 2) + kNumOfMantBits;
+  static_assert(kMinValToSquareBiasedExp < kExpBias,
+                "kMinValToSquareBiasedExp < kExpBias must be true");
+
+  // kMaxValToSquareBiasedExp is the largest biased exponent such that
+  // pow(pow(2, kMaxValToSquareBiasedExp - kExpBias) * x, 2) * 2 is guaranteed
+  // to be a finite value if x is a finite value
+  constexpr int kMaxValToSquareBiasedExp = kExpBias + ((kExpBias / 2) - 1);
+  static_assert(kMaxValToSquareBiasedExp > kExpBias,
+                "kMaxValToSquareBiasedExp > kExpBias must be true");
+  static_assert(kMaxValToSquareBiasedExp < kMaxBiasedExp,
+                "kMaxValToSquareBiasedExp < kMaxBiasedExp must be true");
+
+#if HWY_TARGET == HWY_SCALAR || HWY_TARGET == HWY_EMU128 || \
+    HWY_TARGET == HWY_Z14 || HWY_TARGET == HWY_Z15
+  using TExpSatSub = MakeUnsigned<T>;
+  using TExpMinMax = TI;
+#else
+  using TExpSatSub = uint16_t;
+  using TExpMinMax = int16_t;
+#endif
+
+  const Repartition<TExpSatSub, decltype(d)> d_exp_sat_sub;
+  const Repartition<TExpMinMax, decltype(d)> d_exp_min_max;
+
+  const V abs_a = Abs(a);
+  const V abs_b = Abs(b);
+
+  const auto zero = Zero(di);
+
+  // exp_a[i] is the biased exponent of abs_a[i]
+  const auto exp_a =
+      BitCast(di, ShiftRight<kNumOfMantBits>(BitCast(du, abs_a)));
+
+  // exp_b[i] is the biased exponent of abs_b[i]
+  const auto exp_b =
+      BitCast(di, ShiftRight<kNumOfMantBits>(BitCast(du, abs_b)));
+
+  // max_exp[i] is equal to HWY_MAX(exp_a[i], exp_b[i])
+
+  // If abs_a[i] and abs_b[i] are both NaN values, max_exp[i] will be equal to
+  // the biased exponent of the larger value. Otherwise, if either abs_a[i] or
+  // abs_b[i] is NaN, max_exp[i] will be equal to kMaxBiasedExp.
+  const auto max_exp = BitCast(
+      di, Max(BitCast(d_exp_min_max, exp_a), BitCast(d_exp_min_max, exp_b)));
+
+  // If either abs_a[i] or abs_b[i] is zero, min_exp[i] is equal to max_exp[i].
+  // Otherwise, if abs_a[i] and abs_b[i] are both nonzero, min_exp[i] is equal
+  // to HWY_MIN(exp_a[i], exp_b[i]).
+  const auto min_exp = IfThenElse(
+      Or(Eq(BitCast(di, abs_a), zero), Eq(BitCast(di, abs_b), zero)), max_exp,
+      BitCast(di, Min(BitCast(d_exp_min_max, exp_a),
+                      BitCast(d_exp_min_max, exp_b))));
+
+  // scl_pow2[i] is the power of 2 to scale abs_a[i] and abs_b[i] by
+
+  // abs_a[i] and abs_b[i] should be scaled by a factor that is greater than
+  // zero but less than or equal to
+  // pow(2, kMaxValToSquareBiasedExp - max_exp[i]) to ensure that that the
+  // multiplications or addition operations do not overflow if
+  // std::hypot(abs_a[i], abs_b[i]) is finite
+
+  // If either abs_a[i] or abs_b[i] is a a positive value that is less than
+  // pow(2, kMinValToSquareBiasedExp - kExpBias), then scaling up abs_a[i] and
+  // abs_b[i] by pow(2, kMinValToSquareBiasedExp - min_exp[i]) will ensure that
+  // the multiplications and additions result in normal floating point values,
+  // infinities, or NaNs.
+
+  // If HWY_MAX(kMinValToSquareBiasedExp - min_exp[i], 0) is greater than
+  // kMaxValToSquareBiasedExp - max_exp[i], scale abs_a[i] and abs_b[i] up by
+  // pow(2, kMaxValToSquareBiasedExp - max_exp[i]) to ensure that the
+  // multiplication and addition operations result in a finite result if
+  // std::hypot(abs_a[i], abs_b[i]) is finite.
+
+  const auto scl_pow2 = BitCast(
+      di,
+      Min(BitCast(d_exp_min_max,
+                  SaturatedSub(BitCast(d_exp_sat_sub,
+                                       Set(di, static_cast<TI>(
+                                                   kMinValToSquareBiasedExp))),
+                               BitCast(d_exp_sat_sub, min_exp))),
+          BitCast(d_exp_min_max,
+                  Sub(Set(di, static_cast<TI>(kMaxValToSquareBiasedExp)),
+                      max_exp))));
+
+  const auto exp_bias = Set(di, static_cast<TI>(kExpBias));
+
+  const auto ab_scl_factor =
+      BitCast(d, ShiftLeft<kNumOfMantBits>(Add(exp_bias, scl_pow2)));
+  const auto hypot_scl_factor =
+      BitCast(d, ShiftLeft<kNumOfMantBits>(Sub(exp_bias, scl_pow2)));
+
+  const auto scl_a = Mul(abs_a, ab_scl_factor);
+  const auto scl_b = Mul(abs_b, ab_scl_factor);
+
+  const auto scl_hypot = Sqrt(MulAdd(scl_a, scl_a, Mul(scl_b, scl_b)));
+  return Mul(scl_hypot, hypot_scl_factor);
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)

--- a/hwy/contrib/math/math_test.cc
+++ b/hwy/contrib/math/math_test.cc
@@ -502,6 +502,17 @@ void HypotTestCases(T /*unused*/, D d, size_t& padded,
   for (; i < kNumTestCases; ++i) {
     const T a = test_cases[i].a;
     const T b = test_cases[i].b;
+
+#if HWY_TARGET <= HWY_NEON_WITHOUT_AES && HWY_ARCH_ARM_V7
+    // Ignore test cases that have infinite or NaN inputs on Armv7 NEON
+    if (!ScalarIsFinite(a) || !ScalarIsFinite(b)) {
+      out_a[i] = p0;
+      out_b[i] = p0;
+      out_expected[i] = p0;
+      continue;
+    }
+#endif
+
     out_a[i] = a;
     out_b[i] = b;
 

--- a/hwy/contrib/math/math_test.cc
+++ b/hwy/contrib/math/math_test.cc
@@ -405,6 +405,194 @@ HWY_NOINLINE void TestAllAtan2() {
   ForFloat3264Types(ForPartialVectors<TestAtan2>());
 }
 
+template <typename T, class D>
+void HypotTestCases(T /*unused*/, D d, size_t& padded,
+                    AlignedFreeUniquePtr<T[]>& out_a,
+                    AlignedFreeUniquePtr<T[]>& out_b,
+                    AlignedFreeUniquePtr<T[]>& out_expected) {
+  using TU = MakeUnsigned<T>;
+
+  struct AB {
+    T a;
+    T b;
+  };
+
+  constexpr int kNumOfMantBits = MantissaBits<T>();
+  static_assert(kNumOfMantBits > 0, "kNumOfMantBits > 0 must be true");
+
+  const T pos = ConvertScalarTo<T>(1E5);
+  const T neg = ConvertScalarTo<T>(-1E7);
+  const T p0 = ConvertScalarTo<T>(0);
+  // -0 is not enough to get an actual negative zero.
+  const T n0 = ConvertScalarTo<T>(-0.0);
+  const T p1 = ConvertScalarTo<T>(1);
+  const T n1 = ConvertScalarTo<T>(-1);
+  const T p2 = ConvertScalarTo<T>(2);
+  const T n2 = ConvertScalarTo<T>(-2);
+  const T inf = BitCastScalar<T>(ExponentMask<T>());
+  const T neg_inf = ScalarCopySign(inf, n1);
+  const T nan = BitCastScalar<T>(
+      static_cast<TU>(ExponentMask<T>() | (TU{1} << (kNumOfMantBits - 1))));
+
+  const T max = HighestValue<T>();
+
+  const T huge =
+      ConvertScalarTo<T>(ConvertScalarTo<double>(HighestValue<T>()) * 0.25);
+  const T neg_huge = ScalarCopySign(huge, n1);
+
+  const T huge2 = ConvertScalarTo<T>(
+      ConvertScalarTo<double>(HighestValue<T>()) * 0.039415044328304796);
+
+  const T large = ConvertScalarTo<T>(3.512227595593985E18);
+  const T neg_large = ScalarCopySign(large, n1);
+  const T large2 = ConvertScalarTo<T>(2.1190576943127544E16);
+
+  const T small = ConvertScalarTo<T>(1.067033284841808E-11);
+  const T neg_small = ScalarCopySign(small, n1);
+  const T small2 = ConvertScalarTo<T>(1.9401409532292856E-12);
+
+  const T tiny = BitCastScalar<T>(static_cast<TU>(TU{1} << kNumOfMantBits));
+  const T neg_tiny = ScalarCopySign(tiny, n1);
+
+  const T tiny2 =
+      ConvertScalarTo<T>(78.68466968859765 * ConvertScalarTo<double>(tiny));
+
+  const AB test_cases[] = {{p0, p0},          {p0, n0},
+                           {n0, n0},          {p1, p1},
+                           {p1, n1},          {n1, n1},
+                           {p2, p2},          {p2, n2},
+                           {p2, pos},         {p2, neg},
+                           {n2, pos},         {n2, neg},
+                           {n2, n2},          {p0, tiny},
+                           {p0, neg_tiny},    {n0, tiny},
+                           {n0, neg_tiny},    {p1, tiny},
+                           {p1, neg_tiny},    {n1, tiny},
+                           {n1, neg_tiny},    {tiny, p0},
+                           {tiny2, p0},       {tiny, tiny2},
+                           {neg_tiny, tiny2}, {huge, huge2},
+                           {neg_huge, huge2}, {huge, p0},
+                           {huge, tiny},      {huge2, tiny2},
+                           {large, p0},       {large, large2},
+                           {neg_large, p0},   {neg_large, large2},
+                           {small, p0},       {small, small2},
+                           {neg_small, p0},   {neg_small, small2},
+                           {max, p0},         {max, huge},
+                           {max, max},        {p0, inf},
+                           {n0, inf},         {p1, inf},
+                           {n1, inf},         {p2, inf},
+                           {n2, inf},         {p0, neg_inf},
+                           {n0, neg_inf},     {p1, neg_inf},
+                           {n1, neg_inf},     {p2, neg_inf},
+                           {n2, neg_inf},     {p0, nan},
+                           {n0, nan},         {p1, nan},
+                           {n1, nan},         {p2, nan},
+                           {n2, nan},         {huge, inf},
+                           {inf, nan},        {neg_inf, nan},
+                           {nan, nan}};
+
+  const size_t kNumTestCases = sizeof(test_cases) / sizeof(test_cases[0]);
+  const size_t N = Lanes(d);
+  padded = RoundUpTo(kNumTestCases, N);  // allow loading whole vectors
+  out_a = AllocateAligned<T>(padded);
+  out_b = AllocateAligned<T>(padded);
+  out_expected = AllocateAligned<T>(padded);
+  HWY_ASSERT(out_a && out_b && out_expected);
+
+  size_t i = 0;
+  for (; i < kNumTestCases; ++i) {
+    const T a = test_cases[i].a;
+    const T b = test_cases[i].b;
+    out_a[i] = a;
+    out_b[i] = b;
+
+    if (ScalarIsNaN(a)) {
+      out_expected[i] = a;
+    } else if (ScalarIsNaN(b)) {
+      out_expected[i] = b;
+    } else {
+      out_expected[i] = std::hypot(a, b);
+    }
+  }
+  for (; i < padded; ++i) {
+    out_a[i] = p0;
+    out_b[i] = p0;
+    out_expected[i] = p0;
+  }
+}
+
+struct TestHypot {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T t, D d) {
+    if (HWY_MATH_TEST_EXCESS_PRECISION) {
+      return;
+    }
+
+    const size_t N = Lanes(d);
+
+    constexpr uint64_t kMaxErrorUlp = 4;
+
+    size_t padded;
+    AlignedFreeUniquePtr<T[]> in_a, in_b, expected;
+    HypotTestCases(t, d, padded, in_a, in_b, expected);
+
+    auto actual1_lanes = AllocateAligned<T>(N);
+    auto actual2_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(actual1_lanes && actual2_lanes);
+
+    uint64_t max_ulp = 0;
+    for (size_t i = 0; i < padded; i += N) {
+      const auto a = Load(d, in_a.get() + i);
+      const auto b = Load(d, in_b.get() + i);
+
+      const auto actual1 = CallHypot(d, a, b);
+      const auto actual2 = CallHypot(d, b, a);
+
+      Store(actual1, d, actual1_lanes.get());
+      Store(actual2, d, actual2_lanes.get());
+
+      for (size_t j = 0; j < N; j++) {
+        const T val_a = in_a[i + j];
+        const T val_b = in_b[i + j];
+        const T expected_val = expected[i + j];
+        const T actual1_val = actual1_lanes[j];
+        const T actual2_val = actual2_lanes[j];
+
+        const auto ulp1 =
+            hwy::detail::ComputeUlpDelta(actual1_val, expected_val);
+        if (ulp1 > kMaxErrorUlp) {
+          fprintf(stderr,
+                  "%s: Hypot(%f, %f) expected %E actual %E ulp %g max ulp %u\n",
+                  hwy::TypeName(T(), Lanes(d)).c_str(), val_a, val_b,
+                  expected_val, actual1_val, static_cast<double>(ulp1),
+                  static_cast<uint32_t>(kMaxErrorUlp));
+        }
+
+        const auto ulp2 =
+            hwy::detail::ComputeUlpDelta(actual2_val, expected_val);
+        if (ulp2 > kMaxErrorUlp) {
+          fprintf(stderr,
+                  "%s: Hypot(%f, %f) expected %E actual %E ulp %g max ulp %u\n",
+                  hwy::TypeName(T(), Lanes(d)).c_str(), val_b, val_a,
+                  expected_val, actual2_val, static_cast<double>(ulp2),
+                  static_cast<uint32_t>(kMaxErrorUlp));
+        }
+
+        max_ulp = HWY_MAX(max_ulp, HWY_MAX(ulp1, ulp2));
+      }
+    }
+
+    fprintf(stderr, "%s: Hypot max_ulp %g\n",
+            hwy::TypeName(T(), Lanes(d)).c_str(), static_cast<double>(max_ulp));
+    HWY_ASSERT(max_ulp <= kMaxErrorUlp);
+  }
+};
+
+HWY_NOINLINE void TestAllHypot() {
+  if (HWY_MATH_TEST_EXCESS_PRECISION) return;
+
+  ForFloat3264Types(ForPartialVectors<TestHypot>());
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -433,6 +621,7 @@ HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllTanh);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllAtan2);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllSinCosSin);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllSinCosCos);
+HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllHypot);
 HWY_AFTER_TEST();
 }  // namespace hwy
 


### PR DESCRIPTION
Added Hypot op to math-inl.h.

`Hypot(d, a, b)` returns the same result as `std::hypot(a[i], b[i])` if `a[i]` and `b[i]` are both non-NaN values, and `Hypot(d, a, b)` returns NaN if either `a[i]` or `b[i]` is NaN.

`Hypot(d, a, b)` is equivalent to `Sqrt(MulAdd(a, a, Mul(b, b)))`, but `Hypot(d, a, b)` will scale both `a[i]` and `b[i]` down prior to the multiplications if necessary to ensure that the multiplication ops result in finite values if `a[i]` and `b[i]` are both finite values.