### PR TITLE
Fixed linker error in bench_sort.cc if HWY_TEST_STANDALONE is 1

### DIFF
--- a/hwy/contrib/sort/bench_sort.cc
+++ b/hwy/contrib/sort/bench_sort.cc
@@ -477,4 +477,6 @@ HWY_EXPORT_AND_TEST_P(BenchSort, BenchAllSort);
 HWY_AFTER_TEST();
 }  // namespace hwy
 
+HWY_TEST_MAIN();
+
 #endif  // HWY_ONCE


### PR DESCRIPTION
Added HWY_TEST_MAIN() to hwy/contrib/sort/bench_sort.cc to fix linker error if HWY_TEST_STANDALONE is 1. 