### PR TITLE
Complex number operations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -510,6 +510,7 @@ HWY_TESTS = [
     ("hwy/tests/", "combine_test"),
     ("hwy/tests/", "compare_test"),
     ("hwy/tests/", "compress_test"),
+    ("hwy/tests/", "complex_arithmetic_test"),
     ("hwy/tests/", "concat_test"),
     ("hwy/tests/", "convert_test"),
     ("hwy/tests/", "count_test"),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,7 @@ set(HWY_TEST_FILES
   hwy/tests/cast_test.cc
   hwy/tests/combine_test.cc
   hwy/tests/compare_test.cc
+  hwy/tests/complex_arithmetic_test.cc
   hwy/tests/compress_test.cc
   hwy/tests/concat_test.cc
   hwy/tests/convert_test.cc

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -948,20 +948,28 @@ i.e. `(a + ib)(c + id)`.
 
 Take `j` to be the even values of `i`.
 
-*   <code>V **ComplexConj**(V v)</code>: returns the complex conjugate of the vector,
+*   `V`: `{f}` \
+    <code>V **ComplexConj**(V v)</code>: returns the complex conjugate of the vector,
     this negates the imaginary lanes. This is equivalent to `OddEven(Neg(a), a)`.
-*   <code>V **MulComplex**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])`
-*   <code>V **MulComplexConj**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])`
-*   <code>V **MulComplexAdd**(V a, V b, V c)</code>: returns
+*   `V`: `{f}` \
+    <code>V **MulComplex**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])`
+*   `V`: `{f}` \
+    <code>V **MulComplexConj**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])`
+*   `V`: `{f}` \
+    <code>V **MulComplexAdd**(V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   <code>V **MulComplexConjAdd**(V a, V b, V c)</code>: returns
+*   `V`: `{f}` \
+    <code>V **MulComplexConjAdd**(V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   <code>V **MaskedMulComplexConjAdd**(M mask, V a, V b, V c)</code>: returns
+*   `V`: `{f}` \
+    <code>V **MaskedMulComplexConjAdd**(M mask, V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])` or `0` if
     `mask[i]` is false.
-*   <code>V **MaskedMulComplexConj**(M mask, V a, V b)</code>: returns
+*   `V`: `{f}` \
+    <code>V **MaskedMulComplexConj**(M mask, V a, V b)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])` or `0` if `mask[i]` is false.
-*   <code>V **MaskedMulComplexOr**(V no, M mask, V a, V b)</code>: returns `(a[j] +
+*   `V`: `{f}` \
+    <code>V **MaskedMulComplexOr**(V no, M mask, V a, V b)</code>: returns `(a[j] +
     i.a[j + 1])(b[j] + i.b[j + 1])` or `no[i]` if `mask[i]` is false.
 
 #### Shifts

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -937,6 +937,33 @@ to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
     <code>V **MaskedApproximateReciprocal**(M m, V a)</code>: returns the
     result of ApproximateReciprocal where m is true and zero otherwise.
 
+#### Complex number operations
+
+Complex types are represented as complex value pairs of real and imaginary
+components, with the real components in even-indexed lanes and the imaginary
+components in odd-indexed lanes.
+
+All multiplies in this section are performing complex multiplication,
+i.e. `(a + ib)(c + id)`.
+
+Take `j` to be the even values of `i`.
+
+*   <code>V **CplxConj**(V v)</code>: returns the complex conjugate of the vector,
+    this negates the imaginary lanes. This is equivalent to `OddEven(Neg(a), a)`.
+*   <code>V **MulCplx**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])`
+*   <code>V **MulCplxConj**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])`
+*   <code>V **MulCplxAdd**(V a, V b, V c)</code>: returns
+    `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1]) + (c[j] + i.c[j + 1])`
+*   <code>V **MulCplxConjAdd**(V a, V b, V c)</code>: returns
+    `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])`
+*   <code>V **MaskedMulCplxConjAddOrZero**(M mask, V a, V b, V c)</code>: returns
+    `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])` or `0` if
+    `mask[i]` is false.
+*   <code>V **MaskedMulCplxConjOrZero**(M mask, V a, V b)</code>: returns
+    `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])` or `0` if `mask[i]` is false.
+*   <code>V **MaskedMulCplxOr**(M mask, V a, V b, V c)</code>: returns `(a[j] +
+    i.a[j + 1])(b[j] + i.b[j + 1])` or `c[i]` if `mask[i]` is false.
+
 #### Shifts
 
 **Note**: Counts not in `[0, sizeof(T)*8)` yield implementation-defined results.

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -948,21 +948,21 @@ i.e. `(a + ib)(c + id)`.
 
 Take `j` to be the even values of `i`.
 
-*   <code>V **CplxConj**(V v)</code>: returns the complex conjugate of the vector,
+*   <code>V **ComplexConj**(V v)</code>: returns the complex conjugate of the vector,
     this negates the imaginary lanes. This is equivalent to `OddEven(Neg(a), a)`.
-*   <code>V **MulCplx**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])`
-*   <code>V **MulCplxConj**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])`
-*   <code>V **MulCplxAdd**(V a, V b, V c)</code>: returns
+*   <code>V **MulComplex**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])`
+*   <code>V **MulComplexConj**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])`
+*   <code>V **MulComplexAdd**(V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   <code>V **MulCplxConjAdd**(V a, V b, V c)</code>: returns
+*   <code>V **MulComplexConjAdd**(V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   <code>V **MaskedMulCplxConjAddOrZero**(M mask, V a, V b, V c)</code>: returns
+*   <code>V **MaskedMulComplexConjAdd**(M mask, V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])` or `0` if
     `mask[i]` is false.
