### PR TITLE
Float operations SqrtLower, MulSubAdd, GetExponent etc.

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -658,10 +658,6 @@ from left to right, of the arguments passed to `Create{2-4}`.
     <code>V **Sqrt**(V a)</code>: returns `sqrt(a[i])`.
 
 *   `V`: `{f}` \
-    <code>V **SqrtLower**(V a)</code>: returns `sqrt(a[0])` in lowest lane and
-    `a[i]` elsewhere.
-
-*   `V`: `{f}` \
     <code>V **ApproximateReciprocalSqrt**(V a)</code>: returns an approximation
     of `1.0 / sqrt(a[i])`. `sqrt(a) ~= ApproximateReciprocalSqrt(a) * a`. x86
     and PPC provide 12-bit approximations but the error on Arm is closer to 1%.
@@ -893,6 +889,9 @@ exceptions for those lanes if that is supported by the ISA. When exceptions are
 not a concern, these are equivalent to, and potentially more efficient than,
 `IfThenElse(m, Add(a, b), no);` etc.
 
+*   `V`: `{f}` \
+    <code>V **MaskedSqrtOr**(V no, M m, V a)</code>: returns `sqrt(a[i])` or
+    `no[i]` if `m[i]` is false.
 *   <code>V **MaskedMinOr**(V no, M m, V a, V b)</code>: returns `Min(a, b)[i]`
     or `no[i]` if `m[i]` is false.
 *   <code>V **MaskedMaxOr**(V no, M m, V a, V b)</code>: returns `Max(a, b)[i]`
@@ -923,13 +922,13 @@ All ops in this section return `0` for `mask=false` lanes. These are equivalent
 to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
 
 *   `V`: `{f}` \
-    <code>V **MaskedSqrtOrZero**(M m, V a)</code>: returns `sqrt(a[i])` where
+    <code>V **MaskedSqrt**(M m, V a)</code>: returns `sqrt(a[i])` where
     m is true, and zero otherwise.
 *   `V`: `{f}` \
-    <code>V **MaskedApproximateReciprocalSqrtOrZero**(M m, V a)</code>: returns
+    <code>V **MaskedApproximateReciprocalSqrt**(M m, V a)</code>: returns
     the result of ApproximateReciprocalSqrt where m is true and zero otherwise.
 *   `V`: `{f}` \
-    <code>V **MaskedApproximateReciprocalOrZero**(M m, V a)</code>: returns the
+    <code>V **MaskedApproximateReciprocal**(M m, V a)</code>: returns the
     result of ApproximateReciprocal where m is true and zero otherwise.
 
 #### Shifts

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -658,6 +658,10 @@ from left to right, of the arguments passed to `Create{2-4}`.
     <code>V **Sqrt**(V a)</code>: returns `sqrt(a[i])`.
 
 *   `V`: `{f}` \
+    <code>V **SqrtLower**(V a)</code>: returns `sqrt(a[0])` in lowest lane and
+    `a[i]` elsewhere.
+
+*   `V`: `{f}` \
     <code>V **ApproximateReciprocalSqrt**(V a)</code>: returns an approximation
     of `1.0 / sqrt(a[i])`. `sqrt(a) ~= ApproximateReciprocalSqrt(a) * a`. x86
     and PPC provide 12-bit approximations but the error on Arm is closer to 1%.
@@ -665,6 +669,10 @@ from left to right, of the arguments passed to `Create{2-4}`.
 *   `V`: `{f}` \
     <code>V **ApproximateReciprocal**(V a)</code>: returns an approximation of
     `1.0 / a[i]`.
+
+*   `V`: `{f}` \
+    <code>V **GetExponent**(V v)</code>: returns the exponent of `v[i]` as a floating point value.
+    Essentially calculates `floor(log2(x))`.
 
 #### Min/Max
 
