### PR TITLE
AddLower, PairwiseAdd/Sub and MaskedAbsOr operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -561,16 +561,6 @@ from left to right, of the arguments passed to `Create{2-4}`.
     Return the results of a and b interleaved, such that `r[i] = a[i+1] - a[i]` for
     even lanes and `r[i] = b[i] - b[i-1]` for odd lanes.
 
-*   <code>V **PairwiseAdd128**(D d, V a, V b)</code>: Add consecutive pairs of
-*   elements in a and b, and pack results in 128 bit blocks, such that
-    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
-    bits and repeated.
-
-*   <code>V **PairwiseSub128**(D d, V a, V b)</code>: Subtract consecutive pairs
-    of elements in a and b, and pack results in 128 bit blocks, such that
-    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
-    bits and repeated.
-
 *   `V`: `{i,u}{8,16,32},f{16,32}`, `VW`: `Vec<RepartitionToWide<DFromV<V>>>` \
     <code>VW **SumsOf2**(V v)</code> returns the sums of 2 consecutive lanes,
     promoting each sum into a lane of `TFromV<VW>`.
@@ -2307,6 +2297,16 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
       r[i] = shuf_result;
     }
     ```
+
+*   <code>V **PairwiseAdd128**(D d, V a, V b)</code>: Add consecutive pairs of
+    elements in a and b, and pack results in 128 bit blocks, such that
+    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
+    bits and repeated.
+
+*   <code>V **PairwiseSub128**(D d, V a, V b)</code>: Subtract consecutive pairs
+    of elements in a and b, and pack results in 128 bit blocks, such that
+    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
+    bits and repeated.
 
 #### Interleave
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -530,6 +530,9 @@ from left to right, of the arguments passed to `Create{2-4}`.
     `OddEven(Add(a, b), Sub(a, b))` or `Add(a, OddEven(b, Neg(b)))` on some
     targets.
 
+*   <code>V **AddLower**(V a, V b)</code>: returns `a[0] + b[0]`
+    and `a[i]` in all other lanes.
+
 *   `V`: `{i,f}` \
     <code>V **Neg**(V a)</code>: returns `-a[i]`.
 
@@ -552,6 +555,24 @@ from left to right, of the arguments passed to `Create{2-4}`.
     LimitsMin<T>())), Set(d, LimitsMax<T>()), Abs(a))`.
 
 *   <code>V **AbsDiff**(V a, V b)</code>: returns `|a[i] - b[i]|` in each lane.
+
+*   <code>V **PairwiseAdd**(D d, V a, V b)</code>: Add consecutive pairs of elements.
+    Return the results of a and b interleaved, such that `r[i] = a[i] + a[i+1]` for
+    even lanes and `r[i] = b[i-1] + b[i]` for odd lanes.
+
+*   <code>V **PairwiseSub**(D d, V a, V b)</code>: Subtract consecutive pairs of elements.
+    Return the results of a and b interleaved, such that `r[i] = a[i+1] - a[i]` for
+    even lanes and `r[i] = b[i] - b[i-1]` for odd lanes.
+
+*   <code>V **PairwiseAdd128**(D d, V a, V b)</code>: Add consecutive pairs of
+*   elements in a and b, and pack results in 128 bit blocks, such that
+    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
+    bits and repeated.
+
+*   <code>V **PairwiseSub128**(D d, V a, V b)</code>: Subtract consecutive pairs
+    of elements in a and b, and pack results in 128 bit blocks, such that
+    `r[i] = a[i] + a[i+1]` for 64 bits, followed by `b[i] + b[i+1]` for next 64
+    bits and repeated.
 
 *   `V`: `{i,u}{8,16,32},f{16,32}`, `VW`: `Vec<RepartitionToWide<DFromV<V>>>` \
     <code>VW **SumsOf2**(V v)</code> returns the sums of 2 consecutive lanes,

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -948,10 +948,18 @@ not a concern, these are equivalent to, and potentially more efficient than,
 *   <code>V **MaskedMulAddOr**(V no, M m, V mul, V x, V add)</code>: returns
     `mul[i] * x[i] + add[i]` or `no[i]` if `m[i]` is false.
 
+*   `V`: `{i,f}` \
+    <code>V **MaskedAbsOr**(M m, V a, V b)</code>: returns the absolute value of
+    `a[i]` where m is active and returns `b[i]` otherwise.
+
 #### Zero masked arithmetic
 
 All ops in this section return `0` for `mask=false` lanes. These are equivalent
 to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
+
+*   `V`: `{i,f}` \
+    <code>V **MaskedAbsOrZero**(M m, V a)</code>: returns the absolute value of
+    `a[i]` where m is active and returns zero otherwise.
 
 *   <code>V **MaskedMax**(M m, V a, V b)</code>: returns `Max(a, b)[i]` or
     `zero` if `m[i]` is false.

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -530,9 +530,6 @@ from left to right, of the arguments passed to `Create{2-4}`.
     `OddEven(Add(a, b), Sub(a, b))` or `Add(a, OddEven(b, Neg(b)))` on some
     targets.
 
-*   <code>V **AddLower**(V a, V b)</code>: returns `a[0] + b[0]`
-    and `a[i]` in all other lanes.
-
 *   `V`: `{i,f}` \
     <code>V **Neg**(V a)</code>: returns `-a[i]`.
 
@@ -949,8 +946,8 @@ not a concern, these are equivalent to, and potentially more efficient than,
     `mul[i] * x[i] + add[i]` or `no[i]` if `m[i]` is false.
 
 *   `V`: `{i,f}` \
