### PR TITLE
Made enhancements to SSE2/SSSE3 U16 Min/Max

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -5753,7 +5753,8 @@ HWY_API Vec128<uint8_t, N> Min(Vec128<uint8_t, N> a, Vec128<uint8_t, N> b) {
 template <size_t N>
 HWY_API Vec128<uint16_t, N> Min(Vec128<uint16_t, N> a, Vec128<uint16_t, N> b) {
 #if HWY_TARGET >= HWY_SSSE3
-  return detail::MinU(a, b);
+  return Vec128<uint16_t, N>{
+      _mm_sub_epi16(a.raw, _mm_subs_epu16(a.raw, b.raw))};
 #else
   return Vec128<uint16_t, N>{_mm_min_epu16(a.raw, b.raw)};
 #endif
@@ -5846,7 +5847,8 @@ HWY_API Vec128<uint8_t, N> Max(Vec128<uint8_t, N> a, Vec128<uint8_t, N> b) {
 template <size_t N>
 HWY_API Vec128<uint16_t, N> Max(Vec128<uint16_t, N> a, Vec128<uint16_t, N> b) {
 #if HWY_TARGET >= HWY_SSSE3
-  return detail::MaxU(a, b);
+  return Vec128<uint16_t, N>{
+      _mm_add_epi16(a.raw, _mm_subs_epu16(b.raw, a.raw))};
 #else
   return Vec128<uint16_t, N>{_mm_max_epu16(a.raw, b.raw)};
 #endif


### PR DESCRIPTION
Updated implementation of U16 Min on SSE2/SSSE3 to use `_mm_sub_epi16(a.raw, _mm_subs_epu16(a.raw, b.raw))` as `_mm_sub_epi16(a.raw, _mm_subs_epu16(a.raw, b.raw))` is more efficient than `detail::MinU(a, b)` for U16 vectors on SSE2/SSSE3.

Updated implementation of U16 Max on SSE2/SSSE3 to use `_mm_add_epi16(a.raw, _mm_subs_epu16(b.raw, a.raw))` as `_mm_add_epi16(a.raw, _mm_subs_epu16(b.raw, a.raw))` is more efficient than `detail::MaxU(a, b)` for U16 vectors on SSE2/SSSE3.

Clang 14 and later will optimize U16 `detail::MinU(a, b)` down to movdqa+psubusw+psubw on SSE2/SSSE3 when optimizations are enabled, but Clang 13 and earlier, GCC 14 and earlier, and MSVC will fail to optimize U16 `detail::MinU(a, b)` down to movdqa+psubusw+psubw when optimizations are enabled.

Likewise, Clang 14 and later will optimize U16 `detail::MaxU(a, b)` down to psubusw+paddw on SSE2/SSSE3 when optimizations are enabled, but Clang 13 and earlier, GCC 14 and earlier, and MSVC will fail to optimize U16 `detail::MaxU(a, b)` down to psubusw+paddw when optimizations are enabled.

The updated implementation of U16 Min/Max on SSE2/SSSE3 in this pull request improves codegen with GCC, MSVC, and Clang 13 and earlier.