### PR TITLE
Zero masked arithmetic operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -954,7 +954,7 @@ to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
     b[i]` saturated to the minimum/maximum representable value, or `0` if
     `m[i]` is false.
 *   `V`: `i16` \
-    <code>V **MaskedMulFixedPoint15**(M m, V)</code>: returns returns the
+    <code>V **MaskedMulFixedPoint15**(M m, V a, V b)</code>: returns returns the
     result of multiplying two Q1.15 fixed-point numbers, or `0` if `m[i]` is
     false.
 *   <code>V **MaskedMulAdd**(M m, V a, V b, V c)</code>: returns `a[i] *
@@ -962,7 +962,7 @@ to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
 *   <code>V **MaskedNegMulAdd**(M m, V a, V b, V c)</code>: returns
     `-a[i] * b[i] + c[i]` or `0` if `m[i]` is false.
 *   `V`: `{bf,u,i}16`, `D`: `RepartitionToWide<DFromV<V>>` \
-    <code>Vec&lt;D&gt; **MaskedWidenMulPairwiseAdd**(M m, V)</code>: widens `a`
+    <code>Vec&lt;D&gt; **MaskedWidenMulPairwiseAdd**(D d, M m, V a, V b)</code>: widens `a`
     and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`,
     or `0` if `m[i]` is false.
 *   `V`: `{f}` \

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -935,37 +935,34 @@ not a concern, these are equivalent to, and potentially more efficient than,
 All ops in this section return `0` for `mask=false` lanes. These are equivalent
 to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
 
-*   <code>V **MaskedMaxOrZero**(M m, V a, V b)</code>: returns `Max(a, b)[i]`
+*   <code>V **MaskedMax**(M m, V a, V b)</code>: returns `Max(a, b)[i]`
     or `zero` if `m[i]` is false.
-*   <code>V **MaskedAddOrZero**(M m, V a, V b)</code>: returns `a[i] + b[i]`
+*   <code>V **MaskedAdd**(M m, V a, V b)</code>: returns `a[i] + b[i]`
     or `0` if `m[i]` is false.
-*   <code>V **MaskedSubOrZero**(M m, V a, V b)</code>: returns `a[i] - b[i]`
+*   <code>V **MaskedSub**(M m, V a, V b)</code>: returns `a[i] - b[i]`
     or `0` if `m[i]` is false.
-*   <code>V **MaskedMulOrZero**(M m, V a, V b)</code>: returns `a[i] * b[i]`
+*   <code>V **MaskedMul**(M m, V a, V b)</code>: returns `a[i] * b[i]`
     or `0` if `m[i]` is false.
-*   <code>V **MaskedDivideOrZero**(M m, V a, V b)</code>: returns `a[i] / b[i]`
+*   <code>V **MaskedDiv**(M m, V a, V b)</code>: returns `a[i] / b[i]`
     or `0` if `m[i]` is false.
-*   `V`: `{i,f}` \
-    <code>V **MaskedAbsOrZero**(M m, V a)</code>: returns the absolute value of
-    `a[i]` where m is active and returns zero otherwise.
 *   `V`: `{u,i}{8,16}` \
-    <code>V **MaskedSaturatedAddOrZero**(M m, V a, V b)</code>: returns `a[i] +
+    <code>V **MaskedSaturatedAdd**(M m, V a, V b)</code>: returns `a[i] +
     b[i]` saturated to the minimum/maximum representable value, or `0` if
     `m[i]` is false.
 *   `V`: `{u,i}{8,16}` \
-    <code>V **MaskedSaturatedSubOrZero**(M m, V a, V b)</code>: returns `a[i] -
+    <code>V **MaskedSaturatedSub**(M m, V a, V b)</code>: returns `a[i] -
     b[i]` saturated to the minimum/maximum representable value, or `0` if
     `m[i]` is false.
 *   `V`: `i16` \
-    <code>V **MaskedMulFixedPoint15OrZero**(M m, V)</code>: returns returns the
+    <code>V **MaskedMulFixedPoint15**(M m, V)</code>: returns returns the
     result of multiplying two Q1.15 fixed-point numbers, or `0` if `m[i]` is
     false.
-*   <code>V **MaskedMulAddOrZero**(M m, V a, V b, V c)</code>: returns `a[i] *
+*   <code>V **MaskedMulAdd**(M m, V a, V b, V c)</code>: returns `a[i] *
     b[i] + c[i]` or `0` if `m[i]` is false.
-*   <code>V **MaskedNegMulAddOrZero**(M m, V a, V b, V c)</code>: returns
+*   <code>V **MaskedNegMulAdd**(M m, V a, V b, V c)</code>: returns
     `-a[i] * b[i] + c[i]` or `0` if `m[i]` is false.
 *   `V`: `{bf,u,i}16`, `D`: `RepartitionToWide<DFromV<V>>` \
-    <code>Vec&lt;D&gt; **MaskedWidenMulPairwiseAddOrZero**(M m, V)</code>: widens `a`
+    <code>Vec&lt;D&gt; **MaskedWidenMulPairwiseAdd**(M m, V)</code>: widens `a`
     and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`,
     or `0` if `m[i]` is false.
 *   `V`: `{f}` \

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -935,6 +935,39 @@ not a concern, these are equivalent to, and potentially more efficient than,
 All ops in this section return `0` for `mask=false` lanes. These are equivalent
 to, and potentially more efficient than, `IfThenElseZero(m, Add(a, b));` etc.
 
+*   <code>V **MaskedMaxOrZero**(M m, V a, V b)</code>: returns `Max(a, b)[i]`
+    or `zero` if `m[i]` is false.
+*   <code>V **MaskedAddOrZero**(M m, V a, V b)</code>: returns `a[i] + b[i]`
+    or `0` if `m[i]` is false.
+*   <code>V **MaskedSubOrZero**(M m, V a, V b)</code>: returns `a[i] - b[i]`
+    or `0` if `m[i]` is false.
+*   <code>V **MaskedMulOrZero**(M m, V a, V b)</code>: returns `a[i] * b[i]`
+    or `0` if `m[i]` is false.
+*   <code>V **MaskedDivideOrZero**(M m, V a, V b)</code>: returns `a[i] / b[i]`
+    or `0` if `m[i]` is false.
+*   `V`: `{i,f}` \
+    <code>V **MaskedAbsOrZero**(M m, V a)</code>: returns the absolute value of
+    `a[i]` where m is active and returns zero otherwise.
+*   `V`: `{u,i}{8,16}` \
+    <code>V **MaskedSaturatedAddOrZero**(M m, V a, V b)</code>: returns `a[i] +
+    b[i]` saturated to the minimum/maximum representable value, or `0` if
+    `m[i]` is false.
+*   `V`: `{u,i}{8,16}` \
+    <code>V **MaskedSaturatedSubOrZero**(M m, V a, V b)</code>: returns `a[i] -
+    b[i]` saturated to the minimum/maximum representable value, or `0` if
+    `m[i]` is false.
+*   `V`: `i16` \
+    <code>V **MaskedMulFixedPoint15OrZero**(M m, V)</code>: returns returns the
+    result of multiplying two Q1.15 fixed-point numbers, or `0` if `m[i]` is
+    false.
+*   <code>V **MaskedMulAddOrZero**(M m, V a, V b, V c)</code>: returns `a[i] *
+    b[i] + c[i]` or `0` if `m[i]` is false.
+*   <code>V **MaskedNegMulAddOrZero**(M m, V a, V b, V c)</code>: returns
+    `-a[i] * b[i] + c[i]` or `0` if `m[i]` is false.
+*   `V`: `{bf,u,i}16`, `D`: `RepartitionToWide<DFromV<V>>` \
+    <code>Vec&lt;D&gt; **MaskedWidenMulPairwiseAddOrZero**(M m, V)</code>: widens `a`
+    and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`,
+    or `0` if `m[i]` is false.
 *   `V`: `{f}` \
     <code>V **MaskedSqrt**(M m, V a)</code>: returns `sqrt(a[i])` where
     m is true, and zero otherwise.

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -273,7 +273,12 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
            HWY_SVE_V(BASE, BITS) c) {                         \
     return sv##OP##_##CHAR##BITS(a, b, c);                    \
   }
-
+#define HWY_SVE_RETV_ARGMVVV(BASE, CHAR, BITS, HALF, NAME, OP)           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b, \
+           HWY_SVE_V(BASE, BITS) c) {                                    \
+    return sv##OP##_##CHAR##BITS##_x(m, a, b, c);                        \
+  }
 #define HWY_SVE_RETV_ARGMVVV_Z(BASE, CHAR, BITS, HALF, NAME, OP)           \
   HWY_API HWY_SVE_V(BASE, BITS)                                            \
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) mul, HWY_SVE_V(BASE, BITS) x, \

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -260,11 +260,6 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_x(m, a, b);                             \
   }