-    <code>V **MaskedAbsOr**(M m, V a, V b)</code>: returns the absolute value of
-    `a[i]` where m is active and returns `b[i]` otherwise.
+    <code>V **MaskedAbsOr**(V no, M m, V a)</code>: returns the absolute value of
+    `a[i]` where m is active and returns `no[i]` otherwise.
 
 #### Zero masked arithmetic
 
@@ -958,7 +955,7 @@ All ops in this section return `0` for `mask=false` lanes. These are equivalent
 to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
 
 *   `V`: `{i,f}` \
-    <code>V **MaskedAbsOrZero**(M m, V a)</code>: returns the absolute value of
+    <code>V **MaskedAbs**(M m, V a)</code>: returns the absolute value of
     `a[i]` where m is active and returns zero otherwise.
 
 *   <code>V **MaskedMax**(M m, V a, V b)</code>: returns `Max(a, b)[i]` or

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -664,6 +664,8 @@ using RemovePtr = typename RemovePtrT<T>::type;
   hwy::EnableIf<kN * sizeof(T) <= bytes>* = nullptr
 #define HWY_IF_V_SIZE_GT(T, kN, bytes) \
   hwy::EnableIf<(kN * sizeof(T) > bytes)>* = nullptr
+#define HWY_IF_V_SIZE_GE(T, kN, bytes) \
+  hwy::EnableIf<(kN * sizeof(T) >= bytes)>* = nullptr
 
 #define HWY_IF_LANES(kN, lanes) hwy::EnableIf<(kN == lanes)>* = nullptr
 #define HWY_IF_LANES_LE(kN, lanes) hwy::EnableIf<(kN <= lanes)>* = nullptr

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -664,8 +664,6 @@ using RemovePtr = typename RemovePtrT<T>::type;
   hwy::EnableIf<kN * sizeof(T) <= bytes>* = nullptr
 #define HWY_IF_V_SIZE_GT(T, kN, bytes) \
   hwy::EnableIf<(kN * sizeof(T) > bytes)>* = nullptr
-#define HWY_IF_V_SIZE_GE(T, kN, bytes) \
-  hwy::EnableIf<(kN * sizeof(T) >= bytes)>* = nullptr
 
 #define HWY_IF_LANES(kN, lanes) hwy::EnableIf<(kN == lanes)>* = nullptr
 #define HWY_IF_LANES_LE(kN, lanes) hwy::EnableIf<(kN <= lanes)>* = nullptr

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -219,10 +219,10 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
   HWY_API HWY_SVE_V(BASE, BITS) NAME(HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS(v);                            \
   }
-#define HWY_SVE_RETV_ARGMV_M(BASE, CHAR, BITS, HALF, NAME, OP)             \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
-    return sv##OP##_##CHAR##BITS##_m(b, m, a);                             \
+#define HWY_SVE_RETV_ARGMV_M(BASE, CHAR, BITS, HALF, NAME, OP)              \
+  HWY_API HWY_SVE_V(BASE, BITS)                                             \
+      NAME(HWY_SVE_V(BASE, BITS) no, svbool_t m, HWY_SVE_V(BASE, BITS) a) { \
+    return sv##OP##_##CHAR##BITS##_m(no, m, a);                             \
   }
 #define HWY_SVE_RETV_ARGMV(BASE, CHAR, BITS, HALF, NAME, OP)                \
   HWY_API HWY_SVE_V(BASE, BITS) NAME(svbool_t m, HWY_SVE_V(BASE, BITS) v) { \
@@ -920,8 +920,8 @@ HWY_SVE_FOREACH_I(HWY_SVE_RETV_ARGPV, SaturatedAbs, qabs)
 // ------------------------------ MaskedAbsOr
 HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGMV_M, MaskedAbsOr, abs)
 
-// ------------------------------ MaskedAbsOrZero
-HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGMV_Z, MaskedAbsOrZero, abs)
+// ------------------------------ MaskedAbs
+HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGMV_Z, MaskedAbs, abs)
 
 // ================================================== ARITHMETIC
 
@@ -5236,21 +5236,6 @@ HWY_API V IfNegativeThenElse(V v, V yes, V no) {
 HWY_SVE_FOREACH_IF(HWY_SVE_NEG_IF, IfNegativeThenNegOrUndefIfZero, neg)
 
 #undef HWY_SVE_NEG_IF
-
-// ------------------------------ AddLower
-
-#ifdef HWY_NATIVE_ADD_LOWER
-#undef HWY_NATIVE_ADD_LOWER
-#endif
-
-#define HWY_NATIVE_ADD_LOWER(BASE, CHAR, BITS, HALF, NAME, OP)           \
-  HWY_API HWY_SVE_V(BASE, BITS)                                          \
-      NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) {           \
-    return sv##OP##_##CHAR##BITS##_m(svptrue_pat_b##BITS(SV_VL1), a, b); \
-  }
-
-HWY_SVE_FOREACH(HWY_NATIVE_ADD_LOWER, AddLower, add)
-#undef HWY_NATIVE_ADD_LOWER
 
 // ------------------------------ AverageRound (ShiftRight)
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -219,6 +219,11 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
   HWY_API HWY_SVE_V(BASE, BITS) NAME(HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS(v);                            \
   }
