### PR TITLE
Enable AVX3_SPR F16 support with Clang 19.1 or later

### DIFF
--- a/hwy/contrib/dot/dot_test.cc
+++ b/hwy/contrib/dot/dot_test.cc
@@ -100,7 +100,7 @@ class TestDot {
     const double max = static_cast<double>(8 * 8 * num);
     HWY_ASSERT(-max <= actual && actual <= max);
     const double tolerance =
-        64.0 * ConvertScalarTo<double>(Epsilon<T>()) * HWY_MAX(magnitude, 1.0);
+        96.0 * ConvertScalarTo<double>(Epsilon<T>()) * HWY_MAX(magnitude, 1.0);
     HWY_ASSERT(expected - tolerance <= actual &&
                actual <= expected + tolerance);
   }

--- a/hwy/contrib/unroller/unroller_test.cc
+++ b/hwy/contrib/unroller/unroller_test.cc
@@ -376,7 +376,7 @@ struct TestDot {
       AccumulateUnit<T> accfn;
       T dot_via_mul_acc;
       Unroller(accfn, y, &dot_via_mul_acc, static_cast<ptrdiff_t>(num));
-      const double tolerance = 32.0 *
+      const double tolerance = 48.0 *
                                ConvertScalarTo<double>(hwy::Epsilon<T>()) *
                                ScalarAbs(expected_dot);
       HWY_ASSERT(ScalarAbs(expected_dot - dot_via_mul_acc) < tolerance);

--- a/hwy/examples/skeleton_test.cc
+++ b/hwy/examples/skeleton_test.cc
@@ -106,7 +106,7 @@ struct TestSumMulAdd {
     MulAddLoop(d, mul.get(), add.get(), count, x.get());
     double vector_sum = 0.0;
     for (size_t i = 0; i < count; ++i) {
-      vector_sum += x[i];
+      vector_sum += hwy::ConvertScalarTo<double>(x[i]);
     }
 
     if (hwy::IsSame<T, hwy::float16_t>()) {

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -287,10 +287,9 @@
 
 #define HWY_HAVE_SCALABLE 0
 #define HWY_HAVE_INTEGER64 1
-#if HWY_TARGET == HWY_AVX3_SPR && HWY_COMPILER_GCC_ACTUAL && \
+#if HWY_TARGET == HWY_AVX3_SPR &&                              \
+    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1901) && \
     HWY_HAVE_SCALAR_F16_TYPE
-// TODO: enable F16 for AVX3_SPR target with Clang once compilation issues are
-// fixed
 #define HWY_HAVE_FLOAT16 1
 #else
 #define HWY_HAVE_FLOAT16 0


### PR DESCRIPTION
Clang 19.1.0 `(++20240810103829+866686180a31-1~exp1~20240810103957.18)` is able to successfully compile all of the Highway tests with AVX3_SPR F16 support enabled with the changes made to dot_test.cc, skeleton_test.cc, and unroller_test.cc in this pull request.

AVX3_SPR F16 support is not enabled when compiling with Clang 18 or earlier as there is a bug in LLVM 18 that causes Clang 18 to crash if AVX3_SPR F16 support is enabled, and that bug is described at https://github.com/llvm/llvm-project/issues/92035.