### PR TITLE
Resolve TODO in aligned_allocator

### DIFF
--- a/hwy/aligned_allocator.h
+++ b/hwy/aligned_allocator.h
@@ -232,7 +232,6 @@ class AlignedFreer {
 
   template <typename T>
   void operator()(T* aligned_pointer) const {
-    // TODO(deymo): assert that we are using a POD type T.
     FreeAlignedBytes(aligned_pointer, free_, opaque_ptr_);
   }
 
@@ -251,6 +250,10 @@ using AlignedFreeUniquePtr = std::unique_ptr<T, AlignedFreer>;
 template <typename T>
 AlignedFreeUniquePtr<T[]> AllocateAligned(const size_t items, AllocPtr alloc,
                                           FreePtr free, void* opaque) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "AllocateAligned: requires trivially copyable T");
+  static_assert(std::is_trivially_destructible<T>::value,
+                "AllocateAligned: requires trivially destructible T");
   return AlignedFreeUniquePtr<T[]>(
       detail::AllocateAlignedItems<T>(items, alloc, opaque),
       AlignedFreer(free, opaque));

--- a/hwy/aligned_allocator_test.cc
+++ b/hwy/aligned_allocator_test.cc
@@ -146,8 +146,8 @@ TEST(AlignedAllocatorTest, TestEmptyAlignedUniquePtr) {
 }
 
 TEST(AlignedAllocatorTest, TestEmptyAlignedFreeUniquePtr) {
-  AlignedFreeUniquePtr<SampleObject<32>> ptr(nullptr, AlignedFreer());
-  AlignedFreeUniquePtr<SampleObject<32>[]> arr(nullptr, AlignedFreer());
+  AlignedFreeUniquePtr<std::array<char, 32>> ptr(nullptr, AlignedFreer());
+  AlignedFreeUniquePtr<std::array<char, 32>[]> arr(nullptr, AlignedFreer());
 }
 
 TEST(AlignedAllocatorTest, TestCustomAlloc) {
@@ -227,19 +227,6 @@ TEST(AlignedAllocatorTest, TestAllocMultipleInt) {
     if (i) ret += static_cast<size_t>(ptr[i]) * ptr[i - 1];
   }
   HWY_ASSERT(ret != size_t{0});
-}
-
-TEST(AlignedAllocatorTest, TestAllocateAlignedObjectWithoutDestructor) {
-  int counter = 0;
-  {
-    // This doesn't call the constructor.
-    auto obj = AllocateAligned<SampleObject<24>>(1);
-    HWY_ASSERT(obj);
-    obj[0].counter_ = &counter;
-  }
-  // Destroying the unique_ptr shouldn't have called the destructor of the
-  // SampleObject<24>.
-  HWY_ASSERT_EQ(0, counter);
 }
 
 TEST(AlignedAllocatorTest, TestMakeUniqueAlignedArrayWithCustomAlloc) {


### PR DESCRIPTION
And updated corresponding test.
AllocateAligned was designed to take POD types only.

I also removed `TestAllocateAlignedObjectWithoutDestructor` because objects with constructor/destructor are obviously illegal input.
btw, restriction here can be one `is_trivial`, perhaps?