### PR TITLE
fix compile error on arm32 (missing float64x1_t type)

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -2600,7 +2600,7 @@ HWY_API Vec128<int16_t, N> MulFixedPoint15(Vec128<int16_t, N> a,
 // ------------------------------ Floating-point division
 
 // Emulate missing intrinsic
-#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700
+#if HWY_HAVE_FLOAT64 && HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 700
 HWY_INLINE float64x1_t vrecpe_f64(float64x1_t raw) {
   const CappedTag<double, 1> d;
   const Twice<decltype(d)> dt;


### PR DESCRIPTION
this small commit fixes compiling error on some arm32 devices. cuz lack of `float64x1_t` definition. ( `float64x1_t` is only available on aarch64 [document](https://arm-software.github.io/acle/neon_intrinsics/advsimd.html)).
```
[build] In file included from /workspaces/demo/builds/release/_deps/highway-src/hwy/highway.h:588:0,
[build]                  from /workspaces/demo/builds/release/_deps/highway-src/hwy/timer-inl.h:26,
[build]                  from /workspaces/demo/builds/release/_deps/highway-src/hwy/nanobenchmark.cc:28:
[build] /workspaces/demo/builds/release/_deps/highway-src/hwy/ops/arm_neon-inl.h:2494:12: error: ‘float64x1_t’ does not name a type
[build]  HWY_INLINE float64x1_t vrecpe_f64(float64x1_t raw) {
[build]             ^~~~~~~~~~~
[build] ninja: build stopped: subcommand failed.
```
so the additional `HWY_HAVE_FLOAT64` is added to determine whether the `vrecpe_f64` func should be defined.