-#define HWY_SVE_RETV_ARGMVV_M(BASE, CHAR, BITS, HALF, NAME, OP)            \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
-    return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
-  }
 // User-specified mask. Mask=false value is zero.
 #define HWY_SVE_RETV_ARGMVV_Z(BASE, CHAR, BITS, HALF, NAME, OP)             \
   HWY_API HWY_SVE_V(BASE, BITS)                                            \
@@ -285,7 +280,6 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
            HWY_SVE_V(BASE, BITS) add) {                                    \
     return sv##OP##_##CHAR##BITS##_z(m, x, mul, add);                      \
   }
-
 
 // ------------------------------ Lanes
 
@@ -1801,11 +1795,6 @@ HWY_API VFromD<D> MaskedWidenMulPairwiseAdd(D d32, M m, V16 a, V16 b) {
 template <class DF, class M, HWY_IF_F32_D(DF), class VBF>
 HWY_API VFromD<DF> MaskedWidenMulPairwiseAdd(DF df, M m, VBF a, VBF b) {
   return IfThenElseZero(m, WidenMulPairwiseAdd(df, a, b));
-}
-
-// ------------------------------ MaskedMul_M
-namespace detail {
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_M, MaskedMul_M, mul);
 }
 
 // ================================================== COMPARE
@@ -6663,7 +6652,6 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGMVV
 #undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGMV
-#undef HWY_SVE_RETV_ARGMVV_M
 #undef HWY_SVE_RETV_ARGMVV_Z
 #undef HWY_SVE_RETV_ARGPV
 #undef HWY_SVE_RETV_ARGPVN

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -266,7 +266,7 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
     return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
   }
 // User-specified mask. Mask=false value is zero.
-#define HWY_SVE_RETV_ARGMVVZ(BASE, CHAR, BITS, HALF, NAME, OP)             \
+#define HWY_SVE_RETV_ARGMVV_Z(BASE, CHAR, BITS, HALF, NAME, OP)             \
   HWY_API HWY_SVE_V(BASE, BITS)                                            \
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_z(m, a, b);                             \
@@ -279,12 +279,13 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
     return sv##OP##_##CHAR##BITS(a, b, c);                    \
   }
 
-#define HWY_SVE_RETV_ARGMVVV(BASE, CHAR, BITS, HALF, NAME, OP)           \
-  HWY_API HWY_SVE_V(BASE, BITS)                                          \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b, \
-           HWY_SVE_V(BASE, BITS) c) {                                    \
-    return sv##OP##_##CHAR##BITS##_m(m, a, b, c);                        \
+#define HWY_SVE_RETV_ARGMVVV_Z(BASE, CHAR, BITS, HALF, NAME, OP)           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) mul, HWY_SVE_V(BASE, BITS) x, \
+           HWY_SVE_V(BASE, BITS) add) {                                    \
+    return sv##OP##_##CHAR##BITS##_z(m, x, mul, add);                      \
   }
+
 
 // ------------------------------ Lanes
 
@@ -1751,7 +1752,7 @@ HWY_API VFromD<D> MaxOfLanes(D d, VFromD<D> v) {
   return Set(d, ReduceMax(d, v));
 }
 
-// ------------------------------ MaskedAddOrZero etc. (IfThenElse)
+// ------------------------------ MaskedAdd etc. (IfThenElse)
 
 #ifdef HWY_NATIVE_ZERO_MASKED_ARITH
 #undef HWY_NATIVE_ZERO_MASKED_ARITH
@@ -1759,100 +1760,46 @@ HWY_API VFromD<D> MaxOfLanes(D d, VFromD<D> v) {
 #define HWY_NATIVE_ZERO_MASKED_ARITH
 #endif
 
-#define HWY_SVE_FMAZ(BASE, CHAR, BITS, HALF, NAME, OP)                     \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) mul, HWY_SVE_V(BASE, BITS) x, \
-           HWY_SVE_V(BASE, BITS) add) {                                    \
-    return sv##OP##_##CHAR##BITS##_z(m, x, mul, add);                      \
-  }
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_Z, MaskedMax, max)
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_Z, MaskedAdd, add)
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_Z, MaskedSub, sub)
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_Z, MaskedMul, mul)
+HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGMVV_Z, MaskedDiv, div)
+HWY_SVE_FOREACH_UI32(HWY_SVE_RETV_ARGMVV_Z, MaskedDiv, div)
+HWY_SVE_FOREACH_UI64(HWY_SVE_RETV_ARGMVV_Z, MaskedDiv, div)
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVV_Z, MaskedMulAdd, mad)
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVV_Z, MaskedNegMulAdd, msb)
 
-namespace detail {
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVZ, MaskedAddZero, add)
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVZ, MaskedSubZero, sub)
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVZ, MaskedMulZero, mul)
-HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGMVVZ, MaskedDivZero, div)
-HWY_SVE_FOREACH_UI32(HWY_SVE_RETV_ARGMVVZ, MaskedDivZero, div)
-HWY_SVE_FOREACH_UI64(HWY_SVE_RETV_ARGMVVZ, MaskedDivZero, div)
-HWY_SVE_FOREACH(HWY_SVE_FMAZ, MaskedMulAddZero, mad)
-HWY_SVE_FOREACH(HWY_SVE_FMAZ, MaskedNegMulAddZero, msb)
-#if HWY_SVE_HAVE_2
-HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVVZ, MaskedSatAddZero, qadd)
-HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVVZ, MaskedSatSubZero, qsub)
-#endif
-}  // namespace detail
-
-#undef HWY_SVE_FMAZ
-
-template <class V, class M>
-HWY_API V MaskedAddOrZero(M m, V a, V b) {
-  return detail::MaskedAddZero(m, a, b);
-}
-
-template <class V, class M>
-HWY_API V MaskedSubOrZero(M m, V a, V b) {
-  return detail::MaskedSubZero(m, a, b);
-}
-
-template <class V, class M>
-HWY_API V MaskedMulOrZero(M m, V a, V b) {
-  return detail::MaskedMulZero(m, a, b);
-}
-
-template <class V, class M,
-          HWY_IF_T_SIZE_ONE_OF_V(
-              V, (hwy::IsSame<TFromV<V>, hwy::float16_t>() ? (1 << 2) : 0) |
-                     (1 << 4) | (1 << 8))>
-HWY_API V MaskedDivideOrZero(M m, V a, V b) {
-  return detail::MaskedDivZero(m, a, b);
-}
-
-// I8/U8/I16/U16 MaskedDivideOrZero is implemented after I8/U8/I16/U16 Div
+// I8/U8/I16/U16 MaskedDiv is implemented after I8/U8/I16/U16 Div
 
 #if HWY_SVE_HAVE_2
-template <class V, class M>
-HWY_API V MaskedSaturatedAddOrZero(M m, V a, V b) {
-  return detail::MaskedSatAddZero(m, a, b);
-}
-
-template <class V, class M>
-HWY_API V MaskedSaturatedSubOrZero(M m, V a, V b) {
-  return detail::MaskedSatSubZero(m, a, b);
-}
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVV_Z, MaskedSaturatedAdd, qadd)
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVV_Z, MaskedSaturatedSub, qsub)
 #else
 template <class V, class M>
