### PR TITLE
Added BitShuffle op

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -474,6 +474,7 @@ HWY_TESTS = [
     ("hwy/", "highway_test"),
     ("hwy/", "targets_test"),
     ("hwy/tests/", "arithmetic_test"),
+    ("hwy/tests/", "bit_permute_test"),
     ("hwy/tests/", "blockwise_shift_test"),
     ("hwy/tests/", "blockwise_test"),
     ("hwy/tests/", "cast_test"),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,7 @@ set(HWY_TEST_FILES
   hwy/targets_test.cc
   hwy/examples/skeleton_test.cc
   hwy/tests/arithmetic_test.cc
+  hwy/tests/bit_permute_test.cc
   hwy/tests/blockwise_shift_test.cc
   hwy/tests/blockwise_test.cc
   hwy/tests/cast_test.cc

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1963,6 +1963,31 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     to 0. `VI` are integers, possibly of a different type than those in `V`. The
     number of lanes in `V` and `VI` may differ.
 
+*   `V`: `{u,i}64`, `VI`: `{u,i}8` \
+    <code>V **BitShuffle**(V vals, VI indices)</code>: returns a
+    vector with `(vals[i] >> indices[i*8+j]) & 1` in bit `j` of `r[i]` for each
+    `j` between 0 and 7.
+
+    `BitShuffle(vals, indices)` zeroes out the upper 56 bits of `r[i]`.
+
+    If `indices[i*8+j]` is less than 0 or greater than 63, bit `j` of `r[i]` is
+    implementation-defined.
+
+    `VI` must be either `Vec<Repartition<int8_t, DFromV<V>>>` or
+    `Vec<Repartition<uint8_t, DFromV<V>>>`.
+
+    `BitShuffle(v, indices)` is equivalent to the following loop (where `N` is
+    equal to `Lanes(DFromV<V>())`):
+    ```
+    for(size_t i = 0; i < N; i++) {
+      uint64_t shuf_result = 0;
+      for(int j = 0; j < 7; j++) {
+        shuf_result |= ((v[i] >> indices[i*8+j]) & 1) << j;
+      }
+      r[i] = shuf_result;
+    }
+    ```
+
 #### Interleave
 
 Ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -7164,6 +7164,55 @@ HWY_API Vec<RepartitionToWide<DFromV<V8>>> SumsOfShuffledQuadAbsDiff(V8 a,
 
 #endif  // HWY_NATIVE_SUMS_OF_SHUFFLED_QUAD_ABS_DIFF
 
+// ------------------------------ BitShuffle
+#if (defined(HWY_NATIVE_BITSHUFFLE) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_BITSHUFFLE
+#undef HWY_NATIVE_BITSHUFFLE
+#else
+#define HWY_NATIVE_BITSHUFFLE
+#endif
+
+#if HWY_HAVE_INTEGER64 && HWY_TARGET != HWY_SCALAR
+template <class V, class VI, HWY_IF_UI64(TFromV<V>), HWY_IF_UI8(TFromV<VI>),
+          class VI_2 = VFromD<Repartition<uint8_t, DFromV<V>>>,
+          HWY_IF_LANES_D(DFromV<VI>, HWY_MAX_LANES_V(VI_2))>
+HWY_API V BitShuffle(V v, VI idx) {
+  const DFromV<decltype(v)> d64;
+  const RebindToUnsigned<decltype(d64)> du64;
+  const Repartition<uint8_t, decltype(d64)> du8;
+
+#if HWY_TARGET <= HWY_SSE2 || HWY_TARGET == HWY_WASM || \
+    HWY_TARGET == HWY_WASM_EMU256
+  const Repartition<uint16_t, decltype(d64)> d_idx_shr;
+#else
+  const Repartition<uint8_t, decltype(d64)> d_idx_shr;
+#endif
+
+#if HWY_IS_LITTLE_ENDIAN
+  constexpr uint64_t kExtractedBitsMask =
+      static_cast<uint64_t>(0x8040201008040201u);
+#else
+  constexpr uint64_t kExtractedBitsMask =
+      static_cast<uint64_t>(0x0102040810204080u);
+#endif
+
+  const auto byte_idx = BitwiseIfThenElse(
+      Set(du8, uint8_t{0x07}),
+      BitCast(du8, ShiftRight<3>(BitCast(d_idx_shr, idx))),
+      BitCast(du8, Dup128VecFromValues(du64, uint64_t{0},
+                                       uint64_t{0x0808080808080808u})));
+  const auto u8_rol_amt = Sub(Iota(du8, uint8_t{0}), BitCast(du8, idx));
+
+  const auto extracted_bits =
+      And(Rol(TableLookupBytes(v, byte_idx), u8_rol_amt),
+          BitCast(du8, Set(du64, kExtractedBitsMask)));
+
+  return BitCast(d64, SumsOf8(extracted_bits));
+}
+#endif  // HWY_HAVE_INTEGER64 && HWY_TARGET != HWY_SCALAR
+
+#endif  // HWY_NATIVE_BITSHUFFLE
+
 // ================================================== Operator wrapper
 
 // SVE* and RVV currently cannot define operators and have already defined

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -8263,6 +8263,23 @@ HWY_API Mask256<T> SetAtOrBeforeFirst(Mask256<T> mask) {
 
 // ------------------------------ Reductions in generic_ops
 
+// ------------------------------ BitShuffle
+#if HWY_TARGET <= HWY_AVX3_DL
+template <class V, class VI, HWY_IF_UI64(TFromV<V>), HWY_IF_UI8(TFromV<VI>),
+          HWY_IF_V_SIZE_V(V, 32), HWY_IF_V_SIZE_V(VI, 32)>
+HWY_API V BitShuffle(V v, VI idx) {
+  const DFromV<decltype(v)> d64;
+  const RebindToUnsigned<decltype(d64)> du64;
+  const Rebind<uint8_t, decltype(d64)> du8;
+
+  int32_t i32_bit_shuf_result =
+      static_cast<int32_t>(_mm256_bitshuffle_epi64_mask(v.raw, idx.raw));
+
+  return BitCast(d64, PromoteTo(du64, VFromD<decltype(du8)>{_mm_cvtsi32_si128(
+                                          i32_bit_shuf_result)}));
+}
+#endif  // HWY_TARGET <= HWY_AVX3_DL
+
 // ------------------------------ LeadingZeroCount
 
 #if HWY_TARGET <= HWY_AVX3

--- a/hwy/tests/bit_permute_test.cc
+++ b/hwy/tests/bit_permute_test.cc
@@ -1,0 +1,95 @@
+// Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/bit_permute_test.cc"
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/tests/test_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+
+struct TestBitShuffle {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET == HWY_SCALAR
+    (void)d;
+#else   // HWY_TARGET != HWY_SCALAR
+    using TU = MakeUnsigned<T>;
+
+    const size_t N = Lanes(d);
+
+    auto in1_lanes = AllocateAligned<T>(N);
+    auto in2_lanes = AllocateAligned<uint8_t>(N * sizeof(T));
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(in1_lanes && in2_lanes && expected);
+
+    constexpr uint8_t kBitIdxMask = static_cast<uint8_t>((sizeof(T) * 8) - 1);
+
+    const Repartition<uint8_t, decltype(d)> du8;
+    const RebindToSigned<decltype(du8)> di8;
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; i++) {
+        TU src_val = static_cast<TU>(rng());
+        TU expected_result = static_cast<TU>(0);
+        for (size_t j = 0; j < sizeof(T); j++) {
+          const uint8_t bit_idx = static_cast<uint8_t>(rng() & kBitIdxMask);
+
+          in2_lanes[i * sizeof(T) + j] = bit_idx;
+          expected_result = static_cast<TU>(expected_result |
+                                            (((src_val >> bit_idx) & 1) << j));
+        }
+
+        in1_lanes[i] = static_cast<T>(src_val);
+        expected[i] = static_cast<T>(expected_result);
+      }
+
+      const auto in1 = Load(d, in1_lanes.get());
+      const auto in2 = Load(du8, in2_lanes.get());
+      HWY_ASSERT_VEC_EQ(d, expected.get(), BitShuffle(in1, in2));
+      HWY_ASSERT_VEC_EQ(d, expected.get(), BitShuffle(in1, BitCast(di8, in2)));
+    }
+#endif  // HWY_TARGET == HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllBitShuffle() {
+#if HWY_HAVE_INTEGER64
+  ForPartialVectors<TestBitShuffle>()(int64_t());
+  ForPartialVectors<TestBitShuffle>()(uint64_t());
+#endif
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace hwy {
+HWY_BEFORE_TEST(HwyBitPermuteTest);
+HWY_EXPORT_AND_TEST_P(HwyBitPermuteTest, TestAllBitShuffle);
+HWY_AFTER_TEST();
+}  // namespace hwy
+
+#endif


### PR DESCRIPTION
The BitShuffle op was added as AVX3_DL/PPC8/PPC9/PPC10/Z14 have instructions that can extract the bits at specified indices from each lane of an U64 or I64 vector.

The BitShuffle op can be used to speed up the Pack operation in hwy/contrib/bit_pack/bit_pack-inl.h on AVX3_DL/PPC/Z14.