+#define HWY_SVE_RETV_ARGMV_M(BASE, CHAR, BITS, HALF, NAME, OP)             \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
+    return sv##OP##_##CHAR##BITS##_m(b, m, a);                             \
+  }
 #define HWY_SVE_RETV_ARGMV(BASE, CHAR, BITS, HALF, NAME, OP)                \
   HWY_API HWY_SVE_V(BASE, BITS) NAME(svbool_t m, HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS##_x(m, v);                                 \
@@ -911,6 +916,12 @@ HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGPV, Abs, abs)
 
 HWY_SVE_FOREACH_I(HWY_SVE_RETV_ARGPV, SaturatedAbs, qabs)
 #endif  // HWY_SVE_HAVE_2
+
+// ------------------------------ MaskedAbsOr
+HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGMV_M, MaskedAbsOr, abs)
+
+// ------------------------------ MaskedAbsOrZero
+HWY_SVE_FOREACH_IF(HWY_SVE_RETV_ARGMV_Z, MaskedAbsOrZero, abs)
 
 // ================================================== ARITHMETIC
 
@@ -5226,6 +5237,21 @@ HWY_SVE_FOREACH_IF(HWY_SVE_NEG_IF, IfNegativeThenNegOrUndefIfZero, neg)
 
 #undef HWY_SVE_NEG_IF
 
+// ------------------------------ AddLower
+
+#ifdef HWY_NATIVE_ADD_LOWER
+#undef HWY_NATIVE_ADD_LOWER
+#endif
+
+#define HWY_NATIVE_ADD_LOWER(BASE, CHAR, BITS, HALF, NAME, OP)           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) {           \
+    return sv##OP##_##CHAR##BITS##_m(svptrue_pat_b##BITS(SV_VL1), a, b); \
+  }
+
+HWY_SVE_FOREACH(HWY_NATIVE_ADD_LOWER, AddLower, add)
+#undef HWY_NATIVE_ADD_LOWER
+
 // ------------------------------ AverageRound (ShiftRight)
 
 #ifdef HWY_NATIVE_AVERAGE_ROUND_UI32
@@ -6261,6 +6287,38 @@ HWY_API svuint64_t MulOdd(const svuint64_t a, const svuint64_t b) {
   return detail::InterleaveOdd(lo, hi);
 }
 
+// ------------------------------ PairwiseAdd/PairwiseSub
+#if HWY_TARGET != HWY_SCALAR
+#if HWY_SVE_HAVE_2 || HWY_IDE
+
+#ifdef HWY_NATIVE_PAIRWISE_ADD
+#undef HWY_NATIVE_PAIRWISE_ADD
+#else
+#define HWY_NATIVE_PAIRWISE_ADD
+#endif
+
+namespace detail {
+#define HWY_SVE_SV_PAIRWISE_ADD(BASE, CHAR, BITS, HALF, NAME, OP)          \
+  template <size_t N, int kPow2>                                           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(HWY_SVE_D(BASE, BITS, N, kPow2) /*d*/, HWY_SVE_V(BASE, BITS) a, \
+           HWY_SVE_V(BASE, BITS) b) {                                      \
+    return sv##OP##_##CHAR##BITS##_m(HWY_SVE_PTRUE(BITS), a, b);           \
+  }
+
+HWY_SVE_FOREACH(HWY_SVE_SV_PAIRWISE_ADD, PairwiseAdd, addp)
+#undef HWY_SVE_SV_PAIRWISE_ADD
+}  // namespace detail
+
+// Pairwise add returning interleaved output of a and b
+template <class D, class V, HWY_IF_LANES_GT_D(D, 1)>
+HWY_API V PairwiseAdd(D d, V a, V b) {
+  return detail::PairwiseAdd(d, a, b);
+}
+
+#endif  // HWY_SVE_HAVE_2
+#endif  // HWY_TARGET != HWY_SCALAR
+
 // ------------------------------ WidenMulPairwiseAdd
 
 template <size_t N, int kPow2>
@@ -6911,6 +6969,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGPVV
 #undef HWY_SVE_RETV_ARGV
 #undef HWY_SVE_RETV_ARGVN
