### PR TITLE
Masked compare and floating point classifications

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1057,18 +1057,18 @@ Per-lane variable shifts (slow if SSSE3/SSE4, or 16-bit, or Shr i64 on AVX2):
 #### Masked floating-point classification
 
 All ops in this section return `false` for `mask=false` lanes. These are
-equivalent to, and potentially more efficient than, `And(m, Eq(a, b));` etc.
+equivalent to, and potentially more efficient than, `And(m, IsNaN(v));` etc.
 
 *   `V`: `{f}` \
-    <code>M **MaskedIsNaN**(V v)</code>: returns mask indicating whether `v[i]`
-    is "not a number" (unordered) or `false` if `m[i]` is false.
+    <code>M **MaskedIsNaN**(M m, V v)</code>: returns mask indicating whether
+    `v[i]` is "not a number" (unordered) or `false` if `m[i]` is false.
 
 *   `V`: `{f}` \
-    <code>M **MaskedIsInf**(V v)</code>: returns mask indicating whether `v[i]`
-    is positive or negative infinity or `false` if `m[i]` is false.
+    <code>M **MaskedIsInf**(M m, V v)</code>: returns mask indicating whether
+    `v[i]` is positive or negative infinity or `false` if `m[i]` is false.
 
 *   `V`: `{f}` \
-    <code>M **MaskedIsFinite**(V v)</code>: returns mask indicating whether
+    <code>M **MaskedIsFinite**(M m, V v)</code>: returns mask indicating whether
     `v[i]` is neither NaN nor infinity, i.e. normal, subnormal or zero or
     `false` if `m[i]` is false. Equivalent to `Not(Or(IsNaN(v), IsInf(v)))`.
 
@@ -1555,22 +1555,22 @@ These return a mask (see above) indicating whether the condition is true.
 All ops in this section return `false` for `mask=false` lanes. These are
 equivalent to, and potentially more efficient than, `And(m, Eq(a, b));` etc.
 
-*   <code>M **MaskedCompEq**(M m, V a, V b)</code>: returns `a[i] == b[i]` or
+*   <code>M **MaskedEq**(M m, V a, V b)</code>: returns `a[i] == b[i]` or
     `false` if `m[i]` is false.
 
-*   <code>M **MaskedCompNe**(M m, V a, V b)</code>: returns `a[i] != b[i]` or
+*   <code>M **MaskedNe**(M m, V a, V b)</code>: returns `a[i] != b[i]` or
     `false` if `m[i]` is false.
 
-*   <code>M **MaskedCompLt**(M m, V a, V b)</code>: returns `a[i] < b[i]` or
+*   <code>M **MaskedLt**(M m, V a, V b)</code>: returns `a[i] < b[i]` or
     `false` if `m[i]` is false.
 
-*   <code>M **MaskedCompGt**(M m, V a, V b)</code>: returns `a[i] > b[i]` or
+*   <code>M **MaskedGt**(M m, V a, V b)</code>: returns `a[i] > b[i]` or
     `false` if `m[i]` is false.
 
-*   <code>M **MaskedCompLe**(M m, V a, V b)</code>: returns `a[i] <= b[i]` or
+*   <code>M **MaskedLe**(M m, V a, V b)</code>: returns `a[i] <= b[i]` or
     `false` if `m[i]` is false.
 
-*   <code>M **MaskedCompGe**(M m, V a, V b)</code>: returns `a[i] >= b[i]` or
+*   <code>M **MaskedGe**(M m, V a, V b)</code>: returns `a[i] >= b[i]` or
     `false` if `m[i]` is false.
 
 ### Memory

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1054,6 +1054,24 @@ Per-lane variable shifts (slow if SSSE3/SSE4, or 16-bit, or Shr i64 on AVX2):
     neither NaN nor infinity, i.e. normal, subnormal or zero. Equivalent to
     `Not(Or(IsNaN(v), IsInf(v)))`.
 
+#### Masked floating-point classification
+
+All ops in this section return `false` for `mask=false` lanes. These are
+equivalent to, and potentially more efficient than, `And(m, Eq(a, b));` etc.
+
+*   `V`: `{f}` \
+    <code>M **MaskedIsNaN**(V v)</code>: returns mask indicating whether `v[i]`
+    is "not a number" (unordered) or `false` if `m[i]` is false.
+
+*   `V`: `{f}` \
+    <code>M **MaskedIsInf**(V v)</code>: returns mask indicating whether `v[i]`
+    is positive or negative infinity or `false` if `m[i]` is false.
+
+*   `V`: `{f}` \
+    <code>M **MaskedIsFinite**(V v)</code>: returns mask indicating whether
+    `v[i]` is neither NaN nor infinity, i.e. normal, subnormal or zero or
+    `false` if `m[i]` is false. Equivalent to `Not(Or(IsNaN(v), IsInf(v)))`.
+
 ### Logical
 
 *   `V`: `{u,i}` \