-HWY_API V MaskedSaturatedAddOrZero(M m, V a, V b) {
+HWY_API V MaskedSaturatedAdd(M m, V a, V b) {
   return IfThenElseZero(m, SaturatedAdd(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedSaturatedSubOrZero(M m, V a, V b) {
+HWY_API V MaskedSaturatedSub(M m, V a, V b) {
   return IfThenElseZero(m, SaturatedSub(a, b));
 }
 #endif
 
 template <class V, class M, typename D = DFromV<V>, HWY_IF_I16_D(D)>
-HWY_API V MaskedMulFixedPoint15OrZero(M m, V a, V b) {
+HWY_API V MaskedMulFixedPoint15(M m, V a, V b) {
   return IfThenElseZero(m, MulFixedPoint15(a, b));
-}
-
-template <class V, class M>
-HWY_API V MaskedMulAddOrZero(M m, V mul, V x, V add) {
-  return detail::MaskedMulAddZero(m, mul, x, add);
-}
-
-template <class V, class M>
-HWY_API V MaskedNegMulAddOrZero(M m, V mul, V x, V add) {
-  return detail::MaskedNegMulAddZero(m, mul, x, add);
 }
 
 template <class D, class M, HWY_IF_UI32_D(D),
           class V16 = VFromD<RepartitionToNarrow<D>>>
-HWY_API VFromD<D> MaskedWidenMulPairwiseAddOrZero(D d32, M m, V16 a, V16 b) {
+HWY_API VFromD<D> MaskedWidenMulPairwiseAdd(D d32, M m, V16 a, V16 b) {
   return IfThenElseZero(m, WidenMulPairwiseAdd(d32, a, b));
 }
 
 template <class DF, class M, HWY_IF_F32_D(DF), class VBF>
-HWY_API VFromD<DF> MaskedWidenMulPairwiseAddOrZero(DF df, M m, VBF a, VBF b) {
+HWY_API VFromD<DF> MaskedWidenMulPairwiseAdd(DF df, M m, VBF a, VBF b) {
   return IfThenElseZero(m, WidenMulPairwiseAdd(df, a, b));
 }
 
@@ -1860,21 +1807,6 @@ HWY_API VFromD<DF> MaskedWidenMulPairwiseAddOrZero(DF df, M m, VBF a, VBF b) {
 namespace detail {
 HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_M, MaskedMul_M, mul);
 }
-
-// ------------------------------ MulLower
-#ifdef HWY_NATIVE_MUL_LOWER
-#undef HWY_NATIVE_MUL_LOWER
-#else
-#define HWY_NATIVE_MUL_LOWER
-#endif
-
-#define HWY_SVE_MUL_LOWER(BASE, CHAR, BITS, HALF, NAME, OP)        \
-  HWY_API HWY_SVE_V(BASE, BITS)                                    \
-      NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) {     \
-    return detail::MaskedMul_M(svptrue_pat_b##BITS(SV_VL1), a, b); \
-  }
-
-HWY_SVE_FOREACH(HWY_SVE_MUL_LOWER, MulLower, _)
 
 // ================================================== COMPARE
 
@@ -5170,7 +5102,7 @@ HWY_API V MaskedDivOr(V no, M m, V a, V b) {
 
 template <class V, class M, HWY_IF_T_SIZE_ONE_OF_V(V, (1 << 1) | (1 << 2)),
           HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
-HWY_API V MaskedDivideOrZero(M m, V a, V b) {
+HWY_API V MaskedDiv(M m, V a, V b) {
   return IfThenElseZero(m, Div(a, b));
 }
 
@@ -6731,6 +6663,8 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGMVV
 #undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGMV
+#undef HWY_SVE_RETV_ARGMVV_M
+#undef HWY_SVE_RETV_ARGMVV_Z
 #undef HWY_SVE_RETV_ARGPV
 #undef HWY_SVE_RETV_ARGPVN
 #undef HWY_SVE_RETV_ARGPVV
@@ -6738,6 +6672,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGVN
 #undef HWY_SVE_RETV_ARGVV
 #undef HWY_SVE_RETV_ARGVVV
+#undef HWY_SVE_RETV_ARGMVVV_Z
 #undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T
 #undef HWY_SVE_UNDEFINED

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -661,6 +661,70 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
+#if (defined(HWY_NATIVE_ZERO_MASKED_ARITH) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_ZERO_MASKED_ARITH
+#undef HWY_NATIVE_ZERO_MASKED_ARITH
+#else
+#define HWY_NATIVE_ZERO_MASKED_ARITH
+#endif
+
+template <class V, class M>
+HWY_API V MaskedAddOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, Add(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedSubOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, Sub(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedMulOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, Mul(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedDivideOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, Div(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedSaturatedAddOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, SaturatedAdd(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedSaturatedSubOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, SaturatedSub(a, b));
+}
+
+template <class V, class M, typename D = DFromV<V>, HWY_IF_I16_D(D)>
+HWY_API V MaskedMulFixedPoint15OrZero(M m, V a, V b) {
+  return IfThenElseZero(m, MulFixedPoint15(a, b));
+}
+
+template <class V, class M>
+HWY_API V MaskedMulAddOrZero(M m, V mul, V x, V add) {
+  return IfThenElseZero(m, MulAdd(mul, x, add));
+}
+
+template <class V, class M>
+HWY_API V MaskedNegMulAddOrZero(M m, V mul, V x, V add) {
+  return IfThenElseZero(m, NegMulAdd(mul, x, add));
+}
+
+template <class D, class M, HWY_IF_UI32_D(D),
+          class V16 = VFromD<RepartitionToNarrow<D>>>
+HWY_API VFromD<D> MaskedWidenMulPairwiseAddOrZero(D d32, M m, V16 a, V16 b) {
+  return IfThenElseZero(m, WidenMulPairwiseAdd(d32, a, b));
+}
+
+template <class DF, class M, HWY_IF_F32_D(DF), class VBF>
+HWY_API VFromD<DF> MaskedWidenMulPairwiseAddOrZero(DF df, M m, VBF a, VBF b) {
+  return IfThenElseZero(m, WidenMulPairwiseAdd(df, a, b));
+}
+#endif  // HWY_NATIVE_ZERO_MASKED_ARITH
+
 // ------------------------------ MaskedEq etc.
 #if (defined(HWY_NATIVE_MASKED_COMP) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_MASKED_COMP

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -669,58 +669,63 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 #endif
 
 template <class V, class M>
-HWY_API V MaskedAddOrZero(M m, V a, V b) {
+HWY_API V MaskedMax(M m, V a, V b) {
+  return IfThenElseZero(m, (Max(a, b)));
+}
+
+template <class V, class M>
+HWY_API V MaskedAdd(M m, V a, V b) {
   return IfThenElseZero(m, Add(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedSubOrZero(M m, V a, V b) {
+HWY_API V MaskedSub(M m, V a, V b) {
   return IfThenElseZero(m, Sub(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedMulOrZero(M m, V a, V b) {
+HWY_API V MaskedMul(M m, V a, V b) {
   return IfThenElseZero(m, Mul(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedDivideOrZero(M m, V a, V b) {
+HWY_API V MaskedDiv(M m, V a, V b) {
   return IfThenElseZero(m, Div(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedSaturatedAddOrZero(M m, V a, V b) {
+HWY_API V MaskedSaturatedAdd(M m, V a, V b) {
   return IfThenElseZero(m, SaturatedAdd(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedSaturatedSubOrZero(M m, V a, V b) {
+HWY_API V MaskedSaturatedSub(M m, V a, V b) {
   return IfThenElseZero(m, SaturatedSub(a, b));
 }
 
 template <class V, class M, typename D = DFromV<V>, HWY_IF_I16_D(D)>
-HWY_API V MaskedMulFixedPoint15OrZero(M m, V a, V b) {
+HWY_API V MaskedMulFixedPoint15(M m, V a, V b) {
   return IfThenElseZero(m, MulFixedPoint15(a, b));
 }
 
 template <class V, class M>
-HWY_API V MaskedMulAddOrZero(M m, V mul, V x, V add) {
+HWY_API V MaskedMulAdd(M m, V mul, V x, V add) {
   return IfThenElseZero(m, MulAdd(mul, x, add));
 }
 
 template <class V, class M>
-HWY_API V MaskedNegMulAddOrZero(M m, V mul, V x, V add) {
+HWY_API V MaskedNegMulAdd(M m, V mul, V x, V add) {
   return IfThenElseZero(m, NegMulAdd(mul, x, add));
 }
 
 template <class D, class M, HWY_IF_UI32_D(D),
           class V16 = VFromD<RepartitionToNarrow<D>>>
-HWY_API VFromD<D> MaskedWidenMulPairwiseAddOrZero(D d32, M m, V16 a, V16 b) {
+HWY_API VFromD<D> MaskedWidenMulPairwiseAdd(D d32, M m, V16 a, V16 b) {
   return IfThenElseZero(m, WidenMulPairwiseAdd(d32, a, b));
 }
 
 template <class DF, class M, HWY_IF_F32_D(DF), class VBF>
-HWY_API VFromD<DF> MaskedWidenMulPairwiseAddOrZero(DF df, M m, VBF a, VBF b) {
+HWY_API VFromD<DF> MaskedWidenMulPairwiseAdd(DF df, M m, VBF a, VBF b) {
   return IfThenElseZero(m, WidenMulPairwiseAdd(df, a, b));
 }
 #endif  // HWY_NATIVE_ZERO_MASKED_ARITH

--- a/hwy/tests/fma_test.cc
+++ b/hwy/tests/fma_test.cc
@@ -35,10 +35,13 @@ struct TestMulAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
+
+    using TI = MakeSigned<T>;
+    const Rebind<TI, D> di;
     const Vec<D> k0 = Zero(d);
     const Vec<D> v1 = Iota(d, 1);
     const Vec<D> v2 = Iota(d, 2);
-    VFromD<D> mask_i;
+    VFromD<decltype(di)> mask_i;
     Mask<D> mask;
 
     // Unlike RebindToSigned, we want to leave floating-point unchanged.
@@ -47,7 +50,7 @@ struct TestMulAdd {
     const Vec<D> neg_v2 = BitCast(d, Neg(BitCast(dif, v2)));
 
     const size_t N = Lanes(d);
-    auto bool_lanes = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<TI>(N);
     auto masked_expected = AllocateAligned<T>(N);
     auto expected = AllocateAligned<T>(N);
     HWY_ASSERT(bool_lanes && masked_expected && expected);
@@ -65,7 +68,7 @@ struct TestMulAdd {
     HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAdd(MaskTrue(d), v1, k0, v2));
 
     for (size_t i = 0; i < N; ++i) {
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
       expected[i] = ConvertScalarTo<T>((i + 1) * (i + 2));
       if (bool_lanes[i]) {
         masked_expected[i] = expected[i];
@@ -73,8 +76,8 @@ struct TestMulAdd {
         masked_expected[i] = ConvertScalarTo<T>(0);
       }
     }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+    mask_i = Load(di, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v2, v1, k0));
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v1, v2, k0));
@@ -88,7 +91,7 @@ struct TestMulAdd {
                       MaskedNegMulAdd(mask, v1, neg_v2, k0));
 
     for (size_t i = 0; i < N; ++i) {
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
       expected[i] = ConvertScalarTo<T>((i + 2) * (i + 2) + (i + 1));
       if (bool_lanes[i]) {
         masked_expected[i] = expected[i];
@@ -96,8 +99,8 @@ struct TestMulAdd {
         masked_expected[i] = ConvertScalarTo<T>(0);
       }
     }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+    mask_i = Load(di, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v2, v2, v1));
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(neg_v2, v2, v1));
@@ -109,7 +112,7 @@ struct TestMulAdd {
       const T nm = ConvertScalarTo<T>(-static_cast<int>(i + 2));
       const T f = ConvertScalarTo<T>(i + 2);
       const T a = ConvertScalarTo<T>(i + 1);
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
       expected[i] = ConvertScalarTo<T>(nm * f + a);
       if (bool_lanes[i]) {
         masked_expected[i] = expected[i];
@@ -117,8 +120,8 @@ struct TestMulAdd {
         masked_expected[i] = ConvertScalarTo<T>(0);
       }
     }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+    mask_i = Load(di, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(v2, v2, v1));
     HWY_ASSERT_VEC_EQ(d, masked_expected.get(),

--- a/hwy/tests/fma_test.cc
+++ b/hwy/tests/fma_test.cc
@@ -34,9 +34,12 @@ namespace {
 struct TestMulAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
     const Vec<D> k0 = Zero(d);
     const Vec<D> v1 = Iota(d, 1);
     const Vec<D> v2 = Iota(d, 2);
+    VFromD<D> mask_i;
+    Mask<D> mask;
 
     // Unlike RebindToSigned, we want to leave floating-point unchanged.
     // This allows Neg for unsigned types.
@@ -44,36 +47,82 @@ struct TestMulAdd {
     const Vec<D> neg_v2 = BitCast(d, Neg(BitCast(dif, v2)));
 
     const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<T>(N);
+    auto masked_expected = AllocateAligned<T>(N);
     auto expected = AllocateAligned<T>(N);
-    HWY_ASSERT(expected);
+    HWY_ASSERT(bool_lanes && masked_expected && expected);
     HWY_ASSERT_VEC_EQ(d, k0, MulAdd(k0, k0, k0));
     HWY_ASSERT_VEC_EQ(d, v2, MulAdd(k0, v1, v2));
     HWY_ASSERT_VEC_EQ(d, v2, MulAdd(v1, k0, v2));
+    HWY_ASSERT_VEC_EQ(d, k0, MaskedMulAdd(MaskTrue(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAdd(MaskTrue(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAdd(MaskTrue(d), v1, k0, v2));
     HWY_ASSERT_VEC_EQ(d, k0, NegMulAdd(k0, k0, k0));
     HWY_ASSERT_VEC_EQ(d, v2, NegMulAdd(k0, v1, v2));
     HWY_ASSERT_VEC_EQ(d, v2, NegMulAdd(v1, k0, v2));
+    HWY_ASSERT_VEC_EQ(d, k0, MaskedNegMulAdd(MaskTrue(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAdd(MaskTrue(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAdd(MaskTrue(d), v1, k0, v2));
 
     for (size_t i = 0; i < N; ++i) {
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
       expected[i] = ConvertScalarTo<T>((i + 1) * (i + 2));
+      if (bool_lanes[i]) {
+        masked_expected[i] = expected[i];
+      } else {
+        masked_expected[i] = ConvertScalarTo<T>(0);
+      }
     }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v2, v1, k0));
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v1, v2, k0));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(), MaskedMulAdd(mask, v2, v1, k0));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(), MaskedMulAdd(mask, v1, v2, k0));
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(neg_v2, v1, k0));
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(v1, neg_v2, k0));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(),
+                      MaskedNegMulAdd(mask, neg_v2, v1, k0));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(),
+                      MaskedNegMulAdd(mask, v1, neg_v2, k0));
 
     for (size_t i = 0; i < N; ++i) {
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
       expected[i] = ConvertScalarTo<T>((i + 2) * (i + 2) + (i + 1));
+      if (bool_lanes[i]) {
+        masked_expected[i] = expected[i];
+      } else {
+        masked_expected[i] = ConvertScalarTo<T>(0);
+      }
     }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
     HWY_ASSERT_VEC_EQ(d, expected.get(), MulAdd(v2, v2, v1));
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(neg_v2, v2, v1));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(), MaskedMulAdd(mask, v2, v2, v1));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(),
+                      MaskedNegMulAdd(mask, neg_v2, v2, v1));
 
     for (size_t i = 0; i < N; ++i) {
       const T nm = ConvertScalarTo<T>(-static_cast<int>(i + 2));
       const T f = ConvertScalarTo<T>(i + 2);
       const T a = ConvertScalarTo<T>(i + 1);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
       expected[i] = ConvertScalarTo<T>(nm * f + a);
+      if (bool_lanes[i]) {
+        masked_expected[i] = expected[i];
+      } else {
+        masked_expected[i] = ConvertScalarTo<T>(0);
+      }
     }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
     HWY_ASSERT_VEC_EQ(d, expected.get(), NegMulAdd(v2, v2, v1));
+    HWY_ASSERT_VEC_EQ(d, masked_expected.get(),
+                      MaskedNegMulAdd(mask, v2, v2, v1));
   }
 };
 

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -882,6 +882,7 @@ HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSub);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivMod);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllFloatExceptions);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedMulAdd);
 
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedAddSubMul);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedSatAddSub);

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -429,7 +429,7 @@ HWY_NOINLINE void TestAllMaskedMulAdd() {
   ForAllTypes(ForPartialVectors<TestMaskedMulAdd>());
 }
 }  // namespace
-struct TestAddSubMulOrZero {
+struct TestMaskedAddSubMul {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
@@ -474,19 +474,19 @@ struct TestAddSubMulOrZero {
       const VI mask_i = Load(di, bool_lanes.get());
       const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
-      HWY_ASSERT_VEC_EQ(d, expected_add.get(), MaskedAddOrZero(mask, v3, v4));
-      HWY_ASSERT_VEC_EQ(d, expected_sub.get(), MaskedSubOrZero(mask, tv4, v3));
+      HWY_ASSERT_VEC_EQ(d, expected_add.get(), MaskedAdd(mask, v3, v4));
+      HWY_ASSERT_VEC_EQ(d, expected_sub.get(), MaskedSub(mask, tv4, v3));
       HWY_ASSERT_VEC_EQ(d, expected_mul.get(),
-                        MaskedMulOrZero(mask, in_mul, in_mul));
+                        MaskedMul(mask, in_mul, in_mul));
     }
   }
 };
 
-HWY_NOINLINE void TestAllAddSubMulOrZero() {
-  ForAllTypes(ForPartialVectors<TestAddSubMulOrZero>());
+HWY_NOINLINE void TestAllMaskedAddSubMul() {
+  ForAllTypes(ForPartialVectors<TestMaskedAddSubMul>());
 }
 
-struct TestUnsignedSatAddSubOrZero {
+struct TestUnsignedMaskedSatAddSub {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
@@ -515,37 +515,37 @@ struct TestUnsignedSatAddSubOrZero {
       Vec<D> expected_add =
           IfThenElse(mask, Set(d, static_cast<T>(0)), disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, v0));
+                        MaskedSaturatedAdd(mask, v0, v0));
       expected_add = IfThenElse(mask, vi, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, vi));
+                        MaskedSaturatedAdd(mask, v0, vi));
       expected_add = IfThenElse(mask, Set(d, static_cast<T>(LimitsMax<T>())),
                                 disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, vm));
+                        MaskedSaturatedAdd(mask, v0, vm));
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, vi, vm));
+                        MaskedSaturatedAdd(mask, vi, vm));
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, vm, vm));
+                        MaskedSaturatedAdd(mask, vm, vm));
 
       Vec<D> expected_sub =
           IfThenElse(mask, Set(d, static_cast<T>(0)), disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, v0, v0));
+                        MaskedSaturatedSub(mask, v0, v0));
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, v0, vi));
+                        MaskedSaturatedSub(mask, v0, vi));
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vi, vi));
+                        MaskedSaturatedSub(mask, vi, vi));
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vi, vm));
+                        MaskedSaturatedSub(mask, vi, vm));
       expected_sub = IfThenElse(mask, Sub(vm, vi), disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vm, vi));
+                        MaskedSaturatedSub(mask, vm, vi));
     }
   }
 };
 
-struct TestSignedSatAddSubOrZero {
+struct TestSignedMaskedSatAddSub {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
@@ -575,42 +575,42 @@ struct TestSignedSatAddSubOrZero {
 
       Vec<D> expected_add = IfThenElse(mask, v0, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, v0));
+                        MaskedSaturatedAdd(mask, v0, v0));
       expected_add = IfThenElse(mask, vi, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, vi));
+                        MaskedSaturatedAdd(mask, v0, vi));
       expected_add = IfThenElse(mask, vpm, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, v0, vpm));