@@ -864,6 +872,10 @@ variants are somewhat slower on Arm, and unavailable for integer inputs; if the
     c))` or `MulAddSub(a, b, OddEven(c, Neg(c))`, but `MulSub(a, b, c)` is more
     efficient on some targets (including AVX2/AVX3).
 
+*   <code>V **MulSubAdd**(V a, V b, V c)</code>: returns `a[i] * b[i] + c[i]` in
+    the even lanes and `a[i] * b[i] - c[i]` in the odd lanes. Essentially,
+    MulAddSub with `c[i]` negated.
+
 *   `V`: `bf16`, `D`: `RepartitionToWide<DFromV<V>>`, `VW`: `Vec<D>` \
     <code>VW **MulEvenAdd**(D d, V a, V b, VW c)</code>: equivalent to and
     potentially more efficient than `MulAdd(PromoteEvenTo(d, a),
@@ -904,6 +916,21 @@ not a concern, these are equivalent to, and potentially more efficient than,
     <code>V **MaskedSatSubOr**(V no, M m, V a, V b)</code>: returns `a[i] +
     b[i]` saturated to the minimum/maximum representable value, or `no[i]` if
     `m[i]` is false.
+
+#### Zero masked arithmetic
+
+All ops in this section return `0` for `mask=false` lanes. These are equivalent
+to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
+
+*   `V`: `{f}` \
+    <code>V **MaskedSqrtOrZero**(M m, V a)</code>: returns `sqrt(a[i])` where
+    m is true, and zero otherwise.
+*   `V`: `{f}` \
+    <code>V **MaskedApproximateReciprocalSqrtOrZero**(M m, V a)</code>: returns
+    the result of ApproximateReciprocalSqrt where m is true and zero otherwise.
+*   `V`: `{f}` \
+    <code>V **MaskedApproximateReciprocalOrZero**(M m, V a)</code>: returns the
+    result of ApproximateReciprocal where m is true and zero otherwise.
 
 #### Shifts
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -5275,29 +5275,25 @@ HWY_API VFromD<DI32> SatWidenMulAccumFixedPoint(DI32 di32,
 
 #endif  // HWY_NATIVE_I16_SATWIDENMULACCUMFIXEDPOINT
 
-// ------------------------------ SqrtLower
-#if (defined(HWY_NATIVE_SQRT_LOWER) == defined(HWY_TARGET_TOGGLE))
-#ifdef HWY_NATIVE_SQRT_LOWER
-#undef HWY_NATIVE_SQRT_LOWER
+// ------------------------------ MaskedSqrt
+
+#if (defined(HWY_NATIVE_MASKED_SQRT) == defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_MASKED_SQRT
+#undef HWY_NATIVE_MASKED_SQRT
 #else
-#define HWY_NATIVE_SQRT_LOWER
+#define HWY_NATIVE_MASKED_SQRT
 #endif
-
-template <class V, HWY_IF_FLOAT_V(V)>
-HWY_API V SqrtLower(V a) {
-  const DFromV<V> d;
-  const auto first_mask = FirstN(d, 1);
-  return IfThenElse(first_mask, Sqrt(a), a);
-}
-
-#undef HWY_SVE_SQRT_LOWER
-#endif  // HWY_NATIVE_SQRT_LOWER
-
-// ------------------------------ MaskedSqrtOrZero
 template <class V, HWY_IF_FLOAT_V(V), class M>
-HWY_API V MaskedSqrtOrZero(M m, V v) {
+HWY_API V MaskedSqrt(M m, V v) {
   return IfThenElseZero(m, Sqrt(v));
 }
+
+template <class V, HWY_IF_FLOAT_V(V), class M>
+HWY_API V MaskedSqrtOr(V no, M m, V v) {
+  return IfThenElse(m, Sqrt(v), no);
+}
+#endif
 
 // ------------------------------ SumOfMulQuadAccumulate
 
@@ -5483,9 +5479,9 @@ HWY_API V ApproximateReciprocal(V v) {
 
 #endif  // HWY_NATIVE_F64_APPROX_RECIP
 
-// ------------------------------ MaskedApproximateReciprocalOrZero
+// ------------------------------ MaskedApproximateReciprocal
 template <class V, HWY_IF_FLOAT_V(V), class M>
-HWY_API V MaskedApproximateReciprocalOrZero(M m, V v) {
+HWY_API V MaskedApproximateReciprocal(M m, V v) {
   return IfThenElseZero(m, ApproximateReciprocal(v));
 }
 
@@ -5514,9 +5510,9 @@ HWY_API V ApproximateReciprocalSqrt(V v) {
 
 #endif  // HWY_NATIVE_F64_APPROX_RSQRT
 
-// ------------------------------ MaskedApproximateReciprocalSqrtOrZero
+// ------------------------------ MaskedApproximateReciprocalSqrt
 template <class V, HWY_IF_FLOAT_V(V), class M>
-HWY_API V MaskedApproximateReciprocalSqrtOrZero(M m, V v) {
+HWY_API V MaskedApproximateReciprocalSqrt(M m, V v) {
   return IfThenElseZero(m, ApproximateReciprocalSqrt(v));
 }
 

--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -1939,6 +1939,9 @@ HWY_API Vec128<T, N> ApproximateReciprocal(Vec128<T, N> v) {
 #endif
 }
 
+// TODO: Implement GetExponent using vec_extract_exp (which returns the biased
+//       exponent) followed by a subtraction by MaxExponentField<T>() >> 1
+
 // ------------------------------ Floating-point square root
 
 #if HWY_S390X_HAVE_Z14

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -1842,6 +1842,8 @@ HWY_API Vec512<double> ApproximateReciprocal(Vec512<double> v) {
   return Vec512<double>{_mm512_rcp14_pd(v.raw)};
 }
 
+// TODO: Implement GetExponent using _mm_getexp_ps/_mm_getexp_pd/_mm_getexp_ph
+
 // ------------------------------ MaskedMinOr
 
 template <typename T, HWY_IF_U8(T)>

--- a/hwy/tests/float_test.cc
+++ b/hwy/tests/float_test.cc
@@ -17,7 +17,7 @@
 
 #include <stdio.h>
 
-#include <cmath>  // std::ceil, std::floor
+#include <cmath>  // std::ceil, std::floor, std::log2
 
 #include "hwy/base.h"
 
@@ -166,6 +166,52 @@ HWY_NOINLINE void TestAllApproximateReciprocal() {
   ForFloatTypes(ForPartialVectors<TestApproximateReciprocal>());
 }
 
+struct TestMaskedApproximateReciprocal {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const MFromD<D> first_three = FirstN(d, 3);
+    const auto v = Iota(d, -2);
+    const auto nonzero =
+        IfThenElse(Eq(v, Zero(d)), Set(d, ConvertScalarTo<T>(1)), v);
+    const size_t N = Lanes(d);
+    auto input = AllocateAligned<T>(N);
+    auto actual = AllocateAligned<T>(N);
+    HWY_ASSERT(input && actual);
+
+    Store(nonzero, d, input.get());
+    Store(MaskedApproximateReciprocalOrZero(first_three, nonzero), d, actual.get());
+
+    double max_l1 = 0.0;
+    double worst_expected = 0.0;
+    double worst_actual = 0.0;
+    double expected;
+    for (size_t i = 0; i < N; ++i) {
+      if (i < 3) {
+        expected = 1.0 / input[i];
+      } else {
+        expected = 0.0;
+      }
+      const double l1 = ScalarAbs(expected - actual[i]);
+      if (l1 > max_l1) {
+        max_l1 = l1;
+        worst_expected = expected;
+        worst_actual = actual[i];
+      }
+    }
+    const double abs_worst_expected = ScalarAbs(worst_expected);
+    if (abs_worst_expected > 1E-5) {
+      const double max_rel = max_l1 / abs_worst_expected;
+      fprintf(stderr, "max l1 %f rel %f (%f vs %f)\n", max_l1, max_rel,
+              worst_expected, worst_actual);
+      HWY_ASSERT(max_rel < 0.004);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedApproximateReciprocal() {
+  ForFloatTypes(ForPartialVectors<TestMaskedApproximateReciprocal>());
+}
+
 struct TestSquareRoot {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -176,6 +222,47 @@ struct TestSquareRoot {
 
 HWY_NOINLINE void TestAllSquareRoot() {
   ForFloatTypes(ForPartialVectors<TestSquareRoot>());
+}
+
+struct TestSqrtLower {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const auto vi = Iota(d, 4);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+
+    for (size_t i = 0; i < N; ++i) {
+      if (i == 0) {
+        expected[i] = ConvertScalarTo<T>(2);  // sqrt(4)
+      } else {
+        expected[i] = ConvertScalarTo<T>(i + 4);
+      }
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), SqrtLower(vi));
+  }
+};
+
+HWY_NOINLINE void TestAllSqrtLower() {
+  ForFloatTypes(ForPartialVectors<TestSqrtLower>());
+}
+
+struct TestMaskedSqrt {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const auto v0 = Zero(d);
+    const auto vi = Iota(d, 4);
+
+    const MFromD<D> first_four = FirstN(d, 4);
+    const auto expected = IfThenElse(first_four, Sqrt(vi), v0);
+
+    HWY_ASSERT_VEC_EQ(d, expected, MaskedSqrtOrZero(first_four, vi));
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedSqrt() {
+  ForFloatTypes(ForPartialVectors<TestMaskedSqrt>());
 }
 
 struct TestReciprocalSquareRoot {
@@ -200,6 +287,35 @@ struct TestReciprocalSquareRoot {
 
 HWY_NOINLINE void TestAllReciprocalSquareRoot() {
   ForFloatTypes(ForPartialVectors<TestReciprocalSquareRoot>());
+}
+
+struct TestMaskedReciprocalSquareRoot {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> v = Set(d, ConvertScalarTo<T>(123.0f));
+    const MFromD<D> first_three = FirstN(d, 3);
+    const size_t N = Lanes(d);
+    auto lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(lanes);
+    Store(MaskedApproximateReciprocalSqrtOrZero(first_three, v), d,
+          lanes.get());
+    for (size_t i = 0; i < N; ++i) {
+      T expected_val = i < 3 ? ConvertScalarTo<T>(1 / std::sqrt(123.0f))
+                             : ConvertScalarTo<T>(0);
+      T err =
+          ConvertScalarTo<T>(ConvertScalarTo<float>(lanes[i]) - expected_val);
+      if (err < ConvertScalarTo<T>(0)) err = -err;
+      if (static_cast<double>(err) >= 4E-4) {
+        HWY_ABORT("Lane %d (%d): actual %f err %f\n", static_cast<int>(i),
+                  static_cast<int>(N), static_cast<double>(lanes[i]),
+                  static_cast<double>(err));
+      }
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedReciprocalSquareRoot() {
+  ForFloatTypes(ForPartialVectors<TestMaskedReciprocalSquareRoot>());
 }
 
 template <typename T, class D>
@@ -506,6 +622,29 @@ HWY_NOINLINE void TestAllAbsDiff() {
   ForFloatTypes(ForPartialVectors<TestAbsDiff>());
 }
 
+// Test GetExponent
+struct TestGetExponent {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+
+    auto v = Iota(d, 1);
+
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    for (size_t i = 0; i < N; ++i) {
+      auto test_val = (float)(i + 1);
+      expected[i] = ConvertScalarTo<T>(std::floor(std::log2(test_val)));
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), GetExponent(v));
+  }
+};
+
+HWY_NOINLINE void TestAllGetExponent() {
+  ForFloatTypes(ForPartialVectors<TestGetExponent>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -521,7 +660,11 @@ HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllF32FromF16);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllApproximateReciprocal);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllSquareRoot);
+HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllSqrtLower);
+HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllMaskedSqrt);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllReciprocalSquareRoot);
+HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllMaskedReciprocalSquareRoot);
+HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllMaskedApproximateReciprocal);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllRound);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllNearestInt);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllDemoteToNearestInt);
@@ -529,6 +672,7 @@ HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllTrunc);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllCeil);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllFloor);
 HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllAbsDiff);
