### PR TITLE
Updated SSE2/SSSE3 Trunc/Ceil/Floor to use ConvertInRangeTo

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -11170,7 +11170,7 @@ HWY_API Vec128<T, N> Trunc(const Vec128<T, N> v) {
   const DFromV<decltype(v)> df;
   const RebindToSigned<decltype(df)> di;
 
-  const auto integer = ConvertTo(di, v);  // round toward 0
+  const auto integer = ConvertInRangeTo(di, v);  // round toward 0
   const auto int_f = ConvertTo(df, integer);
 
   return IfThenElse(detail::UseInt(v), CopySign(int_f, v), v);
@@ -11183,7 +11183,7 @@ HWY_API Vec128<T, N> Ceil(const Vec128<T, N> v) {
   const DFromV<decltype(v)> df;
   const RebindToSigned<decltype(df)> di;
 
-  const auto integer = ConvertTo(di, v);  // round toward 0
+  const auto integer = ConvertInRangeTo(di, v);  // round toward 0
   const auto int_f = ConvertTo(df, integer);
 
   // Truncating a positive non-integer ends up smaller; if so, add 1.
@@ -11199,7 +11199,7 @@ HWY_API Vec128<T, N> Floor(const Vec128<T, N> v) {
   const DFromV<decltype(v)> df;
   const RebindToSigned<decltype(df)> di;
 
-  const auto integer = ConvertTo(di, v);  // round toward 0
+  const auto integer = ConvertInRangeTo(di, v);  // round toward 0
   const auto int_f = ConvertTo(df, integer);
 
   // Truncating a negative non-integer ends up larger; if so, subtract 1.


### PR DESCRIPTION
Updated SSE2/SSSE3 Trunc/Ceil/Floor ops to do the float to int conversion using ConvertInRangeTo instead of ConvertTo since the SSE2/SSSE3 Trunc/Ceil/Floor ops have an IfThenElse that will simply return `v[i]` if `v[i]` is outside of the range of `MakeSigned<T>`.