### PR TITLE
Allow compilation of AVX2 on x86

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -166,7 +166,12 @@
 
 // 32-bit may fail to compile AVX2/3.
 #if HWY_ARCH_X86_32
+// GCC-13 is ok with AVX2:
+#if (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL >= 1300)
+#define HWY_BROKEN_32BIT (HWY_AVX3 | (HWY_AVX3 - 1))
+#else
 #define HWY_BROKEN_32BIT (HWY_AVX2 | (HWY_AVX2 - 1))
+#endif
 #else
 #define HWY_BROKEN_32BIT 0
 #endif


### PR DESCRIPTION
GCC-13 seems to be ok:

* https://buildd.debian.org/status/fetch.php?pkg=highway&arch=i386&ver=1.1.0-3&stamp=1717006825&raw=0