+                        MaskedSaturatedAdd(mask, v0, vpm));
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, vi, vpm));
+                        MaskedSaturatedAdd(mask, vi, vpm));
       HWY_ASSERT_VEC_EQ(d, expected_add,
-                        MaskedSaturatedAddOrZero(mask, vpm, vpm));
+                        MaskedSaturatedAdd(mask, vpm, vpm));
 
       Vec<D> expected_sub = IfThenElse(mask, v0, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, v0, v0));
+                        MaskedSaturatedSub(mask, v0, v0));
       expected_sub = IfThenElse(mask, Sub(v0, vi), disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, v0, vi));
+                        MaskedSaturatedSub(mask, v0, vi));
       expected_sub = IfThenElse(mask, vn, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vn, v0));
+                        MaskedSaturatedSub(mask, vn, v0));
       expected_sub = IfThenElse(mask, vnm, disabled_lane_val);
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vnm, vi));
+                        MaskedSaturatedSub(mask, vnm, vi));
       HWY_ASSERT_VEC_EQ(d, expected_sub,
-                        MaskedSaturatedSubOrZero(mask, vnm, vpm));
+                        MaskedSaturatedSub(mask, vnm, vpm));
     }
   }
 };
 
-HWY_NOINLINE void TestAllSatAddSubOrZero() {
-  ForU816(ForPartialVectors<TestUnsignedSatAddSubOrZero>());
-  ForI816(ForPartialVectors<TestSignedSatAddSubOrZero>());
+HWY_NOINLINE void TestAllMaskedSatAddSub() {
+  ForU816(ForPartialVectors<TestUnsignedMaskedSatAddSub>());
+  ForI816(ForPartialVectors<TestSignedMaskedSatAddSub>());
 }
 
-struct TestDivOrZero {
+struct TestMaskedDiv {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
@@ -645,16 +645,16 @@ struct TestDivOrZero {
       const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
       const Vec<D> div = Set(d, ConvertScalarTo<T>(2));
-      HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedDivideOrZero(mask, pows, div));
+      HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedDiv(mask, pows, div));
     }
   }
 };
 
