### PR TITLE
Fixes for ZSeries with GCC 9 or earlier or Clang 18 or earlier

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -294,15 +294,30 @@
 #define HWY_BROKEN_LOONGARCH 0
 #endif
 
+#if HWY_ARCH_S390X
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1900
+// Clang 18 and earlier have bugs with some ZVector intrinsics
+#define HWY_BROKEN_Z14 (HWY_Z14 | HWY_Z15)
+#elif HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 900
+// Z15 target requires GCC 9 or later
+#define HWY_BROKEN_Z14 (HWY_Z15)
+#else
+#define HWY_BROKEN_Z14 0
+#endif
+#else  // !HWY_ARCH_S390X
+#define HWY_BROKEN_Z14 0
+#endif  // HWY_ARCH_S390X
+
 // Allow the user to override this without any guarantee of success.
 #ifndef HWY_BROKEN_TARGETS
 
-#define HWY_BROKEN_TARGETS                                     \
-  (HWY_BROKEN_CLANG6 | HWY_BROKEN_32BIT | HWY_BROKEN_MSVC |    \
-   HWY_BROKEN_AVX3_DL_ZEN4 | HWY_BROKEN_AVX3_SPR |             \
-   HWY_BROKEN_ARM7_BIG_ENDIAN | HWY_BROKEN_ARM7_WITHOUT_VFP4 | \
-   HWY_BROKEN_NEON_BF16 | HWY_BROKEN_SVE | HWY_BROKEN_PPC10 |  \
-   HWY_BROKEN_PPC_32BIT | HWY_BROKEN_RVV | HWY_BROKEN_LOONGARCH)
+#define HWY_BROKEN_TARGETS                                        \
+  (HWY_BROKEN_CLANG6 | HWY_BROKEN_32BIT | HWY_BROKEN_MSVC |       \
+   HWY_BROKEN_AVX3_DL_ZEN4 | HWY_BROKEN_AVX3_SPR |                \
+   HWY_BROKEN_ARM7_BIG_ENDIAN | HWY_BROKEN_ARM7_WITHOUT_VFP4 |    \
+   HWY_BROKEN_NEON_BF16 | HWY_BROKEN_SVE | HWY_BROKEN_PPC10 |     \
+   HWY_BROKEN_PPC_32BIT | HWY_BROKEN_RVV | HWY_BROKEN_LOONGARCH | \
+   HWY_BROKEN_Z14)
 
 #endif  // HWY_BROKEN_TARGETS
 


### PR DESCRIPTION
Resolves issue #2409.

Made fixes to F32->F64 PromoteTo and F64->F32 DemoteTo to work around compiler errors on Z14/Z15 with GCC 8 or GCC 9.

Also made fixes to Reverse on Z14 with GCC 8 to work around the missing vec_reve intrinsic on Z14 with GCC 8 or earlier.

Also marked Z15 target as broken with GCC 8 or earlier as the Z15 target requires GCC 9 or later.

Also marked Z14 and Z15 targets as broken with Clang 18 or earlier due to LLVM bugs in LLVM 18 or earlier on Z14/Z15 that were fixed in LLVM 19, including a bug in LLVM 18 and earlier that was fixed in commit https://github.com/llvm/llvm-project/commit/7e4c6e98fa05f5c3bf14f96365ae74a8d12c6257 (which made its way into LLVM 19 and later).