+#undef HWY_SVE_RETV_ARGMV_M
 #undef HWY_SVE_RETV_ARGVV
 #undef HWY_SVE_RETV_ARGVVV
 #undef HWY_SVE_RETV_ARGMVVV_Z

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -894,6 +894,18 @@ HWY_API V SaturatedAbs(V v) {
 
 #endif
 
+// ------------------------------ MaskedAbsOr
+template <class V, HWY_IF_SIGNED_V(V), class M>
+HWY_API V MaskedAbsOr(M m, V v, V no) {
+  return IfThenElse(m, Abs(v), no);
+}
+
+// ------------------------------ MaskedAbsOrZero
+template <class V, HWY_IF_SIGNED_V(V), class M>
+HWY_API V MaskedAbsOrZero(M m, V v) {
+  return IfThenElseZero(m, Abs(v));
+}
+
 // ------------------------------ Reductions
 
 // Targets follow one of two strategies. If HWY_NATIVE_REDUCE_SCALAR is toggled,
@@ -1215,6 +1227,22 @@ HWY_API VFromD<RebindToSigned<DFromV<V>>> FloorInt(V v) {
 }
 
 #endif  // HWY_NATIVE_CEIL_FLOOR_INT
+
+#if (defined(HWY_NATIVE_ADD_LOWER) == defined(HWY_TARGET_TOGGLE))
+
+// ------------------------------ Addlower
+#ifdef HWY_NATIVE_ADD_LOWER
+#undef HWY_NATIVE_ADD_LOWER
+#else
+#define HWY_NATIVE_ADD_LOWER
+#endif
+template <class V>
+HWY_API V AddLower(V a, V b) {
+  const DFromV<V> d;
+  const MFromD<DFromV<V>> LowerMask = FirstN(d, 1);
+  return IfThenElse(LowerMask, Add(a, b), a);
+}
+#endif
 
 // ------------------------------ MulByPow2/MulByFloorPow2
 
@@ -2283,6 +2311,83 @@ HWY_API void StoreInterleaved4(VFromD<D> part0, VFromD<D> part1,
 }
 
 #endif  // HWY_NATIVE_LOAD_STORE_INTERLEAVED
+
+// ------------------------------ PairwiseAdd/PairwiseSub
+#if (defined(HWY_NATIVE_PAIRWISE_ADD) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_PAIRWISE_ADD
+#undef HWY_NATIVE_PAIRWISE_ADD
+#else
+#define HWY_NATIVE_PAIRWISE_ADD
+#endif
+
+template <class D, class V = VFromD<D>(), HWY_IF_LANES_GT_D(D, 1)>
+HWY_API V PairwiseAdd(D d, V a, V b) {
+  return Add(InterleaveEven(d, a, b), InterleaveOdd(d, a, b));
+}
+
+#endif
+
+#if (defined(HWY_NATIVE_PAIRWISE_SUB) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_PAIRWISE_SUB
+#undef HWY_NATIVE_PAIRWISE_SUB
+#else
+#define HWY_NATIVE_PAIRWISE_SUB
+#endif
+
+template <class D, class V = VFromD<D>(), HWY_IF_LANES_GT_D(D, 1)>
+HWY_API V PairwiseSub(D d, V a, V b) {
+  return Sub(InterleaveOdd(d, a, b), InterleaveEven(d, a, b));
+}
+
+#endif
+
+#if (defined(HWY_NATIVE_PAIRWISE_ADD_128) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_PAIRWISE_ADD_128
+#undef HWY_NATIVE_PAIRWISE_ADD_128
+#else
+#define HWY_NATIVE_PAIRWISE_ADD_128
+#endif
+
+template <class D>
+using IndicesFromD = decltype(IndicesFromVec(D(), Zero(RebindToUnsigned<D>())));
+
+// Generate indices to convert
+// a[0]+a[1], b[0]+b[1], a[2]+a[3], b[2]+b[3] and so on
+// to
+// Interleaved 64 bits of a[0]+a[1], a[2]+a[3], ...
+//         and 64 bits of b[0]+b[1], b[2]+b[3], ... and so on
+template <typename V, typename D = DFromV<V>, typename T = TFromD<D>,
+          const size_t N = HWY_LANES(T)>
+constexpr IndicesFromD<D> Pairwise128Indices(D d) {
+  const size_t block_len = 8 / sizeof(T);
+  const size_t n_blocks = N / block_len;
+  TFromD<RebindToUnsigned<D>> indices[N] = {0};
+
+  TFromD<RebindToUnsigned<D>> even = 0, odd = 1;
+  for (size_t block = 0; block < n_blocks; block += 2) {
+    for (size_t index = 0; index < block_len; ++index, even += 2) {
+      indices[block * block_len + index] = even;
+    }
+    for (size_t index = 0; index < block_len; ++index, odd += 2) {
+      indices[(block + 1) * block_len + index] = odd;
+    }
+  }
+  return SetTableIndices(d, indices);
+}
+
+// Pairwise add with output in 128 bit blocks of a and b.
+template <class D, class V = VFromD<D>, HWY_IF_V_SIZE_GE_D(D, 16)>
+HWY_API V PairwiseAdd128(D d, V a, V b) {
+  return TableLookupLanes(PairwiseAdd(d, a, b), Pairwise128Indices<V>(d));
+}
+
+// Pairwise sub with output in 128 bit blocks of a and b.
+template <class D, class V = VFromD<D>, HWY_IF_V_SIZE_GE_D(D, 16)>
+HWY_API V PairwiseSub128(D d, V a, V b) {
+  return TableLookupLanes(PairwiseSub(d, a, b), Pairwise128Indices<V>(d));
+}
+
+#endif
 
 // Load/StoreInterleaved for special floats. Requires HWY_GENERIC_IF_EMULATED_D
 // is defined such that it is true only for types that actually require these

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -896,13 +896,13 @@ HWY_API V SaturatedAbs(V v) {
 
 // ------------------------------ MaskedAbsOr
 template <class V, HWY_IF_SIGNED_V(V), class M>
-HWY_API V MaskedAbsOr(M m, V v, V no) {
+HWY_API V MaskedAbsOr(V no, M m, V v) {
   return IfThenElse(m, Abs(v), no);
 }
 
-// ------------------------------ MaskedAbsOrZero
+// ------------------------------ MaskedAbs
 template <class V, HWY_IF_SIGNED_V(V), class M>
-HWY_API V MaskedAbsOrZero(M m, V v) {
+HWY_API V MaskedAbs(M m, V v) {
   return IfThenElseZero(m, Abs(v));
 }
 
@@ -1227,22 +1227,6 @@ HWY_API VFromD<RebindToSigned<DFromV<V>>> FloorInt(V v) {
 }
 
 #endif  // HWY_NATIVE_CEIL_FLOOR_INT
-
-#if (defined(HWY_NATIVE_ADD_LOWER) == defined(HWY_TARGET_TOGGLE))
-
-// ------------------------------ Addlower
-#ifdef HWY_NATIVE_ADD_LOWER
-#undef HWY_NATIVE_ADD_LOWER
-#else
-#define HWY_NATIVE_ADD_LOWER
-#endif
-template <class V>
-HWY_API V AddLower(V a, V b) {
-  const DFromV<V> d;
-  const MFromD<DFromV<V>> LowerMask = FirstN(d, 1);
-  return IfThenElse(LowerMask, Add(a, b), a);
-}
-#endif
 
 // ------------------------------ MulByPow2/MulByFloorPow2
 

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -623,6 +623,8 @@ HWY_API bool IsAligned(D d, T* ptr) {
   HWY_IF_V_SIZE_LE(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
 #define HWY_IF_V_SIZE_GT_D(D, bytes) \
   HWY_IF_V_SIZE_GT(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
+#define HWY_IF_V_SIZE_GE_D(D, bytes) \
+  HWY_IF_V_SIZE_GE(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
 
 // Same, but with a vector argument. ops/*-inl.h define their own TFromV.
 #define HWY_IF_UNSIGNED_V(V) HWY_IF_UNSIGNED(hwy::HWY_NAMESPACE::TFromV<V>)

--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -623,8 +623,6 @@ HWY_API bool IsAligned(D d, T* ptr) {
   HWY_IF_V_SIZE_LE(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
 #define HWY_IF_V_SIZE_GT_D(D, bytes) \
   HWY_IF_V_SIZE_GT(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
-#define HWY_IF_V_SIZE_GE_D(D, bytes) \
-  HWY_IF_V_SIZE_GE(hwy::HWY_NAMESPACE::TFromD<D>, HWY_MAX_LANES_D(D), bytes)
 
 // Same, but with a vector argument. ops/*-inl.h define their own TFromV.
 #define HWY_IF_UNSIGNED_V(V) HWY_IF_UNSIGNED(hwy::HWY_NAMESPACE::TFromV<V>)
@@ -676,6 +674,12 @@ HWY_API bool IsAligned(D d, T* ptr) {
 #undef HWY_IF_MULADDSUB_V
 #define HWY_IF_MULADDSUB_V(V) \
   HWY_IF_LANES_GT_D(hwy::HWY_NAMESPACE::DFromV<V>, 1)
+
+#undef HWY_IF_PAIRWISE_ADD_128_D
+#define HWY_IF_PAIRWISE_ADD_128_D(D) HWY_IF_V_SIZE_GT_D(D, 8)
+
+#undef HWY_IF_PAIRWISE_SUB_128_D
+#define HWY_IF_PAIRWISE_SUB_128_D(D) HWY_IF_V_SIZE_GT_D(D, 8)
 
 // HWY_IF_U2I_DEMOTE_FROM_LANE_SIZE_V is used to disable the default
 // implementation of unsigned to signed DemoteTo/ReorderDemote2To in

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -3914,6 +3914,8 @@ HWY_API Vec128<double> AddSub(Vec128<double> a, Vec128<double> b) {
 // Need to use the default implementation of PairwiseAdd128/PairwiseSub128 in
 // generic_ops-inl.h for U8/I8/F16/I64/U64 vectors and 64-byte vectors
 
+#if HWY_TARGET <= HWY_SSSE3
+
 #undef HWY_IF_PAIRWISE_ADD_128_D
 #undef HWY_IF_PAIRWISE_SUB_128_D
 #define HWY_IF_PAIRWISE_ADD_128_D(D)                                       \
@@ -3962,6 +3964,8 @@ template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F64_D(D)>
 HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
   return Neg(VFromD<D>{_mm_hsub_pd(a.raw, b.raw)});
 }
+
+#endif  // HWY_TARGET <= HWY_SSSE3
 
 // ------------------------------ SumsOf8
 template <size_t N>

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -3909,6 +3909,60 @@ HWY_API Vec128<double> AddSub(Vec128<double> a, Vec128<double> b) {
 }
 #endif  // HWY_TARGET <= HWY_SSSE3
 
+// ------------------------------ PairwiseAdd128/PairwiseSub128
+
+// Need to use the default implementation of PairwiseAdd128/PairwiseSub128 in
+// generic_ops-inl.h for U8/I8/F16/I64/U64 vectors and 64-byte vectors
+
+#undef HWY_IF_PAIRWISE_ADD_128_D
+#undef HWY_IF_PAIRWISE_SUB_128_D
+#define HWY_IF_PAIRWISE_ADD_128_D(D)                                       \
+  hwy::EnableIf<(                                                          \
+      HWY_MAX_LANES_D(D) > (32 / sizeof(hwy::HWY_NAMESPACE::TFromD<D>)) || \
+      (HWY_MAX_LANES_D(D) > (8 / sizeof(hwy::HWY_NAMESPACE::TFromD<D>)) && \
+       !(hwy::IsSameEither<hwy::HWY_NAMESPACE::TFromD<D>, int16_t,         \
+                           uint16_t>() ||                                  \
+         sizeof(hwy::HWY_NAMESPACE::TFromD<D>) == 4 ||                     \
+         hwy::IsSame<hwy::HWY_NAMESPACE::TFromD<D>, double>())))>* = nullptr
+#define HWY_IF_PAIRWISE_SUB_128_D(D) HWY_IF_PAIRWISE_ADD_128_D(D)
+
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_UI16_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm_hadd_epi16(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_UI16_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  const DFromV<decltype(a)> d;
+  const RebindToSigned<decltype(d)> di;
+  return BitCast(d, Neg(BitCast(di, VFromD<D>{_mm_hsub_epi16(a.raw, b.raw)})));
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_UI32_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm_hadd_epi32(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_UI32_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  const DFromV<decltype(a)> d;
+  const RebindToSigned<decltype(d)> di;
+  return BitCast(d, Neg(BitCast(di, VFromD<D>{_mm_hsub_epi32(a.raw, b.raw)})));
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F32_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm_hadd_ps(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F32_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return Neg(VFromD<D>{_mm_hsub_ps(a.raw, b.raw)});
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F64_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm_hadd_pd(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_F64_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return Neg(VFromD<D>{_mm_hsub_pd(a.raw, b.raw)});
+}
+
 // ------------------------------ SumsOf8
 template <size_t N>
 HWY_API Vec128<uint64_t, N / 8> SumsOf8(const Vec128<uint8_t, N> v) {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -1978,6 +1978,47 @@ HWY_API Vec256<double> AddSub(Vec256<double> a, Vec256<double> b) {
   return Vec256<double>{_mm256_addsub_pd(a.raw, b.raw)};
 }
 
+// ------------------------------ PairwiseAdd128/PairwiseSub128
+
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_UI16_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm256_hadd_epi16(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_UI16_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  const DFromV<decltype(a)> d;
+  const RebindToSigned<decltype(d)> di;
+  return BitCast(d,
+                 Neg(BitCast(di, VFromD<D>{_mm256_hsub_epi16(a.raw, b.raw)})));
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_UI32_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm256_hadd_epi32(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_UI32_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  const DFromV<decltype(a)> d;
+  const RebindToSigned<decltype(d)> di;
+  return BitCast(d,
+                 Neg(BitCast(di, VFromD<D>{_mm256_hsub_epi32(a.raw, b.raw)})));
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_F32_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm256_hadd_ps(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_F32_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return Neg(VFromD<D>{_mm256_hsub_ps(a.raw, b.raw)});
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_F64_D(D)>
+HWY_API VFromD<D> PairwiseAdd128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return VFromD<D>{_mm256_hadd_pd(a.raw, b.raw)};
+}
+template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_F64_D(D)>
+HWY_API VFromD<D> PairwiseSub128(D /*d*/, VFromD<D> a, VFromD<D> b) {
+  return Neg(VFromD<D>{_mm256_hsub_pd(a.raw, b.raw)});
+}
+
 // ------------------------------ SumsOf8
 HWY_API Vec256<uint64_t> SumsOf8(Vec256<uint8_t> v) {
   return Vec256<uint64_t>{_mm256_sad_epu8(v.raw, _mm256_setzero_si256())};

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -193,9 +193,41 @@ struct TestFloatAbs {
   }
 };
 
+struct TestMaskedAbs {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const MFromD<D> zero_mask = MaskFalse(d);
+    const MFromD<D> first_five = FirstN(d, 5);
+
+    const Vec<D> v0 = Zero(d);
+    const Vec<D> vp1 = Set(d, ConvertScalarTo<T>(1));
+    const Vec<D> vn1 = Set(d, ConvertScalarTo<T>(-1));
+    const Vec<D> vp2 = Set(d, ConvertScalarTo<T>(0.01));
+    const Vec<D> vn2 = Set(d, ConvertScalarTo<T>(-0.01));
+
+    // Test that mask is applied correctly for MaskedAbsOr
+    const Vec<D> v1_exp = IfThenElse(first_five, vp1, vn1);
+    const Vec<D> v2_exp = IfThenElse(first_five, vp2, vn2);
+
+    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedAbsOr(first_five, vn1, vn1));
+    HWY_ASSERT_VEC_EQ(d, v2_exp, MaskedAbsOr(first_five, vn2, vn2));
+
+    // Test that zero mask will return all zeroes for MaskedAbsOrZero
+    HWY_ASSERT_VEC_EQ(d, v0, MaskedAbsOrZero(zero_mask, vn1));
+
+    // Test that zero is returned in cases m==0 for MaskedAbsOrZero
+    const Vec<D> v1_exp_z = IfThenElseZero(first_five, vp1);
+    const Vec<D> v2_exp_z = IfThenElseZero(first_five, vp2);
+
+    HWY_ASSERT_VEC_EQ(d, v1_exp_z, MaskedAbsOrZero(first_five, vn1));
+    HWY_ASSERT_VEC_EQ(d, v2_exp_z, MaskedAbsOrZero(first_five, vn2));
+  }
+};
+
 HWY_NOINLINE void TestAllAbs() {
   ForSignedTypes(ForPartialVectors<TestAbs>());
   ForFloatTypes(ForPartialVectors<TestFloatAbs>());
+  ForSignedTypes(ForPartialVectors<TestMaskedAbs>());
 }
 
 struct TestIntegerNeg {
@@ -248,6 +280,128 @@ HWY_NOINLINE void TestAllNeg() {
   ForSignedTypes(ForPartialVectors<TestIntegerNeg>());
 
   ForSignedTypes(ForPartialVectors<TestNegOverflow>());
+}
+
+struct TestPairwiseAdd {
+  template <typename T, class D, HWY_IF_LANES_GT_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> a = Iota(d, 1);
+    const Vec<D> b = Iota(d, 2);
+
+    const size_t N = Lanes(d);
+    if (N < 2) {
+      return;
+    }
+    T even_val_a, odd_val_a, even_val_b, odd_val_b;
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // Results of a and b are interleaved
+      even_val_a = ConvertScalarTo<T>(i + 1);     // a[i]
+      odd_val_a = ConvertScalarTo<T>(i + 1 + 1);  // a[i+1]
+      even_val_b = ConvertScalarTo<T>(i + 2);     // b[i]
+      odd_val_b = ConvertScalarTo<T>(i + 2 + 1);  // b[i+1]
+
+      expected[i] = even_val_a + odd_val_a;
+      expected[i + 1] = even_val_b + odd_val_b;
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), PairwiseAdd(d, a, b));
+  }
+
+  template <typename T, class D, HWY_IF_LANES_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    (void)d;
+  }
+};
+
+struct TestPairwiseSub {
+  template <typename T, class D, HWY_IF_LANES_GT_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    if (N < 2) {
+      return;
+    }
+
+    auto a_lanes = AllocateAligned<T>(N);
+    auto b_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(a_lanes && b_lanes);
+
+    T even_val_a, odd_val_a, even_val_b, odd_val_b;
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // Results of a and are interleaved
+      even_val_a = ConvertScalarTo<T>(i);         // a[i]
+      odd_val_a = ConvertScalarTo<T>(i * i);      // a[i+1]
+      even_val_b = ConvertScalarTo<T>(i);         // b[i]
+      odd_val_b = ConvertScalarTo<T>(i * i + 2);  // b[i+1]
+
+      a_lanes[i] = even_val_a;     // a[i]
+      a_lanes[i + 1] = odd_val_a;  // a[i+1]
+      b_lanes[i] = even_val_b;     // b[i]
+      b_lanes[i + 1] = odd_val_b;  // b[i+1]
+
+      expected[i] = odd_val_a - even_val_a;
+      expected[i + 1] = odd_val_b - even_val_b;
+    }
+
+    const auto a = Load(d, a_lanes.get());
+    const auto b = Load(d, b_lanes.get());
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), PairwiseSub(d, a, b));
+  }
+
+  template <typename T, class D, HWY_IF_LANES_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    (void)d;
+  }
+};
+
+struct TestPairWiseAdd128 {
+  template <typename T, class D, HWY_IF_LANES_GT_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    auto a = Iota(d, 1);
+    auto b = Iota(d, 2);
+    T even_val_a, odd_val_a, even_val_b, odd_val_b;
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+
+    const size_t vec_bytes = sizeof(T) * N;
+    const size_t blocks_of_128 = (vec_bytes >= 16) ? vec_bytes / 16 : 1;
+    const size_t lanes_in_128 = (vec_bytes >= 16) ? 16 / sizeof(T) : N;
+
+    for (size_t block = 0; block < blocks_of_128; ++block) {
+      for (size_t i = 0; i < lanes_in_128 / 2; ++i) {
+        size_t j = 2 * (block * lanes_in_128 / 2 + i);
+
+        even_val_a = ConvertScalarTo<T>(j + 1);
+        odd_val_a = ConvertScalarTo<T>(j + 2);
+        even_val_b = ConvertScalarTo<T>(j + 2);
+        odd_val_b = ConvertScalarTo<T>(j + 3);
+
+        expected[block * lanes_in_128 + i] = even_val_a + odd_val_a;
+        expected[block * lanes_in_128 + lanes_in_128 / 2 + i] =
+            even_val_b + odd_val_b;
+      }
+    }
+    const auto expected_v = Load(d, expected.get());
+    auto res = PairwiseAdd128(d, a, b);
+    HWY_ASSERT_VEC_EQ(d, expected_v, res);
+  }
+
+  template <typename T, class D, HWY_IF_LANES_D(D, 1)>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    (void)d;
+  }
+};
+
+HWY_NOINLINE void TestAllPairwise() {
+  ForAllTypes(ForPartialVectors<TestPairwiseAdd>());
+  ForAllTypes(ForPartialVectors<TestPairwiseSub>());
+  ForAllTypes(ForGEVectors<128, TestPairWiseAdd128>());
 }
 
 struct TestIntegerAbsDiff {
@@ -306,7 +460,33 @@ HWY_NOINLINE void TestAllIntegerAbsDiff() {
 #endif
 }
 
+struct TestAddLower {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> a = Iota(d, 1);
+    const Vec<D> b = Iota(d, 2);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; ++i) {
+      expected[i] = ConvertScalarTo<T>((i == 0) ? 3 : (i + 1));
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), AddLower(a, b));
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllAddLower() {
+  ForAllTypes(ForPartialVectors<TestAddLower>());
+}
 }  // namespace
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -322,6 +502,8 @@ HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAverage);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAbs);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllNeg);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllIntegerAbsDiff);
+HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAddLower);
+HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllPairwise);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -382,9 +382,10 @@ struct TestPairwiseAdd128 {
         even_val_b = ConvertScalarTo<T>(j + 2);
         odd_val_b = ConvertScalarTo<T>(j + 3);
 
-        expected[block * lanes_in_128 + i] = even_val_a + odd_val_a;
+        expected[block * lanes_in_128 + i] =
+            ConvertScalarTo<T>(even_val_a + odd_val_a);
         expected[block * lanes_in_128 + lanes_in_128 / 2 + i] =
-            even_val_b + odd_val_b;
+            ConvertScalarTo<T>(even_val_b + odd_val_b);
       }
     }
     const auto expected_v = Load(d, expected.get());