-HWY_NOINLINE void TestAllDivOrZero() {
-  ForFloatTypes(ForPartialVectors<TestDivOrZero>());
+HWY_NOINLINE void TestAllMaskedDiv() {
+  ForFloatTypes(ForPartialVectors<TestMaskedDiv>());
 }
 
-struct TestIntegerDivOrZero {
+struct TestIntegerMaskedDiv {
   template <class D, HWY_IF_SIGNED_D(D)>
   static HWY_INLINE void DoSignedDivModTests(
       D d, const TFromD<D>* HWY_RESTRICT expected_quot,
@@ -664,10 +664,10 @@ struct TestIntegerDivOrZero {
     const auto neg_b = Neg(vb);
 
     HWY_ASSERT_VEC_EQ(d, neg_expected_quot,
-                      MaskedDivideOrZero(mask, neg_a, vb));
+                      MaskedDiv(mask, neg_a, vb));
     HWY_ASSERT_VEC_EQ(d, neg_expected_quot,
-                      MaskedDivideOrZero(mask, va, neg_b));
-    HWY_ASSERT_VEC_EQ(d, expected_quot, MaskedDivideOrZero(mask, neg_a, neg_b));
+                      MaskedDiv(mask, va, neg_b));
+    HWY_ASSERT_VEC_EQ(d, expected_quot, MaskedDiv(mask, neg_a, neg_b));
   }
 
   template <class D, HWY_IF_UNSIGNED_D(D)>
@@ -738,18 +738,18 @@ struct TestIntegerDivOrZero {
       const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
       HWY_ASSERT_VEC_EQ(d, expected_quot.get(),
-                        MaskedDivideOrZero(mask, va, vb));
+                        MaskedDiv(mask, va, vb));
       DoSignedDivModTests(d, expected_quot.get(), neg_expected_quot.get(), mask,
                           va, vb);
     }
   }
 };
 
-HWY_NOINLINE void TestAllIntegerDivOrZero() {
-  ForIntegerTypes(ForPartialVectors<TestIntegerDivOrZero>());
+HWY_NOINLINE void TestAllIntegerMaskedDiv() {
+  ForIntegerTypes(ForPartialVectors<TestIntegerMaskedDiv>());
 }
 
-struct TestMulFixedPoint15OrZero {
+struct TestMaskedMulFixedPoint15 {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const auto v0 = Zero(d);
@@ -803,98 +803,16 @@ struct TestMulFixedPoint15OrZero {
       const auto a = Load(d, in1.get());
       const auto b = Load(d, in2.get());
       HWY_ASSERT_VEC_EQ(d, expected.get(),
-                        MaskedMulFixedPoint15OrZero(mask, a, b));
+                        MaskedMulFixedPoint15(mask, a, b));
     }
   }
 };
 