@@ -1531,6 +1549,29 @@ These return a mask (see above) indicating whether the condition is true.
     each pair, the mask lanes are either both true or both false. This is useful
     for comparing 64-bit keys alongside 64-bit values. Only available if
     `HWY_TARGET != HWY_SCALAR`.
+
+#### Masked comparison
+
+All ops in this section return `false` for `mask=false` lanes. These are
+equivalent to, and potentially more efficient than, `And(m, Eq(a, b));` etc.
+
+*   <code>M **MaskedCompEq**(M m, V a, V b)</code>: returns `a[i] == b[i]` or
+    `false` if `m[i]` is false.
+
+*   <code>M **MaskedCompNe**(M m, V a, V b)</code>: returns `a[i] != b[i]` or
+    `false` if `m[i]` is false.
+
+*   <code>M **MaskedCompLt**(M m, V a, V b)</code>: returns `a[i] < b[i]` or
+    `false` if `m[i]` is false.
+
+*   <code>M **MaskedCompGt**(M m, V a, V b)</code>: returns `a[i] > b[i]` or
+    `false` if `m[i]` is false.
+
+*   <code>M **MaskedCompLe**(M m, V a, V b)</code>: returns `a[i] <= b[i]` or
+    `false` if `m[i]` is false.
+
+*   <code>M **MaskedCompGe**(M m, V a, V b)</code>: returns `a[i] >= b[i]` or
+    `false` if `m[i]` is false.
 
 ### Memory
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1063,15 +1063,6 @@ equivalent to, and potentially more efficient than, `And(m, IsNaN(v));` etc.
     <code>M **MaskedIsNaN**(M m, V v)</code>: returns mask indicating whether
     `v[i]` is "not a number" (unordered) or `false` if `m[i]` is false.
 
-*   `V`: `{f}` \
-    <code>M **MaskedIsInf**(M m, V v)</code>: returns mask indicating whether
-    `v[i]` is positive or negative infinity or `false` if `m[i]` is false.
-
-*   `V`: `{f}` \
-    <code>M **MaskedIsFinite**(M m, V v)</code>: returns mask indicating whether
-    `v[i]` is neither NaN nor infinity, i.e. normal, subnormal or zero or
-    `false` if `m[i]` is false. Equivalent to `Not(Or(IsNaN(v), IsInf(v)))`.
-
 ### Logical
 
 *   `V`: `{u,i}` \

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2138,6 +2138,77 @@ HWY_SVE_FOREACH_F(HWY_SVE_MUL_BY_POW2, MulByPow2, scale)
 
 #undef HWY_SVE_MUL_BY_POW2
 