@@ -422,9 +423,10 @@ struct TestPairwiseSub128 {
         even_val_b = ConvertScalarTo<T>(j + 2);
         odd_val_b = ConvertScalarTo<T>(2 * j + 4);
 
-        expected[block * lanes_in_128 + i] = odd_val_a - even_val_a;
+        expected[block * lanes_in_128 + i] =
+            ConvertScalarTo<T>(odd_val_a - even_val_a);
         expected[block * lanes_in_128 + lanes_in_128 / 2 + i] =
-            odd_val_b - even_val_b;
+            ConvertScalarTo<T>(odd_val_b - even_val_b);
       }
     }
     const auto expected_v = Load(d, expected.get());

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -303,8 +303,8 @@ struct TestPairwiseAdd {
       even_val_b = ConvertScalarTo<T>(i + 2);     // b[i]
       odd_val_b = ConvertScalarTo<T>(i + 2 + 1);  // b[i+1]
 
-      expected[i] = even_val_a + odd_val_a;
-      expected[i + 1] = even_val_b + odd_val_b;
+      expected[i] = ConvertScalarTo<T>(even_val_a + odd_val_a);
+      expected[i + 1] = ConvertScalarTo<T>(even_val_b + odd_val_b);
     }
 
     HWY_ASSERT_VEC_EQ(d, expected.get(), PairwiseAdd(d, a, b));
