### PR TITLE
Fixes to hwy/base.h and vqsort-inl.h

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -21,7 +21,10 @@
 // IWYU pragma: begin_exports
 #include <stddef.h>
 #include <stdint.h>
+
+#if !defined(HWY_NO_LIBCXX)
 #include <ostream>
+#endif
 
 #include "hwy/detect_compiler_arch.h"
 #include "hwy/highway_export.h"
@@ -254,11 +257,11 @@ HWY_DLLEXPORT HWY_NORETURN void HWY_FORMAT(3, 4)
   ::hwy::Abort(__FILE__, __LINE__, format, ##__VA_ARGS__)
 
 // Always enabled.
-#define HWY_ASSERT_M(condition, msg)             \
-  do {                                    \
-    if (!(condition)) {                   \
+#define HWY_ASSERT_M(condition, msg)               \
+  do {                                             \
+    if (!(condition)) {                            \
       HWY_ABORT("Assert %s: %s", #condition, msg); \
-    }                                     \
+    }                                              \
   } while (0)
 #define HWY_ASSERT(condition) HWY_ASSERT_M(condition, "")
 
@@ -320,14 +323,15 @@ HWY_DLLEXPORT HWY_NORETURN void HWY_FORMAT(3, 4)
 
 #if HWY_IS_DEBUG_BUILD
 #define HWY_DASSERT_M(condition, msg) HWY_ASSERT_M(condition, msg)
-#define HWY_DASSERT(condition)  HWY_ASSERT_M(condition, "")
+#define HWY_DASSERT(condition) HWY_ASSERT_M(condition, "")
 #else
 #define HWY_DASSERT_M(condition, msg) \
   do {                                \
   } while (0)
-#define HWY_DASSERT(condition) do {} while (0)
+#define HWY_DASSERT(condition) \
+  do {                         \
+  } while (0)
 #endif
-
 
 //------------------------------------------------------------------------------
 // CopyBytes / ZeroBytes
@@ -457,10 +461,13 @@ static inline HWY_MAYBE_UNUSED bool operator==(const uint128_t& a,
                                                const uint128_t& b) {
   return a.lo == b.lo && a.hi == b.hi;
 }
+
+#if !defined(HWY_NO_LIBCXX)
 static inline HWY_MAYBE_UNUSED std::ostream& operator<<(std::ostream& os,
-                                                        const uint128_t& n){
-return os << "[hi=" << n.hi << ",lo=" << n.lo << "]";
+                                                        const uint128_t& n) {
+  return os << "[hi=" << n.hi << ",lo=" << n.lo << "]";
 }
+#endif
 
 static inline HWY_MAYBE_UNUSED bool operator<(const K64V64& a,
                                               const K64V64& b) {
@@ -475,10 +482,13 @@ static inline HWY_MAYBE_UNUSED bool operator==(const K64V64& a,
                                                const K64V64& b) {
   return a.key == b.key;
 }
-static inline HWY_MAYBE_UNUSED std::ostream& operator<<(std::ostream& os, const K64V64& n){
-  return os << "[k=" << n.key << ",v=" << n.value<< "]";
-}
 
+#if !defined(HWY_NO_LIBCXX)
+static inline HWY_MAYBE_UNUSED std::ostream& operator<<(std::ostream& os,
+                                                        const K64V64& n) {
+  return os << "[k=" << n.key << ",v=" << n.value << "]";
+}
+#endif
 
 static inline HWY_MAYBE_UNUSED bool operator<(const K32V32& a,
                                               const K32V32& b) {
@@ -493,11 +503,13 @@ static inline HWY_MAYBE_UNUSED bool operator==(const K32V32& a,
                                                const K32V32& b) {
   return a.key == b.key;
 }
-static inline HWY_MAYBE_UNUSED std::ostream& operator<<(std::ostream& os, const K32V32& n){
-  return os << "[k=" << n.key << ",v=" << n.value<< "]";
+
+#if !defined(HWY_NO_LIBCXX)
+static inline HWY_MAYBE_UNUSED std::ostream& operator<<(std::ostream& os,
+                                                        const K32V32& n) {
+  return os << "[k=" << n.key << ",v=" << n.value << "]";
 }
-
-
+#endif
 
 //------------------------------------------------------------------------------
 // Controlling overload resolution (SFINAE)

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -590,16 +590,17 @@ HWY_NOINLINE void BaseCase(D d, TraitsKV, T* HWY_RESTRICT keys,
 
   using FuncPtr = decltype(&Sort2To2<Traits, T>);
   const FuncPtr funcs[9] = {
-    /* <= 1 */ nullptr,  // We ensured num_keys > 1.
-    /* <= 2 */ &Sort2To2<Traits, T>,
-    /* <= 4 */ &Sort3To4<Traits, T>,
-    /* <= 8 */ &Sort8Rows<1, Traits, T>,  // 1 key per row
-    /* <= 16 */ kMaxKeysPerVector >= 2 ? &Sort8Rows<2, Traits, T> : nullptr,
-    /* <= 32 */ kMaxKeysPerVector >= 4 ? &Sort8Rows<4, Traits, T> : nullptr,
-    /* <= 64 */ kMaxKeysPerVector >= 4 ? &Sort16Rows<4, Traits, T> : nullptr,
-    /* <= 128 */ kMaxKeysPerVector >= 8 ? &Sort16Rows<8, Traits, T> : nullptr,
+      /* <= 1 */ nullptr,  // We ensured num_keys > 1.
+      /* <= 2 */ &Sort2To2<Traits, T>,
+      /* <= 4 */ &Sort3To4<Traits, T>,
+      /* <= 8 */ &Sort8Rows<1, Traits, T>,  // 1 key per row
+      /* <= 16 */ kMaxKeysPerVector >= 2 ? &Sort8Rows<2, Traits, T> : nullptr,
+      /* <= 32 */ kMaxKeysPerVector >= 4 ? &Sort8Rows<4, Traits, T> : nullptr,
+      /* <= 64 */ kMaxKeysPerVector >= 4 ? &Sort16Rows<4, Traits, T> : nullptr,
+      /* <= 128 */ kMaxKeysPerVector >= 8 ? &Sort16Rows<8, Traits, T> : nullptr,
 #if !HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD
-    /* <= 256 */ kMaxKeysPerVector >= 16 ? &Sort16Rows<16, Traits, T> : nullptr,
+      /* <= 256 */ kMaxKeysPerVector >= 16 ? &Sort16Rows<16, Traits, T>
+                                           : nullptr,
 #endif
   };
   funcs[ceil_log2](st, keys, num_lanes, buf);
@@ -1856,6 +1857,7 @@ HWY_NOINLINE void Recurse(D d, Traits st, T* HWY_RESTRICT keys,
   // return the same value (for -inf inputs), but that would just mean the
   // pivot is again one of the keys.
   using Order = typename Traits::Order;
+  (void)Order::IsAscending();
   HWY_DASSERT_M(bound != 0,
                 (Order::IsAscending() ? "Ascending" : "Descending"));
   // ChoosePivot* ensure pivot != last, so the right partition is never empty


### PR DESCRIPTION
Updated hwy/base.h to ensure that `<ostream>` is not included by hwy/base.h if HWY_NO_LIBCXX is defined.

Also updated vqsort-inl.h to fix a compiler warning that occurs in the Order typedef in the the Recurse function in non-debug builds.