+// ------------------------------ MaskedCompEq etc.
+#ifdef HWY_NATIVE_MASKED_COMP
+#undef HWY_NATIVE_MASKED_COMP
+#else
+#define HWY_NATIVE_MASKED_COMP
+#endif
+
+// mask = f(mask, vector, vector)
+#define HWY_SVE_COMPARE_Z(BASE, CHAR, BITS, HALF, NAME, OP)  \
+  HWY_API svbool_t NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, \
+                        HWY_SVE_V(BASE, BITS) b) {           \
+    return sv##OP##_##CHAR##BITS(m, a, b);                   \
+  }
+
+namespace detail {
+HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedEq, cmpeq)
+HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedNe, cmpne)
+HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedLt, cmplt)
+HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedLe, cmple)
+
+}  // namespace detail
+
+#undef HWY_SVE_COMPARE_Z
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompEq(M m, V a, V b) {
+  return detail::MaskedEq(m, a, b);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompNe(M m, V a, V b) {
+  return detail::MaskedNe(m, a, b);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompLt(M m, V a, V b) {
+  return detail::MaskedLt(m, a, b);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompGt(M m, V a, V b) {
+  // Swap args to reverse comparison
+  return detail::MaskedLt(m, b, a);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompLe(M m, V a, V b) {
+  return detail::MaskedLe(m, a, b);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedCompGe(M m, V a, V b) {
+  // Swap args to reverse comparison
+  return detail::MaskedLe(m, b, a);
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsInf(const M m, const V v) {
+  return And(m, IsInf(v));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
+  return And(m, IsFinite(v));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsNaN(const M m, const V v) {
+  return detail::MaskedNe(m, v, v);
+}
+
 // ================================================== MEMORY
 
 // ------------------------------ LoadU/MaskedLoad/LoadDup128/StoreU/Stream

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2138,7 +2138,7 @@ HWY_SVE_FOREACH_F(HWY_SVE_MUL_BY_POW2, MulByPow2, scale)
 
 #undef HWY_SVE_MUL_BY_POW2
 
-// ------------------------------ MaskedCompEq etc.
+// ------------------------------ MaskedEq etc.
 #ifdef HWY_NATIVE_MASKED_COMP
 #undef HWY_NATIVE_MASKED_COMP
 #else
@@ -2152,46 +2152,24 @@ HWY_SVE_FOREACH_F(HWY_SVE_MUL_BY_POW2, MulByPow2, scale)
     return sv##OP##_##CHAR##BITS(m, a, b);                   \
   }
 
-namespace detail {
 HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedEq, cmpeq)
 HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedNe, cmpne)
 HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedLt, cmplt)
 HWY_SVE_FOREACH(HWY_SVE_COMPARE_Z, MaskedLe, cmple)
 
-}  // namespace detail
-
 #undef HWY_SVE_COMPARE_Z
 
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompEq(M m, V a, V b) {
-  return detail::MaskedEq(m, a, b);
-}
 
 template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompNe(M m, V a, V b) {
-  return detail::MaskedNe(m, a, b);
-}
-
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompLt(M m, V a, V b) {
-  return detail::MaskedLt(m, a, b);
-}
-
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompGt(M m, V a, V b) {
+HWY_API MFromD<D> MaskedGt(M m, V a, V b) {
   // Swap args to reverse comparison
-  return detail::MaskedLt(m, b, a);
+  return MaskedLt(m, b, a);
 }
 
 template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompLe(M m, V a, V b) {
-  return detail::MaskedLe(m, a, b);
-}
-
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedCompGe(M m, V a, V b) {
+HWY_API MFromD<D> MaskedGe(M m, V a, V b) {
   // Swap args to reverse comparison
-  return detail::MaskedLe(m, b, a);
+  return MaskedLe(m, b, a);
 }
 
 template <class V, class M, class D = DFromV<V>>
@@ -2206,7 +2184,7 @@ HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
 
 template <class V, class M, class D = DFromV<V>>
 HWY_API MFromD<D> MaskedIsNaN(const M m, const V v) {
-  return detail::MaskedNe(m, v, v);
+  return MaskedNe(m, v, v);
 }
 
 // ================================================== MEMORY

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2173,16 +2173,6 @@ HWY_API MFromD<D> MaskedGe(M m, V a, V b) {
 }
 
 template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedIsInf(const M m, const V v) {
-  return And(m, IsInf(v));
-}
-
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
-  return And(m, IsFinite(v));
-}
-
-template <class V, class M, class D = DFromV<V>>
 HWY_API MFromD<D> MaskedIsNaN(const M m, const V v) {
   return MaskedNe(m, v, v);
 }

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -670,16 +670,6 @@ HWY_API auto MaskedGe(M m, V a, V b) -> decltype(a == b) {
 }
 
 template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedIsInf(const M m, const V v) {
-  return And(m, IsInf(v));
-}
-
-template <class V, class M, class D = DFromV<V>>
-HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
-  return And(m, IsFinite(v));
-}
-
-template <class V, class M, class D = DFromV<V>>
 HWY_API MFromD<D> MaskedIsNaN(const M m, const V v) {
   return And(m, IsNaN(v));
 }

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -631,7 +631,7 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
-// ------------------------------ MaskedCompEq etc.
+// ------------------------------ MaskedEq etc.
 #if (defined(HWY_NATIVE_MASKED_COMP) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_MASKED_COMP
 #undef HWY_NATIVE_MASKED_COMP
@@ -640,32 +640,32 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 #endif
 
 template <class V, class M>
-HWY_API auto MaskedCompEq(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedEq(M m, V a, V b) -> decltype(a == b) {
   return And(m, Eq(a, b));
 }
 
 template <class V, class M>
-HWY_API auto MaskedCompNe(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedNe(M m, V a, V b) -> decltype(a == b) {
   return And(m, Ne(a, b));
 }
 
 template <class V, class M>
-HWY_API auto MaskedCompLt(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedLt(M m, V a, V b) -> decltype(a == b) {
   return And(m, Lt(a, b));
 }
 
 template <class V, class M>
-HWY_API auto MaskedCompGt(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedGt(M m, V a, V b) -> decltype(a == b) {
   return And(m, Gt(a, b));
 }
 
 template <class V, class M>
-HWY_API auto MaskedCompLe(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedLe(M m, V a, V b) -> decltype(a == b) {
   return And(m, Le(a, b));
 }
 
 template <class V, class M>
-HWY_API auto MaskedCompGe(M m, V a, V b) -> decltype(a == b) {
+HWY_API auto MaskedGe(M m, V a, V b) -> decltype(a == b) {
   return And(m, Ge(a, b));
 }
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -631,6 +631,60 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
+// ------------------------------ MaskedCompEq etc.
+#if (defined(HWY_NATIVE_MASKED_COMP) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MASKED_COMP
+#undef HWY_NATIVE_MASKED_COMP
+#else
+#define HWY_NATIVE_MASKED_COMP
+#endif
+
+template <class V, class M>
+HWY_API auto MaskedCompEq(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Eq(a, b));
+}
+
+template <class V, class M>
+HWY_API auto MaskedCompNe(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Ne(a, b));
+}
+
+template <class V, class M>
+HWY_API auto MaskedCompLt(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Lt(a, b));
+}
+
+template <class V, class M>
+HWY_API auto MaskedCompGt(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Gt(a, b));
+}
+
+template <class V, class M>
+HWY_API auto MaskedCompLe(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Le(a, b));
+}
+
+template <class V, class M>
+HWY_API auto MaskedCompGe(M m, V a, V b) -> decltype(a == b) {
+  return And(m, Ge(a, b));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsInf(const M m, const V v) {
+  return And(m, IsInf(v));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
+  return And(m, IsFinite(v));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsNaN(const M m, const V v) {
+  return And(m, IsNaN(v));
+}
+#endif  // HWY_NATIVE_MASKED_COMP
+
 // ------------------------------ IfNegativeThenNegOrUndefIfZero
 
 #if (defined(HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG) == \

--- a/hwy/tests/compare_test.cc
+++ b/hwy/tests/compare_test.cc
@@ -673,7 +673,7 @@ HWY_NOINLINE void TestAllEq128Upper() {
   ForGEVectors<128, TestEq128Upper>()(uint64_t());
 }
 
-struct TestMaskedComparision {
+struct TestMaskedCompare {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
@@ -767,8 +767,8 @@ struct TestMaskedComparision {
   }
 };
 
-HWY_NOINLINE void TestAllMaskedComparision() {
-  ForAllTypes(ForPartialVectors<TestMaskedComparision>());
+HWY_NOINLINE void TestAllMaskedCompare() {
+  ForAllTypes(ForPartialVectors<TestMaskedCompare>());
 }
 
 struct TestMaskedFloatClassification {
@@ -849,7 +849,7 @@ HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllLt128Upper);
 HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllEq128);
 HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllEq128Upper);
 
-HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllMaskedComparision);
+HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllMaskedCompare);
 HWY_EXPORT_AND_TEST_P(HwyCompareTest, TestAllMaskedFloatClassification);
 HWY_AFTER_TEST();
 }  // namespace

--- a/hwy/tests/compare_test.cc
+++ b/hwy/tests/compare_test.cc
@@ -786,23 +786,15 @@ struct TestMaskedFloatClassification {
     const Mask<D> mask_true = MaskTrue(d);
 
     // Test against all zeros
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsFinite(mask_true, v0));
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v0));
 
     // Test against finite values
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v1));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsFinite(mask_true, v1));
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v1));
 
     // Test against infinite values
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsInf(mask_true, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask_true, v2));
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v2));
 
     // Test against NaN values
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v3));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask_true, v3));
     HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsNaN(mask_true, v3));
 
     auto bool_lanes = AllocateAligned<T>(N);