@@ -344,8 +344,8 @@ struct TestPairwiseSub {
       b_lanes[i] = even_val_b;     // b[i]
       b_lanes[i + 1] = odd_val_b;  // b[i+1]
 
-      expected[i] = odd_val_a - even_val_a;
-      expected[i + 1] = odd_val_b - even_val_b;
+      expected[i] = ConvertScalarTo<T>(odd_val_a - even_val_a);
+      expected[i + 1] = ConvertScalarTo<T>(odd_val_b - even_val_b);
     }
 
     const auto a = Load(d, a_lanes.get());

--- a/hwy/tests/arithmetic_test.cc
+++ b/hwy/tests/arithmetic_test.cc
@@ -209,18 +209,18 @@ struct TestMaskedAbs {
     const Vec<D> v1_exp = IfThenElse(first_five, vp1, vn1);
     const Vec<D> v2_exp = IfThenElse(first_five, vp2, vn2);
 
-    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedAbsOr(first_five, vn1, vn1));
-    HWY_ASSERT_VEC_EQ(d, v2_exp, MaskedAbsOr(first_five, vn2, vn2));
+    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedAbsOr(vn1, first_five, vn1));
+    HWY_ASSERT_VEC_EQ(d, v2_exp, MaskedAbsOr(vn2, first_five, vn2));
 
