### PR TITLE
Add RVV linker flag in case of building with RVV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ else()
     # either compiler) to support V.
     if(HWY_CMAKE_RVV)
       list(APPEND HWY_FLAGS -march=rv64gcv1p0)
+      add_link_options(-march=rv64gcv1p0)
       if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         list(APPEND HWY_FLAGS -menable-experimental-extensions)
       endif()


### PR DESCRIPTION
As simple as that. One line change in CMakeLists.txt
Tested on risc-v which not supported vectors but compiled it (failed on tests)