@@ -817,23 +809,15 @@ struct TestMaskedFloatClassification {
       const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
 
       // Test against all zeros
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v0));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsFinite(mask, v0));
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v0));
 
       // Test against finite values
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v1));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsFinite(mask, v1));
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v1));
 
       // Test against infinite values
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsInf(mask, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask, v2));
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v2));
 
       // Test against NaN values
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v3));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask, v3));
       HWY_ASSERT_MASK_EQ(d, mask, MaskedIsNaN(mask, v3));
     }
   }

--- a/hwy/tests/compare_test.cc
+++ b/hwy/tests/compare_test.cc
@@ -687,38 +687,38 @@ struct TestMaskedComparision {
     const Mask<D> mask_false = MaskFalse(d);
     const Mask<D> mask_true = MaskTrue(d);
 
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompEq(mask_true, v2, v3));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompEq(mask_true, v3, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompEq(mask_true, v2, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompEq(mask_true, v2, v2b));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompNe(mask_true, v2, v3));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompNe(mask_true, v3, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompNe(mask_true, v2, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompNe(mask_true, v2, v2b));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedEq(mask_true, v2, v3));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedEq(mask_true, v3, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedEq(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedEq(mask_true, v2, v2b));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedNe(mask_true, v2, v3));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedNe(mask_true, v3, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedNe(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedNe(mask_true, v2, v2b));
 
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask_true, v0, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask_true, v0, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask_true, v0, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask_true, v2, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask_true, v0, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask_true, v0, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask_true, v2, v2));
 
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompGt(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompLt(mask_true, v0, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedGt(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedLt(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask_true, v0, v2));
 
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLe(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGe(mask_true, v0, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompLe(mask_true, v0, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompGe(mask_true, v0, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompLe(mask_true, v2, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompGe(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLe(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGe(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedLe(mask_true, v0, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedGe(mask_true, v0, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedLe(mask_true, v2, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedGe(mask_true, v2, v2));
 
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompGe(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedCompLe(mask_true, v0, v2));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLe(mask_true, v2, v0));
-    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGe(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedGe(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedLe(mask_true, v0, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLe(mask_true, v2, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGe(mask_true, v0, v2));
 
     auto bool_lanes = AllocateAligned<T>(N);
     HWY_ASSERT(bool_lanes);
@@ -731,38 +731,38 @@ struct TestMaskedComparision {
       const Vec<D> mask_i = Load(d, bool_lanes.get());
       const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
 
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompEq(mask, v2, v3));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompEq(mask, v3, v2));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompEq(mask, v2, v2));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompEq(mask, v2, v2b));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompNe(mask, v2, v3));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompNe(mask, v3, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompNe(mask, v2, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompNe(mask, v2, v2b));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedEq(mask, v2, v3));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedEq(mask, v3, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedEq(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedEq(mask, v2, v2b));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedNe(mask, v2, v3));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedNe(mask, v3, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedNe(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedNe(mask, v2, v2b));
 
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask, v0, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask, v0, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask, v0, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask, v2, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask, v0, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask, v0, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask, v2, v2));
 
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompGt(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompLt(mask, v0, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLt(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGt(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedGt(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedLt(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLt(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGt(mask, v0, v2));
 
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLe(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGe(mask, v0, v2));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompLe(mask, v0, v0));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompGe(mask, v0, v0));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompLe(mask, v2, v2));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompGe(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLe(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGe(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedLe(mask, v0, v0));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedGe(mask, v0, v0));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedLe(mask, v2, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedGe(mask, v2, v2));
 
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompGe(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask, MaskedCompLe(mask, v0, v2));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompLe(mask, v2, v0));
-      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedCompGe(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedGe(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedLe(mask, v0, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedLe(mask, v2, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedGe(mask, v0, v2));
     }
   }
 };


### PR DESCRIPTION
Introduces:
- MaskedIsNaN(v): returns mask indicating whether `v[i]` is "not a number" (unordered) or `false` if `m[i]` is false.
- MaskedIsInf(v): returns mask indicating whether `v[i]` is positive or negative infinity or `false` if `m[i]` is false.
- MaskedIsFinite(v): returns mask indicating whether `v[i]` is neither NaN nor infinity, i.e. normal, subnormal or zero or `false` if `m[i]` is false. Equivalent to `Not(Or(IsNaN(v), IsInf(v)))`.

- MaskedCompEq(m, a, b), MaskedCompNe(m, a, b), MaskedCompLt(m, a, b), MaskedCompGt(m, a, b), MaskedCompLe(m, a, b), MaskedCompGe(m, a, b), returning the output for all versions of `==, !=, <, >, >=, <=`, or `false` if `m[i]` is false.

All operations are written for both `arm_sve-inl.h` and `generic_ops-inl.h` and, equally, tests are included for all operations.