-*   <code>V **MaskedMulCplxConjOrZero**(M mask, V a, V b)</code>: returns
+*   <code>V **MaskedMulComplexConj**(M mask, V a, V b)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1])` or `0` if `mask[i]` is false.
-*   <code>V **MaskedMulCplxOr**(M mask, V a, V b, V c)</code>: returns `(a[j] +
-    i.a[j + 1])(b[j] + i.b[j + 1])` or `c[i]` if `mask[i]` is false.
+*   <code>V **MaskedMulComplexOr**(V no, M mask, V a, V b)</code>: returns `(a[j] +
+    i.a[j + 1])(b[j] + i.b[j + 1])` or `no[i]` if `mask[i]` is false.
 
 #### Shifts
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -6197,6 +6197,130 @@ HWY_API VFromD<DU64> SumOfMulQuadAccumulate(DU64 /*du64*/, svuint16_t a,
   return svdot_u64(sum, a, b);
 }
 
+// ------------------------------ MulCplx* / MaskedMulCplx*
+
+// Per-target flag to prevent generic_ops-inl.h from defining MulCplx*.
+#ifdef HWY_NATIVE_CPLX
+#undef HWY_NATIVE_CPLX
+#else
+#define HWY_NATIVE_CPLX
+#endif
+
+template <class V, HWY_IF_NOT_UNSIGNED(TFromV<V>)>
+HWY_API V CplxConj(V a) {
+  return OddEven(Neg(a), a);
+}
+
+namespace detail {
+#define HWY_SVE_CPLX_FMA_ROT(BASE, CHAR, BITS, HALF, NAME, OP, ROT)      \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME##ROT(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b,        \
+                HWY_SVE_V(BASE, BITS) c) {                               \
+    return sv##OP##_##CHAR##BITS##_x(HWY_SVE_PTRUE(BITS), a, b, c, ROT); \
+  }                                                                      \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME##Z##ROT(svbool_t m, HWY_SVE_V(BASE, BITS) a,                  \
+                   HWY_SVE_V(BASE, BITS) b, HWY_SVE_V(BASE, BITS) c) {   \
+    return sv##OP##_##CHAR##BITS##_z(m, a, b, c, ROT);                   \
+  }
+
+#define HWY_SVE_CPLX_FMA(BASE, CHAR, BITS, HALF, NAME, OP)    \
+  HWY_SVE_CPLX_FMA_ROT(BASE, CHAR, BITS, HALF, NAME, OP, 0)   \
+  HWY_SVE_CPLX_FMA_ROT(BASE, CHAR, BITS, HALF, NAME, OP, 90)  \
+  HWY_SVE_CPLX_FMA_ROT(BASE, CHAR, BITS, HALF, NAME, OP, 180) \
+  HWY_SVE_CPLX_FMA_ROT(BASE, CHAR, BITS, HALF, NAME, OP, 270)
+
+// Only SVE2 has complex multiply add for integer types
+// and these do not include masked variants
+HWY_SVE_FOREACH_F(HWY_SVE_CPLX_FMA, CplxMulAdd, cmla)
+#undef HWY_SVE_CPLX_FMA
+#undef HWY_SVE_CPLX_FMA_ROT
+}  // namespace detail
+
+template <class V, class M, HWY_IF_FLOAT_V(V)>
+HWY_API V MaskedMulCplxConjAddOrZero(M mask, V a, V b, V c) {
+  return detail::CplxMulAddZ270(mask, detail::CplxMulAddZ0(mask, c, b, a), b,
+                                a);
+}
+
+template <class V, class M, HWY_IF_FLOAT_V(V)>
+HWY_API V MaskedMulCplxConjOrZero(M mask, V a, V b) {
+  return MaskedMulCplxConjAddOrZero(mask, a, b, Zero(DFromV<V>()));
+}
+
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V MulCplxAdd(V a, V b, V c) {
+  return detail::CplxMulAdd90(detail::CplxMulAdd0(c, a, b), a, b);
+}
+
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V MulCplx(V a, V b) {
+  return MulCplxAdd(a, b, Zero(DFromV<V>()));
+}
+
+template <class V, class M, HWY_IF_FLOAT_V(V)>
+HWY_API V MaskedMulCplxOr(M mask, V a, V b, V c) {
+  return IfThenElse(mask, MulCplx(a, b), c);
+}
+
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V MulCplxConjAdd(V a, V b, V c) {
+  return detail::CplxMulAdd270(detail::CplxMulAdd0(c, b, a), b, a);
+}
+
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V MulCplxConj(V a, V b) {
+  return MulCplxConjAdd(a, b, Zero(DFromV<V>()));
+}
+
+// TODO SVE2 does have intrinsics for integers but not masked variants
+template <class V, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MulCplx(V a, V b) {
+  // a = u + iv, b = x + iy
+  const auto u = DupEven(a);
+  const auto v = DupOdd(a);
+  const auto x = DupEven(b);
+  const auto y = DupOdd(b);
+
+  return OddEven(Add(Mul(u, y), Mul(v, x)), Sub(Mul(u, x), Mul(v, y)));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MulCplxConj(V a, V b) {
+  // a = u + iv, b = x + iy
+  const auto u = DupEven(a);
+  const auto v = DupOdd(a);
+  const auto x = DupEven(b);
+  const auto y = DupOdd(b);
+
+  return OddEven(Sub(Mul(v, x), Mul(u, y)), Add(Mul(u, x), Mul(v, y)));
+}
+
+template <class V, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MulCplxAdd(V a, V b, V c) {
+  return Add(MulCplx(a, b), c);
+}
+
+template <class V, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MulCplxConjAdd(V a, V b, V c) {
+  return Add(MulCplxConj(a, b), c);
+}
+
+template <class V, class M, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MaskedMulCplxConjAddOrZero(M mask, V a, V b, V c) {
+  return IfThenElseZero(mask, MulCplxConjAdd(a, b, c));
+}
+
+template <class V, class M, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MaskedMulCplxConjOrZero(M mask, V a, V b) {
+  return IfThenElseZero(mask, MulCplxConj(a, b));
+}
+
+template <class V, class M, HWY_IF_NOT_FLOAT_V(V)>
+HWY_API V MaskedMulCplxOr(M mask, V a, V b, V c) {
+  return IfThenElse(mask, MulCplx(a, b), c);
+}
+
 // ------------------------------ AESRound / CLMul
 
 // Static dispatch with -march=armv8-a+sve2+aes, or dynamic dispatch WITHOUT a

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -4388,7 +4388,7 @@ HWY_API V MulSub(V mul, V x, V sub) {
   return Sub(Mul(mul, x), sub);
 }
 #endif  // HWY_NATIVE_INT_FMA
-// ------------------------------ MulCplx* / MaskedMulCplx*
+// ------------------------------ MulComplex* / MaskedMulComplex*
 
 #if (defined(HWY_NATIVE_CPLX) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_CPLX
@@ -4400,55 +4400,55 @@ HWY_API V MulSub(V mul, V x, V sub) {
 #if HWY_TARGET != HWY_SCALAR || HWY_IDE
 
 template <class V, HWY_IF_NOT_UNSIGNED(TFromV<V>)>
-HWY_API V CplxConj(V a) {
+HWY_API V ComplexConj(V a) {
   return OddEven(Neg(a), a);
 }
 
 template <class V>
-HWY_API V MulCplx(V a, V b) {
+HWY_API V MulComplex(V a, V b) {
   // a = u + iv, b = x + iy
   const auto u = DupEven(a);
   const auto v = DupOdd(a);
   const auto x = DupEven(b);
   const auto y = DupOdd(b);
 
-  return OddEven(Add(Mul(u, y), Mul(v, x)), Sub(Mul(u, x), Mul(v, y)));
+  return OddEven(MulAdd(u, y, Mul(v, x)), Sub(Mul(u, x), Mul(v, y)));
 }
 
 template <class V>
-HWY_API V MulCplxConj(V a, V b) {
+HWY_API V MulComplexConj(V a, V b) {
   // a = u + iv, b = x + iy
   const auto u = DupEven(a);
   const auto v = DupOdd(a);
   const auto x = DupEven(b);
   const auto y = DupOdd(b);
 
-  return OddEven(Sub(Mul(v, x), Mul(u, y)), Add(Mul(u, x), Mul(v, y)));
+  return OddEven(Sub(Mul(v, x), Mul(u, y)), MulAdd(u, x, Mul(v, y)));
 }
 
 template <class V>
-HWY_API V MulCplxAdd(V a, V b, V c) {
-  return Add(MulCplx(a, b), c);
+HWY_API V MulComplexAdd(V a, V b, V c) {
+  return Add(MulComplex(a, b), c);
 }
 
 template <class V>
-HWY_API V MulCplxConjAdd(V a, V b, V c) {
-  return Add(MulCplxConj(a, b), c);
+HWY_API V MulComplexConjAdd(V a, V b, V c) {
+  return Add(MulComplexConj(a, b), c);
 }
 
 template <class V, class M>
-HWY_API V MaskedMulCplxConjAddOrZero(M mask, V a, V b, V c) {
-  return IfThenElseZero(mask, MulCplxConjAdd(a, b, c));
+HWY_API V MaskedMulComplexConjAdd(M mask, V a, V b, V c) {
+  return IfThenElseZero(mask, MulComplexConjAdd(a, b, c));
 }
 
 template <class V, class M>
-HWY_API V MaskedMulCplxConjOrZero(M mask, V a, V b) {
-  return IfThenElseZero(mask, MulCplxConj(a, b));
+HWY_API V MaskedMulComplexConj(M mask, V a, V b) {
+  return IfThenElseZero(mask, MulComplexConj(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedMulCplxOr(M mask, V a, V b, V c) {
-  return IfThenElse(mask, MulCplx(a, b), c);
+HWY_API V MaskedMulComplexOr(V no, M mask, V a, V b) {
+  return IfThenElse(mask, MulComplex(a, b), no);
 }
 #endif  // HWY_TARGET != HWY_SCALAR
 

--- a/hwy/tests/complex_arithmetic_test.cc
+++ b/hwy/tests/complex_arithmetic_test.cc
@@ -1,0 +1,354 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/complex_arithmetic_test.cc"
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/tests/test_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+
+struct TestCplxConj {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a - ib)
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      expected[i + 0] = ConvertScalarTo<T>(a);
+      expected[i + 1] = ConvertScalarTo<T>(-b);
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), CplxConj(v1));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllCplxConj() {
+  ForSignedTypes(ForShrinkableVectors<TestCplxConj>());
+  ForFloatTypes(ForShrinkableVectors<TestCplxConj>());
+}
+
+struct TestMulCplx {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c + id)
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
+      expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c));
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplx(v1, v2));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMulCplx() {
+  ForAllTypes(ForShrinkableVectors<TestMulCplx>());
+}
+
+struct TestMulCplxAdd {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+    const Vec<D> v3 = Iota(d, 15);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c + id) + e + if
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      auto e = ConvertScalarTo<T>(i + 15);
+      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d) + e);
+      expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c) + f);
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxAdd(v1, v2, v3));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMulCplxAdd() {
+  ForAllTypes(ForShrinkableVectors<TestMulCplxAdd>());
+}
+
+struct TestMaskedMulCplxOr {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+    const Vec<D> v3 = Iota(d, 15);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c + id)
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      auto e = ConvertScalarTo<T>(i + 15);
+      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      if ((i % 4) ==
+          0) {  // Alternate between masking the real and imaginary lanes
+        bool_lanes[i + 0] = ConvertScalarTo<T>(1);
+        expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
+        bool_lanes[i + 1] = ConvertScalarTo<T>(0);
+        expected[i + 1] = ConvertScalarTo<T>(f);
+      } else {
+        bool_lanes[i + 0] = ConvertScalarTo<T>(0);
+        expected[i + 0] = ConvertScalarTo<T>(e);
+        bool_lanes[i + 1] = ConvertScalarTo<T>(1);
+        expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c));
+      }
+    }
+
+    const auto mask_i = Load(d, bool_lanes.get());
+    const Mask<D> mask = Gt(mask_i, Zero(d));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulCplxOr(mask, v1, v2, v3));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedMulCplxOr() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxOr>());
+}
+
+struct TestMulCplxConj {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c - id)
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
+      expected[i + 1] = ConvertScalarTo<T>((b * c) - (a * d));
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxConj(v1, v2));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMulCplxConj() {
+  ForAllTypes(ForShrinkableVectors<TestMulCplxConj>());
+}
+
+struct TestMulCplxConjAdd {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+    const Vec<D> v3 = Iota(d, 15);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c - id) + e + if
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      auto e = ConvertScalarTo<T>(i + 15);
+      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
+      expected[i + 1] = ConvertScalarTo<T>((f + (c * b)) - (d * a));
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxConjAdd(v1, v2, v3));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMulCplxConjAdd() {
+  ForAllTypes(ForShrinkableVectors<TestMulCplxConjAdd>());
+}
+
+struct TestMaskedMulCplxConjOrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c - id)
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      if ((i % 4) ==
+          0) {  // Alternate between masking the real and imaginary lanes
+        bool_lanes[i + 0] = ConvertScalarTo<T>(1);
+        expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
+        bool_lanes[i + 1] = ConvertScalarTo<T>(0);
+        expected[i + 1] = ConvertScalarTo<T>(0);
+      } else {
+        bool_lanes[i + 0] = ConvertScalarTo<T>(0);
+        expected[i + 0] = ConvertScalarTo<T>(0);
+        bool_lanes[i + 1] = ConvertScalarTo<T>(1);
+        expected[i + 1] = ConvertScalarTo<T>((b * c) - (a * d));
+      }
+    }
+
+    const auto mask_i = Load(d, bool_lanes.get());
+    const Mask<D> mask = Gt(mask_i, Zero(d));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulCplxConjOrZero(mask, v1, v2));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedMulCplxConjOrZero() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxConjOrZero>());
+}
+
+struct TestMaskedMulCplxConjAddOrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const Vec<D> v1 = Iota(d, 2);
+    const Vec<D> v2 = Iota(d, 10);
+    const Vec<D> v3 = Iota(d, 15);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; i += 2) {
+      // expected = (a + ib)(c - id) + e + if
+      auto a = ConvertScalarTo<T>(i + 2);
+      auto b = ConvertScalarTo<T>(i + 2 + 1);
+      auto c = ConvertScalarTo<T>(i + 10);
+      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      auto e = ConvertScalarTo<T>(i + 15);
+      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      if ((i % 4) ==
+          2) {  // Alternate between masking the real and imaginary lanes
+        bool_lanes[i + 0] = ConvertScalarTo<T>(1);
+        expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
+        bool_lanes[i + 1] = ConvertScalarTo<T>(0);
+        expected[i + 1] = ConvertScalarTo<T>(0);
+      } else {
+        bool_lanes[i + 0] = ConvertScalarTo<T>(0);
+        expected[i + 0] = ConvertScalarTo<T>(0);
+        bool_lanes[i + 1] = ConvertScalarTo<T>(1);
+        expected[i + 1] = ConvertScalarTo<T>((f + (c * b)) - (d * a));
+      }
+    }
+
+    const auto mask_i = Load(d, bool_lanes.get());
+    const Mask<D> mask = Gt(mask_i, Zero(d));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedMulCplxConjAddOrZero(mask, v1, v2, v3));
+#else
+    (void)d;
+#endif  // HWY_TARGET != HWY_SCALAR
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedMulCplxConjAddOrZero() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxConjAddOrZero>());
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace hwy {
+HWY_BEFORE_TEST(HwyCplxTest);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllCplxConj);
+
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplx);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxAdd);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxOr);
+
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxConj);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxConjAdd);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxConjOrZero);
+HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxConjAddOrZero);
+HWY_AFTER_TEST();
+}  // namespace hwy
+
+#endif

--- a/hwy/tests/complex_arithmetic_test.cc
+++ b/hwy/tests/complex_arithmetic_test.cc
@@ -350,5 +350,5 @@ HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMaskedMulComplexConj);
 HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMaskedMulComplexConjAdd);
 HWY_AFTER_TEST();
 }  // namespace hwy
-
+HWY_TEST_MAIN();
 #endif

--- a/hwy/tests/complex_arithmetic_test.cc
+++ b/hwy/tests/complex_arithmetic_test.cc
@@ -140,8 +140,8 @@ struct TestMaskedMulComplexOr {
       auto d = ConvertScalarTo<T>(i + 10 + 1);
       auto e = ConvertScalarTo<T>(i + 15);
       auto f = ConvertScalarTo<T>(i + 15 + 1);
-      if ((i % 4) ==
-          0) {  // Alternate between masking the real and imaginary lanes
+      // Alternate between masking the real and imaginary lanes
+      if ((i % 4) == 0) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
         expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);
@@ -251,8 +251,8 @@ struct TestMaskedMulComplexConj {
       auto b = ConvertScalarTo<T>(i + 2 + 1);
       auto c = ConvertScalarTo<T>(i + 10);
       auto d = ConvertScalarTo<T>(i + 10 + 1);
-      if ((i % 4) ==
-          0) {  // Alternate between masking the real and imaginary lanes
+      // Alternate between masking the real and imaginary lanes
+      if ((i % 4) == 0) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
         expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);
@@ -300,8 +300,8 @@ struct TestMaskedMulComplexConjAdd {
       auto d = ConvertScalarTo<T>(i + 10 + 1);
       auto e = ConvertScalarTo<T>(i + 15);
       auto f = ConvertScalarTo<T>(i + 15 + 1);
-      if ((i % 4) ==
-          2) {  // Alternate between masking the real and imaginary lanes
+      // Alternate between masking the real and imaginary lanes
+      if ((i % 4) == 2) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
         expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);

--- a/hwy/tests/complex_arithmetic_test.cc
+++ b/hwy/tests/complex_arithmetic_test.cc
@@ -25,7 +25,7 @@ HWY_BEFORE_NAMESPACE();
 namespace hwy {
 namespace HWY_NAMESPACE {
 
-struct TestCplxConj {
+struct TestComplexConj {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -42,19 +42,19 @@ struct TestCplxConj {
       expected[i + 0] = ConvertScalarTo<T>(a);
       expected[i + 1] = ConvertScalarTo<T>(-b);
     }
-    HWY_ASSERT_VEC_EQ(d, expected.get(), CplxConj(v1));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), ComplexConj(v1));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllCplxConj() {
-  ForSignedTypes(ForShrinkableVectors<TestCplxConj>());
-  ForFloatTypes(ForShrinkableVectors<TestCplxConj>());
+HWY_NOINLINE void TestAllComplexConj() {
+  ForSignedTypes(ForShrinkableVectors<TestComplexConj>());
+  ForFloatTypes(ForShrinkableVectors<TestComplexConj>());
 }
 
-struct TestMulCplx {
+struct TestMulComplex {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -74,18 +74,18 @@ struct TestMulCplx {
       expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
       expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c));
     }
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplx(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplex(v1, v2));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMulCplx() {
-  ForAllTypes(ForShrinkableVectors<TestMulCplx>());
+HWY_NOINLINE void TestAllMulComplex() {
+  ForAllTypes(ForShrinkableVectors<TestMulComplex>());
 }
 
-struct TestMulCplxAdd {
+struct TestMulComplexAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -108,18 +108,18 @@ struct TestMulCplxAdd {
       expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d) + e);
       expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c) + f);
     }
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxAdd(v1, v2, v3));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexAdd(v1, v2, v3));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMulCplxAdd() {
-  ForAllTypes(ForShrinkableVectors<TestMulCplxAdd>());
+HWY_NOINLINE void TestAllMulComplexAdd() {
+  ForAllTypes(ForShrinkableVectors<TestMulComplexAdd>());
 }
 
-struct TestMaskedMulCplxOr {
+struct TestMaskedMulComplexOr {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -157,18 +157,18 @@ struct TestMaskedMulCplxOr {
     const auto mask_i = Load(d, bool_lanes.get());
     const Mask<D> mask = Gt(mask_i, Zero(d));
 
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulCplxOr(mask, v1, v2, v3));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulComplexOr(v3, mask, v1, v2));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMaskedMulCplxOr() {
-  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxOr>());
+HWY_NOINLINE void TestAllMaskedMulComplexOr() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulComplexOr>());
 }
 
-struct TestMulCplxConj {
+struct TestMulComplexConj {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -188,18 +188,18 @@ struct TestMulCplxConj {
       expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
       expected[i + 1] = ConvertScalarTo<T>((b * c) - (a * d));
     }
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxConj(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexConj(v1, v2));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMulCplxConj() {
-  ForAllTypes(ForShrinkableVectors<TestMulCplxConj>());
+HWY_NOINLINE void TestAllMulComplexConj() {
+  ForAllTypes(ForShrinkableVectors<TestMulComplexConj>());
 }
 
-struct TestMulCplxConjAdd {
+struct TestMulComplexConjAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -222,18 +222,18 @@ struct TestMulCplxConjAdd {
       expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
       expected[i + 1] = ConvertScalarTo<T>((f + (c * b)) - (d * a));
     }
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulCplxConjAdd(v1, v2, v3));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexConjAdd(v1, v2, v3));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMulCplxConjAdd() {
-  ForAllTypes(ForShrinkableVectors<TestMulCplxConjAdd>());
+HWY_NOINLINE void TestAllMulComplexConjAdd() {
+  ForAllTypes(ForShrinkableVectors<TestMulComplexConjAdd>());
 }
 
-struct TestMaskedMulCplxConjOrZero {
+struct TestMaskedMulComplexConj {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -268,18 +268,18 @@ struct TestMaskedMulCplxConjOrZero {
     const auto mask_i = Load(d, bool_lanes.get());
     const Mask<D> mask = Gt(mask_i, Zero(d));
 
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulCplxConjOrZero(mask, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulComplexConj(mask, v1, v2));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMaskedMulCplxConjOrZero() {
-  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxConjOrZero>());
+HWY_NOINLINE void TestAllMaskedMulComplexConj() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulComplexConj>());
 }
 
-struct TestMaskedMulCplxConjAddOrZero {
+struct TestMaskedMulComplexConjAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
 #if HWY_TARGET != HWY_SCALAR
@@ -318,15 +318,15 @@ struct TestMaskedMulCplxConjAddOrZero {
     const Mask<D> mask = Gt(mask_i, Zero(d));
 
     HWY_ASSERT_VEC_EQ(d, expected.get(),
-                      MaskedMulCplxConjAddOrZero(mask, v1, v2, v3));
+                      MaskedMulComplexConjAdd(mask, v1, v2, v3));
 #else
     (void)d;
 #endif  // HWY_TARGET != HWY_SCALAR
   }
 };
 
-HWY_NOINLINE void TestAllMaskedMulCplxConjAddOrZero() {
-  ForAllTypes(ForShrinkableVectors<TestMaskedMulCplxConjAddOrZero>());
+HWY_NOINLINE void TestAllMaskedMulComplexConjAdd() {
+  ForAllTypes(ForShrinkableVectors<TestMaskedMulComplexConjAdd>());
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -337,17 +337,17 @@ HWY_AFTER_NAMESPACE();
 #if HWY_ONCE
 
 namespace hwy {
-HWY_BEFORE_TEST(HwyCplxTest);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllCplxConj);
+HWY_BEFORE_TEST(HwyComplexTest);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllComplexConj);
 
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplx);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxAdd);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxOr);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMulComplex);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMulComplexAdd);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMaskedMulComplexOr);
 
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxConj);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMulCplxConjAdd);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxConjOrZero);
-HWY_EXPORT_AND_TEST_P(HwyCplxTest, TestAllMaskedMulCplxConjAddOrZero);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMulComplexConj);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMulComplexConjAdd);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMaskedMulComplexConj);
+HWY_EXPORT_AND_TEST_P(HwyComplexTest, TestAllMaskedMulComplexConjAdd);
 HWY_AFTER_TEST();
 }  // namespace hwy
 

--- a/hwy/tests/complex_arithmetic_test.cc
+++ b/hwy/tests/complex_arithmetic_test.cc
@@ -36,11 +36,11 @@ struct TestComplexConj {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a - ib)
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      expected[i + 0] = ConvertScalarTo<T>(a);
-      expected[i + 1] = ConvertScalarTo<T>(-b);
+      // expected = (x - iy)
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      expected[i + 0] = ConvertScalarTo<T>(x);
+      expected[i + 1] = ConvertScalarTo<T>(-y);
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), ComplexConj(v1));
 #else
@@ -66,13 +66,13 @@ struct TestMulComplex {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c + id)
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
-      expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c));
+      // expected = (x + iy)(u + iv)
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((x * u) - (y * v));
+      expected[i + 1] = ConvertScalarTo<T>((x * v) + (y * u));
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplex(v1, v2));
 #else
@@ -98,15 +98,15 @@ struct TestMulComplexAdd {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c + id) + e + if
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      auto e = ConvertScalarTo<T>(i + 15);
-      auto f = ConvertScalarTo<T>(i + 15 + 1);
-      expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d) + e);
-      expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c) + f);
+      // expected = (x + iy)(u + iv) + a + ib
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      auto a = ConvertScalarTo<T>(i + 15);
+      auto b = ConvertScalarTo<T>(i + 15 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((x * u) - (y * v) + a);
+      expected[i + 1] = ConvertScalarTo<T>((x * v) + (y * u) + b);
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexAdd(v1, v2, v3));
 #else
@@ -133,24 +133,24 @@ struct TestMaskedMulComplexOr {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c + id)
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      auto e = ConvertScalarTo<T>(i + 15);
-      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      // expected = (x + iy)(u + iv)
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      auto a = ConvertScalarTo<T>(i + 15);
+      auto b = ConvertScalarTo<T>(i + 15 + 1);
       // Alternate between masking the real and imaginary lanes
       if ((i % 4) == 0) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
-        expected[i + 0] = ConvertScalarTo<T>((a * c) - (b * d));
+        expected[i + 0] = ConvertScalarTo<T>((x * u) - (y * v));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);
-        expected[i + 1] = ConvertScalarTo<T>(f);
+        expected[i + 1] = ConvertScalarTo<T>(b);
       } else {
         bool_lanes[i + 0] = ConvertScalarTo<T>(0);
-        expected[i + 0] = ConvertScalarTo<T>(e);
+        expected[i + 0] = ConvertScalarTo<T>(a);
         bool_lanes[i + 1] = ConvertScalarTo<T>(1);
-        expected[i + 1] = ConvertScalarTo<T>((a * d) + (b * c));
+        expected[i + 1] = ConvertScalarTo<T>((x * v) + (y * u));
       }
     }
 
@@ -180,13 +180,13 @@ struct TestMulComplexConj {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c - id)
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
-      expected[i + 1] = ConvertScalarTo<T>((b * c) - (a * d));
+      // expected = (x + iy)(u - iv)
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((x * u) + (y * v));
+      expected[i + 1] = ConvertScalarTo<T>((y * u) - (x * v));
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexConj(v1, v2));
 #else
@@ -212,15 +212,15 @@ struct TestMulComplexConjAdd {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c - id) + e + if
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      auto e = ConvertScalarTo<T>(i + 15);
-      auto f = ConvertScalarTo<T>(i + 15 + 1);
-      expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
-      expected[i + 1] = ConvertScalarTo<T>((f + (c * b)) - (d * a));
+      // expected = (x + iy)(u - iv) + a + ib
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      auto a = ConvertScalarTo<T>(i + 15);
+      auto b = ConvertScalarTo<T>(i + 15 + 1);
+      expected[i + 0] = ConvertScalarTo<T>((a + (u * x)) + (v * y));
+      expected[i + 1] = ConvertScalarTo<T>((b + (u * y)) - (v * x));
     }
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulComplexConjAdd(v1, v2, v3));
 #else
@@ -246,22 +246,22 @@ struct TestMaskedMulComplexConj {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c - id)
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
+      // expected = (x + iy)(u - iv)
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
       // Alternate between masking the real and imaginary lanes
       if ((i % 4) == 0) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
-        expected[i + 0] = ConvertScalarTo<T>((a * c) + (b * d));
+        expected[i + 0] = ConvertScalarTo<T>((x * u) + (y * v));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);
         expected[i + 1] = ConvertScalarTo<T>(0);
       } else {
         bool_lanes[i + 0] = ConvertScalarTo<T>(0);
         expected[i + 0] = ConvertScalarTo<T>(0);
         bool_lanes[i + 1] = ConvertScalarTo<T>(1);
-        expected[i + 1] = ConvertScalarTo<T>((b * c) - (a * d));
+        expected[i + 1] = ConvertScalarTo<T>((y * u) - (x * v));
       }
     }
 
@@ -293,24 +293,24 @@ struct TestMaskedMulComplexConjAdd {
     HWY_ASSERT(expected);
 
     for (size_t i = 0; i < N; i += 2) {
-      // expected = (a + ib)(c - id) + e + if
-      auto a = ConvertScalarTo<T>(i + 2);
-      auto b = ConvertScalarTo<T>(i + 2 + 1);
-      auto c = ConvertScalarTo<T>(i + 10);
-      auto d = ConvertScalarTo<T>(i + 10 + 1);
-      auto e = ConvertScalarTo<T>(i + 15);
-      auto f = ConvertScalarTo<T>(i + 15 + 1);
+      // expected = (x + iy)(u - iv) + a + ib
+      auto x = ConvertScalarTo<T>(i + 2);
+      auto y = ConvertScalarTo<T>(i + 2 + 1);
+      auto u = ConvertScalarTo<T>(i + 10);
+      auto v = ConvertScalarTo<T>(i + 10 + 1);
+      auto a = ConvertScalarTo<T>(i + 15);
+      auto b = ConvertScalarTo<T>(i + 15 + 1);
       // Alternate between masking the real and imaginary lanes
       if ((i % 4) == 2) {
         bool_lanes[i + 0] = ConvertScalarTo<T>(1);
-        expected[i + 0] = ConvertScalarTo<T>((e + (c * a)) + (d * b));
+        expected[i + 0] = ConvertScalarTo<T>((a + (u * x)) + (v * y));
         bool_lanes[i + 1] = ConvertScalarTo<T>(0);
         expected[i + 1] = ConvertScalarTo<T>(0);
       } else {
         bool_lanes[i + 0] = ConvertScalarTo<T>(0);
         expected[i + 0] = ConvertScalarTo<T>(0);
         bool_lanes[i + 1] = ConvertScalarTo<T>(1);
-        expected[i + 1] = ConvertScalarTo<T>((f + (c * b)) - (d * a));
+        expected[i + 1] = ConvertScalarTo<T>((b + (u * y)) - (v * x));
       }
     }
 


### PR DESCRIPTION
Introduces basic complex arithmetic for float and integer types. Some masked operations for complex numbers are also included.

A single complex value is formed of a real part which is stored in an even lane, and the imaginary part which is stored in the following odd lane.

All complex operations are written for `arm_sve-inl.h` and `generic_ops-inl.h` and a new set of tests is introduced for all the new complex operations.