-    // Test that zero mask will return all zeroes for MaskedAbsOrZero
-    HWY_ASSERT_VEC_EQ(d, v0, MaskedAbsOrZero(zero_mask, vn1));
+    // Test that zero mask will return all zeroes for MaskedAbs
+    HWY_ASSERT_VEC_EQ(d, v0, MaskedAbs(zero_mask, vn1));
 
-    // Test that zero is returned in cases m==0 for MaskedAbsOrZero
+    // Test that zero is returned in cases m==0 for MaskedAbs
     const Vec<D> v1_exp_z = IfThenElseZero(first_five, vp1);
     const Vec<D> v2_exp_z = IfThenElseZero(first_five, vp2);
 
-    HWY_ASSERT_VEC_EQ(d, v1_exp_z, MaskedAbsOrZero(first_five, vn1));
-    HWY_ASSERT_VEC_EQ(d, v2_exp_z, MaskedAbsOrZero(first_five, vn2));
+    HWY_ASSERT_VEC_EQ(d, v1_exp_z, MaskedAbs(first_five, vn1));
+    HWY_ASSERT_VEC_EQ(d, v2_exp_z, MaskedAbs(first_five, vn2));
   }
 };
 
@@ -460,33 +460,7 @@ HWY_NOINLINE void TestAllIntegerAbsDiff() {
 #endif
 }
 
