### PR TITLE
Fixed compile error in concat_test.cc

### DIFF
--- a/hwy/tests/concat_test.cc
+++ b/hwy/tests/concat_test.cc
@@ -90,13 +90,9 @@ struct TestConcatOddEven {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
     const size_t N = Lanes(d);
-    const Vec<D> hi =
-        Iota(d,
-             ConvertScalarTo<T>(static_cast<size_t>(hwy::Unpredictable1()) + N -
-                                1));  // N, N+1, ...
-    const Vec<D> lo =
-        Iota(d,
-             ConvertScalarTo<T>(hwy::Unpredictable1() - 1));  // 0,1,2,3,...
+    const Vec<D> hi = Iota(
+        d, static_cast<size_t>(hwy::Unpredictable1()) + N - 1);  // N, N+1, ...
+    const Vec<D> lo = Iota(d, hwy::Unpredictable1() - 1);        // 0,1,2,3,...
     const Vec<D> even = Add(lo, lo);
     const Vec<D> odd = Add(even, Set(d, 1));
     HWY_ASSERT_VEC_EQ(d, odd, ConcatOdd(d, hi, lo));

--- a/hwy/tests/concat_test.cc
+++ b/hwy/tests/concat_test.cc
@@ -90,8 +90,13 @@ struct TestConcatOddEven {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
     const size_t N = Lanes(d);
-    const Vec<D> hi = Iota(d, hwy::Unpredictable1() + N - 1);  // N, N+1, ...
-    const Vec<D> lo = Iota(d, hwy::Unpredictable1() - 1);      // 0,1,2,3,...
+    const Vec<D> hi =
+        Iota(d,
+             ConvertScalarTo<T>(static_cast<size_t>(hwy::Unpredictable1()) + N -
+                                1));  // N, N+1, ...
+    const Vec<D> lo =
+        Iota(d,
+             ConvertScalarTo<T>(hwy::Unpredictable1() - 1));  // 0,1,2,3,...
     const Vec<D> even = Add(lo, lo);
     const Vec<D> odd = Add(even, Set(d, 1));
     HWY_ASSERT_VEC_EQ(d, odd, ConcatOdd(d, hi, lo));


### PR DESCRIPTION
Updated TestConcatOddEven in concat_test.cc to fix compiler warning with hwy::Unpredictable1 (which returns a signed integer).