### PR TITLE
Enable tuples on RVV with Clang 17 or later

### DIFF
--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -78,7 +78,7 @@
 // Supported on all targets except RVV (requires GCC 14 or upcoming Clang)
 #if HWY_TARGET == HWY_RVV &&                                        \
     ((HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400) || \
-     (HWY_COMPILER_CLANG))
+     (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1700))
 #define HWY_HAVE_TUPLE 0
 #else
 #define HWY_HAVE_TUPLE 1


### PR DESCRIPTION
Updated hwy/ops/set_macros-inl.h to enable tuples for the HWY_RVV target with Clang 17 or later.