-struct TestAddLower {
-  template <typename T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
-#if HWY_TARGET != HWY_SCALAR
-    const Vec<D> a = Iota(d, 1);
-    const Vec<D> b = Iota(d, 2);
-
-    const size_t N = Lanes(d);
-    auto expected = AllocateAligned<T>(N);
-    HWY_ASSERT(expected);
-
-    for (size_t i = 0; i < N; ++i) {
-      expected[i] = ConvertScalarTo<T>((i == 0) ? 3 : (i + 1));
-    }
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(), AddLower(a, b));
-#else
-    (void)d;
-#endif
-  }
-};
-
-HWY_NOINLINE void TestAllAddLower() {
-  ForAllTypes(ForPartialVectors<TestAddLower>());
-}
 }  // namespace
-
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -502,7 +476,6 @@ HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAverage);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAbs);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllNeg);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllIntegerAbsDiff);
-HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllAddLower);
 HWY_EXPORT_AND_TEST_P(HwyArithmeticTest, TestAllPairwise);
 HWY_AFTER_TEST();
 }  // namespace


### PR DESCRIPTION
Adding special arithmetic operations for `arm_sve-inl.h` and `generic_ops-inl.h`:

* AddLower adds the first lane of both input vectors and passes the lanes of vector a for all other lanes.
* PairwiseAdd adds consecutive pairs of elements in each of the vectors and interleaves the resulting lanes.
* PairwiseSub subtracts consecutive pairs of elements in each of the vectors and interleaves the resulting lanes.
* PairwiseAdd128 adds consecutive pairs of elements in each of the vectors and then packs the results in 128 bit blocks, such that the results of vector a are in the lower half of the block and the results of vector b are in the upper half of the block.
* PairwiseSub128 subtracts consecutive pairs of elements in each of the vectors and then packs the results in 128 bit blocks, such that the results of vector a are in the lower half of the block and the results of vector b are in the upper half of the block.

Tests have been added for the operations.

The instruction matrix in g3doc/instruction_matrix.pdf may need to be updated, but it appears to have been generated manually.