### PR TITLE
Fixes to run SIMD test cases if HWY_TEST_STANDALONE is 1

### DIFF
--- a/hwy/tests/hwy_gtest.h
+++ b/hwy/tests/hwy_gtest.h
@@ -565,16 +565,7 @@ struct RegisterRunAll {
     static_assert(true, "For requiring trailing semicolon")
 
 // Must be followed by semicolon, then a closing brace for ONE namespace.
-#define HWY_AFTER_TEST()                          \
-  } /* RunAll*/                                   \
-  } /* namespace */                               \
-  int main(int argc, char** argv) {               \
-    hwy::InitTestProgramOptions(argc, argv);      \
-    hwy::GetRunAll()();                           \
-    if (!hwy::ShouldOnlyListHighwayTestNames()) { \
-      fprintf(stderr, "Success.\n");              \
-    }                                             \
-    return 0
+#define HWY_AFTER_TEST() } /* RunAll*/
 
 // -------------------- Non-SIMD test cases:
 
@@ -630,6 +621,10 @@ struct RegisterTest {
           func_and_name.func();                                            \
         }                                                                  \
       }                                                                    \
+    }                                                                      \
+    const auto run_all_simd_tests_func = hwy::GetRunAll();                 \
+    if (run_all_simd_tests_func) {                                         \
+      run_all_simd_tests_func();                                           \
     }                                                                      \
     if (!hwy::ShouldOnlyListHighwayTestNames()) {                          \
       fprintf(stderr, "Success.\n");                                       \


### PR DESCRIPTION
Updated HWY_TEST_MAIN in hwy/tests/hwy_gtest.h to ensure that the SIMD test cases are executed if HWY_TEST_STANDALONE is 1.

The changes made in pull request #2354 placed the main function that was defined by the HWY_AFTER_TEST() macro in an anonymous namespace (instead of the global namespace) if HWY_TEST_STANDALONE is 1, which prevented SIMD test cases from being executed.

The changes in this pull request remove the unnecessary declaration of the main function by the HWY_AFTER_TEST() macro if HWY_TEST_STANDALONE is 1, and added code to run the SIMD tests in HWY_TEST_MAIN() if HWY_TEST_STANDALONE is 1.

The SIMD unit tests will now run if HWY_TEST_STANDALONE is 1 with the changes in this pull request.