-HWY_NOINLINE void TestAllMulFixedPoint15OrZero() {
-  ForPartialVectors<TestMulFixedPoint15OrZero>()(int16_t());
+HWY_NOINLINE void TestAllMaskedMulFixedPoint15() {
+  ForPartialVectors<TestMaskedMulFixedPoint15>()(int16_t());
 }
 
-struct TestMulAddOrZero {
-  template <typename T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
-    RandomState rng;
-    const Vec<D> k0 = Zero(d);
-    const Vec<D> v1 = Iota(d, 1);
-    const Vec<D> v2 = Iota(d, 2);
-    VFromD<D> mask_i;
-    Mask<D> mask;
-
-    // Unlike RebindToSigned, we want to leave floating-point unchanged.
-    // This allows Neg for unsigned types.
-    const Rebind<If<IsFloat<T>(), T, MakeSigned<T>>, D> dif;
-    const Vec<D> neg_v2 = BitCast(d, Neg(BitCast(dif, v2)));
-
-    const size_t N = Lanes(d);
-    auto bool_lanes = AllocateAligned<T>(N);
-    auto expected = AllocateAligned<T>(N);
-    HWY_ASSERT(bool_lanes && expected);
-    HWY_ASSERT_VEC_EQ(d, k0, MaskedMulAddOrZero(MaskTrue(d), k0, k0, k0));
-    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOrZero(MaskTrue(d), k0, v1, v2));
-    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOrZero(MaskTrue(d), v1, k0, v2));
-    HWY_ASSERT_VEC_EQ(d, k0, MaskedNegMulAddOrZero(MaskTrue(d), k0, k0, k0));
-    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAddOrZero(MaskTrue(d), k0, v1, v2));
-    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAddOrZero(MaskTrue(d), v1, k0, v2));
-
-    for (size_t i = 0; i < N; ++i) {
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
-      if (bool_lanes[i]) {
-        expected[i] = ConvertScalarTo<T>((i + 1) * (i + 2));
-      } else {
-        expected[i] = ConvertScalarTo<T>(0);
-      }
-    }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v2, v1, k0));
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v1, v2, k0));
-    HWY_ASSERT_VEC_EQ(d, expected.get(),
-                      MaskedNegMulAddOrZero(mask, neg_v2, v1, k0));
-    HWY_ASSERT_VEC_EQ(d, expected.get(),
-                      MaskedNegMulAddOrZero(mask, v1, neg_v2, k0));
-
-    for (size_t i = 0; i < N; ++i) {
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
-      if (bool_lanes[i]) {
-        expected[i] = ConvertScalarTo<T>((i + 2) * (i + 2) + (i + 1));
-      } else {
-        expected[i] = ConvertScalarTo<T>(0);
-      }
-    }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v2, v2, v1));
-    HWY_ASSERT_VEC_EQ(d, expected.get(),
-                      MaskedNegMulAddOrZero(mask, neg_v2, v2, v1));
-
-    for (size_t i = 0; i < N; ++i) {
-      const T nm = ConvertScalarTo<T>(-static_cast<int>(i + 2));
-      const T f = ConvertScalarTo<T>(i + 2);
-      const T a = ConvertScalarTo<T>(i + 1);
-      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
-      if (bool_lanes[i]) {
-        expected[i] = ConvertScalarTo<T>(nm * f + a);
-      } else {
-        expected[i] = ConvertScalarTo<T>(0);
-      }
-    }
-    mask_i = Load(d, bool_lanes.get());
-    mask = RebindMask(d, Gt(mask_i, Zero(d)));
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(),
-                      MaskedNegMulAddOrZero(mask, v2, v2, v1));
-  }
-};
-
-HWY_NOINLINE void TestAllMulAddOrZero() {
-  ForAllTypes(ForPartialVectors<TestMulAddOrZero>());
-}
-
-struct TestWidenMulPairwiseAddOrZero {
+struct TestMaskedWidenMulPairwiseAdd {
   // Must be inlined on aarch64 for bf16, else clang crashes.
   template <typename TN, class DN>
   HWY_INLINE void operator()(TN /*unused*/, DN dn) {
@@ -912,11 +830,11 @@ struct TestWidenMulPairwiseAddOrZero {
 
     // Any input zero => both outputs zero
     HWY_ASSERT_VEC_EQ(
-        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf0, bf0));
+        dw, f0, MaskedWidenMulPairwiseAdd(dw, MaskTrue(dw), bf0, bf0));
     HWY_ASSERT_VEC_EQ(
-        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf0, bf1));
+        dw, f0, MaskedWidenMulPairwiseAdd(dw, MaskTrue(dw), bf0, bf1));
     HWY_ASSERT_VEC_EQ(
-        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf1, bf0));
+        dw, f0, MaskedWidenMulPairwiseAdd(dw, MaskTrue(dw), bf1, bf0));
 
     auto expected = AllocateAligned<TW>(NN / 2);
     const auto v1l = Iota(dw, 1);
@@ -938,17 +856,17 @@ struct TestWidenMulPairwiseAddOrZero {
 
     HWY_ASSERT_VEC_EQ(
         dw, expected.get(),
-        MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), v1, v2));
+        MaskedWidenMulPairwiseAdd(dw, MaskTrue(dw), v1, v2));
     HWY_ASSERT_VEC_EQ(
         dw, expected.get(),
-        MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), v2, v1));
+        MaskedWidenMulPairwiseAdd(dw, MaskTrue(dw), v2, v1));
   }
 };
 
-HWY_NOINLINE void TestAllWidenMulPairwiseAddOrZero() {
-  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(bfloat16_t());
-  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(int16_t());
-  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(uint16_t());
+HWY_NOINLINE void TestAllMaskedWidenMulPairwiseAdd() {
+  ForShrinkableVectors<TestMaskedWidenMulPairwiseAdd>()(bfloat16_t());
+  ForShrinkableVectors<TestMaskedWidenMulPairwiseAdd>()(int16_t());
+  ForShrinkableVectors<TestMaskedWidenMulPairwiseAdd>()(uint16_t());
 }
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -965,14 +883,13 @@ HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivMod);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllFloatExceptions);
 
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllAddSubMulOrZero);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSubOrZero);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDivOrZero);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivOrZero);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMulFixedPoint15OrZero);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedMulAdd);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedAddSubMul);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedSatAddSub);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedDiv);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerMaskedDiv);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedMulFixedPoint15);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest,
-                      TestAllWidenMulPairwiseAddOrZero);
+                      TestAllMaskedWidenMulPairwiseAdd);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -429,6 +429,527 @@ HWY_NOINLINE void TestAllMaskedMulAdd() {
   ForAllTypes(ForPartialVectors<TestMaskedMulAdd>());
 }
 }  // namespace