+HWY_EXPORT_AND_TEST_P(HwyFloatTest, TestAllGetExponent);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/fma_test.cc
+++ b/hwy/tests/fma_test.cc
@@ -166,6 +166,41 @@ HWY_NOINLINE void TestAllMulAddSub() {
   ForAllTypes(ForPartialVectors<TestMulAddSub>());
 }
 
+struct TestMulSubAdd {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> k0 = Zero(d);
+    const Vec<D> v1 = Iota(d, 1);
+    const Vec<D> v2 = Iota(d, 2);
+
+    // Unlike RebindToSigned, we want to leave floating-point unchanged.
+    // This allows Neg for unsigned types.
+    const Rebind<If<IsFloat<T>(), T, MakeSigned<T>>, D> dif;
+    const Vec<D> neg_v2 = BitCast(d, Neg(BitCast(dif, v2)));
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(expected);
+
+    HWY_ASSERT_VEC_EQ(d, k0, MulSubAdd(k0, k0, k0));
+
+    const auto v2_negated_if_odd = OddEven(neg_v2, v2);
+    HWY_ASSERT_VEC_EQ(d, v2_negated_if_odd, MulSubAdd(k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2_negated_if_odd, MulSubAdd(v1, k0, v2));
+
+    for (size_t i = 0; i < N; ++i) {
+      expected[i] =
+          ConvertScalarTo<T>(((i & 1) == 0) ? ((i + 2) * (i + 2) + (i + 1))
+                                            : ((i + 2) * (i + 2) - (i + 1)));
+    }
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulSubAdd(v2, v2, v1));
+  }
+};
+
+HWY_NOINLINE void TestAllMulSubAdd() {
+  ForAllTypes(ForPartialVectors<TestMulSubAdd>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -179,6 +214,7 @@ HWY_BEFORE_TEST(HwyFmaTest);
 HWY_EXPORT_AND_TEST_P(HwyFmaTest, TestAllMulAdd);
 HWY_EXPORT_AND_TEST_P(HwyFmaTest, TestAllMulSub);
 HWY_EXPORT_AND_TEST_P(HwyFmaTest, TestAllMulAddSub);
+HWY_EXPORT_AND_TEST_P(HwyFmaTest, TestAllMulSubAdd);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
Introduces:
- Masked arithmetic operations (SqrtLower, MaskedSqrtOrZero, MaskedApproximateReciprocalSqrtOrZero, MaskedApproximateReciprocalOrZero)
- GetExponent which returns the exponents of a vector of floating point numbers. 
- MulSubAdd, a variant of MulAddSub which applied a fused multiply-add operation on even lanes and a fused multiply-subtract operation on odd ones.

Operations have been written for `arm_sve-inl.h` and `generic_ops-inl.h` and all operations have tests written for them. 