+struct TestAddSubMulOrZero {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+    const Vec<D> v3 = Iota(d, hwy::Unpredictable1() + 2);
+    const Vec<D> v4 = Iota(d, hwy::Unpredictable1() + 3);
+    // So that we can subtract two iotas without resulting in a constant.
+    const Vec<D> tv4 = Add(v4, v4);
+    // For range-limited (so mul does not overflow), non-constant inputs.
+    // We cannot just And() because T might be floating-point.
+    alignas(16) static const T mod_lanes[16] = {
+        ConvertScalarTo<T>(0), ConvertScalarTo<T>(1), ConvertScalarTo<T>(2),
+        ConvertScalarTo<T>(hwy::Unpredictable1() + 2)};
+    const Vec<D> in_mul = LoadDup128(d, mod_lanes);
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected_add = AllocateAligned<T>(N);
+    auto expected_sub = AllocateAligned<T>(N);
+    auto expected_mul = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && expected_add && expected_sub && expected_mul);
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+        if (bool_lanes[i]) {
+          expected_add[i] = ConvertScalarTo<T>(2 * i + 7);
+          expected_sub[i] = ConvertScalarTo<T>(i + 5);
+          const size_t mod_i = i & ((16 / sizeof(T)) - 1);
+          expected_mul[i] =
+              ConvertScalarTo<T>(mod_lanes[mod_i] * mod_lanes[mod_i]);
+        } else {
+          expected_add[i] = ConvertScalarTo<T>(0);
+          expected_sub[i] = ConvertScalarTo<T>(0);
+          expected_mul[i] = ConvertScalarTo<T>(0);
+        }
+      }
+
+      const VI mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+
+      HWY_ASSERT_VEC_EQ(d, expected_add.get(), MaskedAddOrZero(mask, v3, v4));
+      HWY_ASSERT_VEC_EQ(d, expected_sub.get(), MaskedSubOrZero(mask, tv4, v3));
+      HWY_ASSERT_VEC_EQ(d, expected_mul.get(),
+                        MaskedMulOrZero(mask, in_mul, in_mul));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllAddSubMulOrZero() {
+  ForAllTypes(ForPartialVectors<TestAddSubMulOrZero>());
+}
+
+struct TestUnsignedSatAddSubOrZero {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    HWY_ASSERT(bool_lanes);
+
+    const Vec<D> v0 = Zero(d);
+    const Vec<D> vi = Iota(d, 1);
+    const Vec<D> vm = Set(d, LimitsMax<T>());
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+      }
+      const VI mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+
+      const Vec<D> disabled_lane_val = Zero(d);
+
+      Vec<D> expected_add =
+          IfThenElse(mask, Set(d, static_cast<T>(0)), disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, v0));
+      expected_add = IfThenElse(mask, vi, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, vi));
+      expected_add = IfThenElse(mask, Set(d, static_cast<T>(LimitsMax<T>())),
+                                disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, vm));
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, vi, vm));
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, vm, vm));
+
+      Vec<D> expected_sub =
+          IfThenElse(mask, Set(d, static_cast<T>(0)), disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, v0, v0));
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, v0, vi));
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vi, vi));
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vi, vm));
+      expected_sub = IfThenElse(mask, Sub(vm, vi), disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vm, vi));
+    }
+  }
+};
+
+struct TestSignedSatAddSubOrZero {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    HWY_ASSERT(bool_lanes);
+
+    const Vec<D> v0 = Zero(d);
+    const Vec<D> vpm = Set(d, LimitsMax<T>());
+    const Vec<D> vi = PositiveIota(d);
+    const Vec<D> vn = Sub(v0, vi);
+    const Vec<D> vnm = Set(d, LimitsMin<T>());
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+      }
+      const VI mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+
+      const Vec<D> disabled_lane_val = Zero(d);
+
+      Vec<D> expected_add = IfThenElse(mask, v0, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, v0));
+      expected_add = IfThenElse(mask, vi, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, vi));
+      expected_add = IfThenElse(mask, vpm, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, v0, vpm));
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, vi, vpm));
+      HWY_ASSERT_VEC_EQ(d, expected_add,
+                        MaskedSaturatedAddOrZero(mask, vpm, vpm));
+
+      Vec<D> expected_sub = IfThenElse(mask, v0, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, v0, v0));
+      expected_sub = IfThenElse(mask, Sub(v0, vi), disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, v0, vi));
+      expected_sub = IfThenElse(mask, vn, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vn, v0));
+      expected_sub = IfThenElse(mask, vnm, disabled_lane_val);
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vnm, vi));
+      HWY_ASSERT_VEC_EQ(d, expected_sub,
+                        MaskedSaturatedSubOrZero(mask, vnm, vpm));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllSatAddSubOrZero() {
+  ForU816(ForPartialVectors<TestUnsignedSatAddSubOrZero>());
+  ForI816(ForPartialVectors<TestSignedSatAddSubOrZero>());
+}
+
+struct TestDivOrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
+
+    // Wrap after 7 so that even float16_t can represent 1 << iota1.
+    const VI iota1 = And(Iota(di, hwy::Unpredictable1()), Set(di, 7));
+    const Vec<D> pows = ConvertTo(d, Shl(Set(di, 1), iota1));
+
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && expected);
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      ZeroBytes(expected.get(), N * sizeof(T));
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+        const size_t iota1 = (i + 1) & 7;
+        expected[i] = ConvertScalarTo<T>(0);
+        if (bool_lanes[i]) {
+          expected[i] =
+              ConvertScalarTo<T>(static_cast<double>(1 << iota1) / 2.0);
+        }
+      }
+
+      const VI mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+
+      const Vec<D> div = Set(d, ConvertScalarTo<T>(2));
+      HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedDivideOrZero(mask, pows, div));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllDivOrZero() {
+  ForFloatTypes(ForPartialVectors<TestDivOrZero>());
+}
+
+struct TestIntegerDivOrZero {
+  template <class D, HWY_IF_SIGNED_D(D)>
+  static HWY_INLINE void DoSignedDivModTests(
+      D d, const TFromD<D>* HWY_RESTRICT expected_quot,
+      const TFromD<D>* HWY_RESTRICT neg_expected_quot, Mask<D> mask, Vec<D> va,
+      Vec<D> vb) {
+    const auto neg_a = Neg(va);
+    const auto neg_b = Neg(vb);
+
+    HWY_ASSERT_VEC_EQ(d, neg_expected_quot,
+                      MaskedDivideOrZero(mask, neg_a, vb));
+    HWY_ASSERT_VEC_EQ(d, neg_expected_quot,
+                      MaskedDivideOrZero(mask, va, neg_b));
+    HWY_ASSERT_VEC_EQ(d, expected_quot, MaskedDivideOrZero(mask, neg_a, neg_b));
+  }
+
+  template <class D, HWY_IF_UNSIGNED_D(D)>
+  static HWY_INLINE void DoSignedDivModTests(
+      D /*d*/, const TFromD<D>* HWY_RESTRICT /*expected_quot*/,
+      const TFromD<D>* HWY_RESTRICT /*neg_expected_quot*/, Mask<D> /*mask*/,
+      Vec<D> /*va*/, Vec<D> /*vb*/) {}
+
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+
+    const auto vmax = Set(d, LimitsMax<T>());
+
+    const auto vb = Max(And(Iota(d, hwy::Unpredictable1() + 1),
+                            Set(d, static_cast<T>(LimitsMax<T>() >> 1))),
+                        Set(d, static_cast<T>(2)));
+    const auto va =
+        Max(And(Sub(vmax, Iota(d, static_cast<T>(hwy::Unpredictable1() - 1))),
+                vmax),
+            Add(vb, vb));
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    using TU = MakeUnsigned<T>;
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
+    const size_t N = Lanes(d);
+
+#if HWY_TARGET <= HWY_AVX3 && HWY_IS_MSAN
+    // Workaround for MSAN bug on AVX3
+    if (sizeof(T) <= 2 && N >= 16) {
+      return;
+    }
+#endif
+#if HWY_COMPILER_CLANG && HWY_ARCH_RISCV && HWY_TARGET == HWY_EMU128
+    // Workaround for incorrect codegen. Off by one in the lowest lane.
+    if (sizeof(T) == 4) return;
+#endif
+
+    auto bool_lanes = AllocateAligned<TI>(N);
+    auto expected_quot = AllocateAligned<T>(N);
+    auto neg_expected_quot = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && expected_quot && neg_expected_quot);
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const auto a0 = static_cast<T>((static_cast<TU>(LimitsMax<T>()) - i) &
+                                       LimitsMax<T>());
+        const auto b0 =
+            static_cast<T>((i + 2u) & static_cast<TU>(LimitsMax<T>() >> 1));
+
+        const auto b = static_cast<T>(HWY_MAX(b0, 2));
+        const auto a = static_cast<T>(HWY_MAX(a0, b + b));
+
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+        if (bool_lanes[i]) {
+          expected_quot[i] = static_cast<T>(a / b);
+        } else {
+          expected_quot[i] = static_cast<T>(0);
+        }
+
+        neg_expected_quot[i] =
+            static_cast<T>(static_cast<T>(0) - expected_quot[i]);
+      }
+
+      const VI mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+
+      HWY_ASSERT_VEC_EQ(d, expected_quot.get(),
+                        MaskedDivideOrZero(mask, va, vb));
+      DoSignedDivModTests(d, expected_quot.get(), neg_expected_quot.get(), mask,
+                          va, vb);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllIntegerDivOrZero() {
+  ForIntegerTypes(ForPartialVectors<TestIntegerDivOrZero>());
+}
+
+struct TestMulFixedPoint15OrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const auto v0 = Zero(d);
+    HWY_ASSERT_VEC_EQ(d, v0, MulFixedPoint15(v0, v0));
+    HWY_ASSERT_VEC_EQ(d, v0, MulFixedPoint15(v0, v0));
+
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<T>(N);
+    auto in1 = AllocateAligned<T>(N);
+    auto in2 = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && in1 && in2 && expected);
+
+    // Random inputs in each lane
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(10000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        in1[i] = ConvertScalarTo<T>(Random64(&rng) & 0xFFFF);
+        in2[i] = ConvertScalarTo<T>(Random64(&rng) & 0xFFFF);
+      }
+
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+        if (bool_lanes[i]) {
+          // There are three ways to compute the results. x86 and Arm are
+          // defined using 32-bit multiplication results:
+          const int arm =
+              static_cast<int32_t>(2u * static_cast<uint32_t>(in1[i] * in2[i]) +
+                                   0x8000u) >>
+              16;
+          const int x86 = (((in1[i] * in2[i]) >> 14) + 1) >> 1;
+          // On other platforms, split the result into upper and lower 16 bits.
+          const auto v1 = Set(d, in1[i]);
+          const auto v2 = Set(d, in2[i]);
+          const int hi = GetLane(MulHigh(v1, v2));
+          const int lo = GetLane(Mul(v1, v2)) & 0xFFFF;
+          const int split = 2 * hi + ((lo + 0x4000) >> 15);
+          expected[i] = ConvertScalarTo<T>(arm);
+          if (in1[i] != -32768 || in2[i] != -32768) {
+            HWY_ASSERT_EQ(arm, x86);
+            HWY_ASSERT_EQ(arm, split);
+          }
+        } else {
+          expected[i] = ConvertScalarTo<T>(0);
+        }
+      }
+
+      const VFromD<D> mask_i = Load(d, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
+      const auto a = Load(d, in1.get());
+      const auto b = Load(d, in2.get());
+      HWY_ASSERT_VEC_EQ(d, expected.get(),
+                        MaskedMulFixedPoint15OrZero(mask, a, b));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllMulFixedPoint15OrZero() {
+  ForPartialVectors<TestMulFixedPoint15OrZero>()(int16_t());
+}
+
+struct TestMulAddOrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+    const Vec<D> k0 = Zero(d);
+    const Vec<D> v1 = Iota(d, 1);
+    const Vec<D> v2 = Iota(d, 2);
+    VFromD<D> mask_i;
+    Mask<D> mask;
+
+    // Unlike RebindToSigned, we want to leave floating-point unchanged.
+    // This allows Neg for unsigned types.
+    const Rebind<If<IsFloat<T>(), T, MakeSigned<T>>, D> dif;
+    const Vec<D> neg_v2 = BitCast(d, Neg(BitCast(dif, v2)));
+
+    const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && expected);
+    HWY_ASSERT_VEC_EQ(d, k0, MaskedMulAddOrZero(MaskTrue(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOrZero(MaskTrue(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOrZero(MaskTrue(d), v1, k0, v2));
+    HWY_ASSERT_VEC_EQ(d, k0, MaskedNegMulAddOrZero(MaskTrue(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAddOrZero(MaskTrue(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedNegMulAddOrZero(MaskTrue(d), v1, k0, v2));
+
+    for (size_t i = 0; i < N; ++i) {
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      if (bool_lanes[i]) {
+        expected[i] = ConvertScalarTo<T>((i + 1) * (i + 2));
+      } else {
+        expected[i] = ConvertScalarTo<T>(0);
+      }
+    }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v2, v1, k0));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v1, v2, k0));
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedNegMulAddOrZero(mask, neg_v2, v1, k0));
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedNegMulAddOrZero(mask, v1, neg_v2, k0));
+
+    for (size_t i = 0; i < N; ++i) {
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      if (bool_lanes[i]) {
+        expected[i] = ConvertScalarTo<T>((i + 2) * (i + 2) + (i + 1));
+      } else {
+        expected[i] = ConvertScalarTo<T>(0);
+      }
+    }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOrZero(mask, v2, v2, v1));
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedNegMulAddOrZero(mask, neg_v2, v2, v1));
+
+    for (size_t i = 0; i < N; ++i) {
+      const T nm = ConvertScalarTo<T>(-static_cast<int>(i + 2));
+      const T f = ConvertScalarTo<T>(i + 2);
+      const T a = ConvertScalarTo<T>(i + 1);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+      if (bool_lanes[i]) {
+        expected[i] = ConvertScalarTo<T>(nm * f + a);
+      } else {
+        expected[i] = ConvertScalarTo<T>(0);
+      }
+    }
+    mask_i = Load(d, bool_lanes.get());
+    mask = RebindMask(d, Gt(mask_i, Zero(d)));
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedNegMulAddOrZero(mask, v2, v2, v1));
+  }
+};
+
+HWY_NOINLINE void TestAllMulAddOrZero() {
+  ForAllTypes(ForPartialVectors<TestMulAddOrZero>());
+}
+
+struct TestWidenMulPairwiseAddOrZero {
+  // Must be inlined on aarch64 for bf16, else clang crashes.
+  template <typename TN, class DN>
+  HWY_INLINE void operator()(TN /*unused*/, DN dn) {
+    using TW = MakeWide<TN>;
+    const RepartitionToWide<DN> dw;
+    using VW = Vec<decltype(dw)>;
+    using VN = Vec<decltype(dn)>;
+    const size_t NN = Lanes(dn);
+
+    const VW f0 = Zero(dw);
+    const VW f1 = Set(dw, ConvertScalarTo<TW>(1));
+    const VN bf0 = Zero(dn);
+    // Cannot Set() bfloat16_t directly.
+    const VN bf1 = ReorderDemote2To(dn, f1, f1);
+
+    // Any input zero => both outputs zero
+    HWY_ASSERT_VEC_EQ(
+        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf0, bf0));
+    HWY_ASSERT_VEC_EQ(
+        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf0, bf1));
+    HWY_ASSERT_VEC_EQ(
+        dw, f0, MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), bf1, bf0));
+
+    auto expected = AllocateAligned<TW>(NN / 2);
+    const auto v1l = Iota(dw, 1);
+    const auto v1h = Iota(dw, 1 + NN / 2);
+    // Cannot Iota() bfloat16_t directly.
+    const auto v1 = OrderedDemote2To(dn, v1l, v1h);
+    const auto v2l = Iota(dw, 3);
+    const auto v2h = Iota(dw, 3 + NN / 2);
+    // Cannot Iota() bfloat16_t directly.
+    const auto v2 = OrderedDemote2To(dn, v2l, v2h);
+    HWY_ASSERT(expected);
+    for (size_t p = 0; p < (NN / 2); ++p) {
+      auto a_odd = 2 * p + 1 + 1;   // a[2*p+1]
+      auto b_odd = 2 * p + 1 + 3;   // b[2*p+1]
+      auto a_even = 2 * p + 0 + 1;  // a[2*p+0]
+      auto b_even = 2 * p + 0 + 3;  // b[2*p+0]
+      expected[p] = ConvertScalarTo<TW>(a_odd * b_odd + a_even * b_even);
+    }
+
+    HWY_ASSERT_VEC_EQ(
+        dw, expected.get(),
+        MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), v1, v2));
+    HWY_ASSERT_VEC_EQ(
+        dw, expected.get(),
+        MaskedWidenMulPairwiseAddOrZero(dw, MaskTrue(dw), v2, v1));
+  }
+};
+
+HWY_NOINLINE void TestAllWidenMulPairwiseAddOrZero() {
+  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(bfloat16_t());
+  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(int16_t());
+  ForShrinkableVectors<TestWidenMulPairwiseAddOrZero>()(uint16_t());
+}
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy
@@ -443,7 +964,15 @@ HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSub);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivMod);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllFloatExceptions);
+
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllAddSubMulOrZero);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSubOrZero);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDivOrZero);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivOrZero);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMulFixedPoint15OrZero);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedMulAdd);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest,
+                      TestAllWidenMulPairwiseAddOrZero);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -619,9 +619,9 @@ struct TestMaskedDiv {
     const Rebind<TI, D> di;
     using VI = Vec<decltype(di)>;
 
-    // Wrap after 7 so that even float16_t can represent 1 << iota1.
-    const VI iota1 = And(Iota(di, hwy::Unpredictable1()), Set(di, 7));
-    const Vec<D> pows = ConvertTo(d, Shl(Set(di, 1), iota1));
+    // Wrap after 7 so that even float16_t can represent 1 << viota1.
+    const VI viota1 = And(Iota(di, hwy::Unpredictable1()), Set(di, 7));
+    const Vec<D> pows = ConvertTo(d, Shl(Set(di, 1), viota1));
 
     const size_t N = Lanes(d);
     auto bool_lanes = AllocateAligned<TI>(N);

--- a/hwy/tests/masked_minmax_test.cc
+++ b/hwy/tests/masked_minmax_test.cc
@@ -137,6 +137,30 @@ HWY_NOINLINE void TestAllSignedMinMax() {
   ForFloatTypes(ForPartialVectors<TestSignedMinMax>());
 }
 
+struct TestMaskedMax {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const MFromD<D> all_true = MaskTrue(d);
+    const auto v1 = Iota(d, 1);
+    const auto v2 = Iota(d, 2);
+
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMax(all_true, v1, v2));
+
+    const MFromD<D> first_five = FirstN(d, 5);
+    const Vec<D> v0 = Zero(d);
+
+    const Vec<D> v1_exp = IfThenElse(first_five, v2, v0);
+
+    auto output = MaskedMax(first_five, v1, v2);
+
+    HWY_ASSERT_VEC_EQ(d, v1_exp, output);
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedMax() {
+  ForAllTypes(ForPartialVectors<TestMaskedMax>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -149,6 +173,7 @@ namespace {
 HWY_BEFORE_TEST(HwyMaskedMinMaxTest);
 HWY_EXPORT_AND_TEST_P(HwyMaskedMinMaxTest, TestAllUnsignedMinMax);
 HWY_EXPORT_AND_TEST_P(HwyMaskedMinMaxTest, TestAllSignedMinMax);
+HWY_EXPORT_AND_TEST_P(HwyMaskedMinMaxTest, TestAllMaskedMax);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
Introduces:
- MaskedMaxOrZero(m, a, b): returns `Max(a, b)[i]` or `zero` if `m[i]` is false
- MaskedAddOrZero(m, a, b): returns `a[i] + b[i]` or `0` if `m[i]` is false.
- MaskedSubOrZero(m, a, b): returns `a[i] - b[i]` or `0` if `m[i]` is false.
- MaskedMulOrZero( m,  a, b): returns `a[i] * b[i]` or `0` if `m[i]` is false.
- MaskedDivideOrZero(m, a, b): returns `a[i] / b[i]` or `0` if `m[i]` is false.
- MaskedSaturatedAddOrZero(m, a, b): returns `a[i] + b[i]` saturated to the minimum/maximum representable value, or `0` if m[i]` is false.
- MaskedSaturatedSubOrZero(m,  a,  b): returns `a[i] - b[i]` saturated to the minimum/maximum representable value, or `0` if m[i]` is false.
- MaskedMulFixedPoint15OrZero(m, a): returns returns the result of multiplying two Q1.15 fixed-point numbers, or `0` if `m[i]` is false.
- MaskedMulAddOrZero(m, a, b, c): returns `a[i] * b[i] + c[i]` or `0` if `m[i]` is false.
- MaskedNegMulAddOrZero(m, a, b, c): returns `-a[i] * b[i] + c[i]` or `0` if `m[i]` is false.
- MaskedWidenMulPairwiseAddOrZero(d, m, a, b): widens `a` and `b` to `TFromD<D>` and computes `a[2*i+1]*b[2*i+1] + a[2*i+0]*b[2*i+0]`, or `0` if `m[i]` is false.


Testing is included for all operations where both the masking and the underlying operation is tested.