### PR TITLE
Various masked operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1125,7 +1125,7 @@ types, and on SVE/RVV.
 
 *   <code>V **AndNot**(V a, V b)</code>: returns `~a[i] & b[i]`.
 
-*   <code>V **MaskedOrOrZero**(M m, V a, V b)</code>: returns `a[i] || b[i]`
+*   <code>V **MaskedOr**(M m, V a, V b)</code>: returns `a[i] | b[i]`
     or `zero` if `m[i]` is false.
 
 The following three-argument functions may be more efficient than assembling
@@ -2353,22 +2353,6 @@ The following `ReverseN` must not be called if `Lanes(D()) < N`:
     `TableLookupLanes` by loading `Lanes(d)` integer indices from `idx`, which
     must be in the range `[0, 2 * Lanes(d))` but need not be unique. The index
     type `TI` must be an integer of the same size as `TFromD<D>`.
-
-*   <code>V **TableLookupLanesOr**(M m, V a, V b, unspecified)</code> returns the
-    result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and returns
-    `b[i]` where `m[i]` is false.
-
-*   <code>V **TableLookupLanesOrZero**(M m, V a, unspecified)</code> returns
-    the result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and
-    returns zero where `m[i]` is false.
-
-*   <code>V **TwoTablesLookupLanesOr**(D d, M m, V a, V b, unspecified)</code>
-    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
-    `m[i]` is true, and `a[i]` where `m[i]` is false.
-
-*   <code>V **TwoTablesLookupLanesOrZero**(D d, M m, V a, V b, unspecified)</code>
-    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
-    `m[i]` is true, and zero where `m[i]` is false.
 
 *   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx3, size_t kIdx2, size_t
     kIdx1, size_t kIdx0&gt;(V v)</code> does a per 4-lane block shuffle of `v`

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1125,6 +1125,9 @@ types, and on SVE/RVV.
 
 *   <code>V **AndNot**(V a, V b)</code>: returns `~a[i] & b[i]`.
 
+*   <code>V **MaskedOrOrZero**(M m, V a, V b)</code>: returns `a[i] || b[i]`
+    or `zero` if `m[i]` is false.
+
 The following three-argument functions may be more efficient than assembling
 them from 2-argument functions:
 
@@ -2351,6 +2354,22 @@ The following `ReverseN` must not be called if `Lanes(D()) < N`:
     must be in the range `[0, 2 * Lanes(d))` but need not be unique. The index
     type `TI` must be an integer of the same size as `TFromD<D>`.
 
+*   <code>V **TableLookupLanesOr**(M m, V a, V b, unspecified)</code> returns the
+    result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and returns
+    `b[i]` where `m[i]` is false.
+
+*   <code>V **TableLookupLanesOrZero**(M m, V a, unspecified)</code> returns
+    the result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and
+    returns zero where `m[i]` is false.
+
+*   <code>V **TwoTablesLookupLanesOr**(D d, M m, V a, V b, unspecified)</code>
+    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
+    `m[i]` is true, and `a[i]` where `m[i]` is false.
+
+*   <code>V **TwoTablesLookupLanesOrZero**(D d, M m, V a, V b, unspecified)</code>
+    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
+    `m[i]` is true, and zero where `m[i]` is false.
+
 *   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx3, size_t kIdx2, size_t
     kIdx1, size_t kIdx0&gt;(V v)</code> does a per 4-lane block shuffle of `v`
     if `Lanes(DFromV<V>())` is greater than or equal to 4 or a shuffle of the
@@ -2490,6 +2509,24 @@ more efficient on some targets.
 *   <code>T **ReduceSum**(D, V v)</code>: returns the sum of all lanes.
 *   <code>T **ReduceMin**(D, V v)</code>: returns the minimum of all lanes.
 *   <code>T **ReduceMax**(D, V v)</code>: returns the maximum of all lanes.
+
+### Masked reductions
+
+**Note**: Horizontal operations (across lanes of the same vector) such as
+reductions are slower than normal SIMD operations and are typically used outside
+critical loops.
+
+All ops in this section ignore lanes where `mask=false`. These are equivalent
+to, and potentially more efficient than, `GetLane(SumOfLanes(d,
+IfThenElseZero(m, v)))` etc. The result is implementation-defined when all mask
+elements are false.
+
+*   <code>T **MaskedReduceSum**(D, M m, V v)</code>: returns the sum of all lanes
+    where `m[i]` is `true`.
+*   <code>T **MaskedReduceMin**(D, M m, V v)</code>: returns the minimum of all
+    lanes where `m[i]` is `true`.
+*   <code>T **MaskedReduceMax**(D, M m, V v)</code>: returns the maximum of all
+    lanes where `m[i]` is `true`.
 
 ### Crypto
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -219,11 +219,6 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
   HWY_API HWY_SVE_V(BASE, BITS) NAME(HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS(v);                            \
   }
-#define HWY_SVE_RETV_ARGMV_M(BASE, CHAR, BITS, HALF, NAME, OP)             \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
-    return sv##OP##_##CHAR##BITS##_m(b, m, a);                             \
-  }
 #define HWY_SVE_RETV_ARGMV(BASE, CHAR, BITS, HALF, NAME, OP)                \
   HWY_API HWY_SVE_V(BASE, BITS) NAME(svbool_t m, HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS##_x(m, v);                                 \
@@ -265,13 +260,8 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_x(m, a, b);                             \
   }
-#define HWY_SVE_RETV_ARGMVV_M(BASE, CHAR, BITS, HALF, NAME, OP)            \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
-    return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
-  }
 // User-specified mask. Mask=false value is zero.
-#define HWY_SVE_RETV_ARGMVVZ(BASE, CHAR, BITS, HALF, NAME, OP)             \
+#define HWY_SVE_RETV_ARGMVV_Z(BASE, CHAR, BITS, HALF, NAME, OP)             \
   HWY_API HWY_SVE_V(BASE, BITS)                                            \
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_z(m, a, b);                             \
@@ -282,13 +272,6 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
       NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b,  \
            HWY_SVE_V(BASE, BITS) c) {                         \
     return sv##OP##_##CHAR##BITS(a, b, c);                    \
-  }
-
-#define HWY_SVE_RETV_ARGMVVV(BASE, CHAR, BITS, HALF, NAME, OP)           \
-  HWY_API HWY_SVE_V(BASE, BITS)                                          \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b, \
-           HWY_SVE_V(BASE, BITS) c) {                                    \
-    return sv##OP##_##CHAR##BITS##_x(m, a, b, c);                        \
   }
 
 // ------------------------------ Lanes
@@ -779,8 +762,8 @@ HWY_API V Or(const V a, const V b) {
   return BitCast(df, Or(BitCast(du, a), BitCast(du, b)));
 }
 
-// ------------------------------ MaskedOrOrZero
-HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVVZ, MaskedOrOrZero, orr)
+// ------------------------------ MaskedOr
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVV_Z, MaskedOr, orr)
 
 // ------------------------------ Xor
 
@@ -1697,6 +1680,7 @@ namespace detail {
     return sv##OP##_##CHAR##BITS(pg, v);                                     \
   }
 
+// TODO: Remove SumOfLanesM in favor of using MaskedReduceSum
 HWY_SVE_FOREACH_UI(HWY_SVE_REDUCE_ADD, SumOfLanesM, addv)
 HWY_SVE_FOREACH_F(HWY_SVE_REDUCE, SumOfLanesM, addv)
 
@@ -6642,7 +6626,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_IF_NOT_EMULATED_D
 #undef HWY_SVE_PTRUE
 #undef HWY_SVE_RETV_ARGMVV
-#undef HWY_SVE_RETV_ARGMVVZ
+#undef HWY_SVE_RETV_ARGMVV_Z
 #undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGMV
 #undef HWY_SVE_RETV_ARGPV
@@ -6650,13 +6634,8 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGPVV
 #undef HWY_SVE_RETV_ARGV
 #undef HWY_SVE_RETV_ARGVN
-#undef HWY_SVE_RETV_ARGMV
-#undef HWY_SVE_RETV_ARGMV_M
-#undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGVV
-#undef HWY_SVE_RETV_ARGMVV_M
 #undef HWY_SVE_RETV_ARGVVV
-#undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T
 #undef HWY_SVE_UNDEFINED
 #undef HWY_SVE_V

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -274,6 +274,13 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
     return sv##OP##_##CHAR##BITS(a, b, c);                    \
   }
 
+#define HWY_SVE_RETV_ARGMVVV(BASE, CHAR, BITS, HALF, NAME, OP)           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b, \
+           HWY_SVE_V(BASE, BITS) c) {                                    \
+    return sv##OP##_##CHAR##BITS##_x(m, a, b, c);                        \
+  }
+
 // ------------------------------ Lanes
 
 namespace detail {
@@ -6636,6 +6643,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGVN
 #undef HWY_SVE_RETV_ARGVV
 #undef HWY_SVE_RETV_ARGVVV
+#undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T
 #undef HWY_SVE_UNDEFINED
 #undef HWY_SVE_V

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -219,6 +219,11 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
   HWY_API HWY_SVE_V(BASE, BITS) NAME(HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS(v);                            \
   }
+#define HWY_SVE_RETV_ARGMV_M(BASE, CHAR, BITS, HALF, NAME, OP)             \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
+    return sv##OP##_##CHAR##BITS##_m(b, m, a);                             \
+  }
 #define HWY_SVE_RETV_ARGMV(BASE, CHAR, BITS, HALF, NAME, OP)                \
   HWY_API HWY_SVE_V(BASE, BITS) NAME(svbool_t m, HWY_SVE_V(BASE, BITS) v) { \
     return sv##OP##_##CHAR##BITS##_x(m, v);                                 \
@@ -259,6 +264,17 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
   HWY_API HWY_SVE_V(BASE, BITS)                                            \
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_x(m, a, b);                             \
+  }
+#define HWY_SVE_RETV_ARGMVV_M(BASE, CHAR, BITS, HALF, NAME, OP)            \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
+    return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
+  }
+// User-specified mask. Mask=false value is zero.
+#define HWY_SVE_RETV_ARGMVVZ(BASE, CHAR, BITS, HALF, NAME, OP)             \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
+    return sv##OP##_##CHAR##BITS##_z(m, a, b);                             \
   }
 
 #define HWY_SVE_RETV_ARGVVV(BASE, CHAR, BITS, HALF, NAME, OP) \
@@ -762,6 +778,9 @@ HWY_API V Or(const V a, const V b) {
   const RebindToUnsigned<decltype(df)> du;
   return BitCast(df, Or(BitCast(du, a), BitCast(du, b)));
 }
+
+// ------------------------------ MaskedOrOrZero
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVVZ, MaskedOrOrZero, orr)
 
 // ------------------------------ Xor
 
@@ -1723,6 +1742,25 @@ HWY_API TFromD<D> ReduceMin(D d, VFromD<D> v) {
 template <class D, HWY_IF_REDUCE_D(D)>
 HWY_API TFromD<D> ReduceMax(D d, VFromD<D> v) {
   return detail::MaxOfLanesM(detail::MakeMask(d), v);
+}
+
+#ifdef HWY_NATIVE_MASKED_REDUCE_SCALAR
+#undef HWY_NATIVE_MASKED_REDUCE_SCALAR
+#else
+#define HWY_NATIVE_MASKED_REDUCE_SCALAR
+#endif
+
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceSum(D /*d*/, M m, VFromD<D> v) {
+  return detail::SumOfLanesM(m, v);
+}
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceMin(D /*d*/, M m, VFromD<D> v) {
+  return detail::MinOfLanesM(m, v);
+}
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceMax(D /*d*/, M m, VFromD<D> v) {
+  return detail::MaxOfLanesM(m, v);
 }
 
 // ------------------------------ SumOfLanes
@@ -5056,6 +5094,23 @@ HWY_API V IfNegativeThenElse(V v, V yes, V no) {
   static_assert(IsSigned<TFromV<V>>(), "Only works for signed/float");
   return IfThenElse(IsNegative(v), yes, no);
 }
+// ------------------------------ IfNegativeThenNegOrUndefIfZero
+
+#ifdef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
+#undef HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
+#else
+#define HWY_NATIVE_INTEGER_IF_NEGATIVE_THEN_NEG
+#endif
+
+#define HWY_SVE_NEG_IF(BASE, CHAR, BITS, HALF, NAME, OP)          \
+  HWY_API HWY_SVE_V(BASE, BITS)                                   \
+      NAME(HWY_SVE_V(BASE, BITS) mask, HWY_SVE_V(BASE, BITS) v) { \
+    return sv##OP##_##CHAR##BITS##_m(v, IsNegative(mask), v);     \
+  }
+
+HWY_SVE_FOREACH_IF(HWY_SVE_NEG_IF, IfNegativeThenNegOrUndefIfZero, neg)
+
+#undef HWY_SVE_NEG_IF
 
 // ------------------------------ AverageRound (ShiftRight)
 
@@ -6587,6 +6642,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_IF_NOT_EMULATED_D
 #undef HWY_SVE_PTRUE
 #undef HWY_SVE_RETV_ARGMVV
+#undef HWY_SVE_RETV_ARGMVVZ
 #undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGMV
 #undef HWY_SVE_RETV_ARGPV
@@ -6594,7 +6650,11 @@ HWY_SVE_FOREACH_UI(HWY_SVE_MASKED_LEADING_ZERO_COUNT, MaskedLeadingZeroCount,
 #undef HWY_SVE_RETV_ARGPVV
 #undef HWY_SVE_RETV_ARGV
 #undef HWY_SVE_RETV_ARGVN
+#undef HWY_SVE_RETV_ARGMV
+#undef HWY_SVE_RETV_ARGMV_M
+#undef HWY_SVE_RETV_ARGMV_Z
 #undef HWY_SVE_RETV_ARGVV
+#undef HWY_SVE_RETV_ARGMVV_M
 #undef HWY_SVE_RETV_ARGVVV
 #undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1026,11 +1026,11 @@ HWY_API TFromD<D> MaskedReduceSum(D d, M m, VFromD<D> v) {
 }
 template <class D, class M>
 HWY_API TFromD<D> MaskedReduceMin(D d, M m, VFromD<D> v) {
-  return ReduceMin(d, IfThenElse(m, v, MaxOfLanes(d, v)));
+  return ReduceMin(d, IfThenElse(m, v, Set(d, hwy::HighestValue<TFromD<D>>())));
 }
 template <class D, class M>
 HWY_API TFromD<D> MaskedReduceMax(D d, M m, VFromD<D> v) {
-  return ReduceMax(d, IfThenElseZero(m, v));
+  return ReduceMax(d, IfThenElse(m, v, Set(d, hwy::LowestValue<TFromD<D>>())));
 }
 
 #endif  // HWY_NATIVE_MASKED_REDUCE_SCALAR
@@ -6735,30 +6735,6 @@ HWY_API V ReverseBits(V v) {
 }
 #endif  // HWY_NATIVE_REVERSE_BITS_UI16_32_64
 
-// ------------------------------ TableLookupLanesOr
-template <class V, class M>
-HWY_API V TableLookupLanesOr(M m, V a, V b, IndicesFromD<DFromV<V>> idx) {
-  return IfThenElse(m, TableLookupLanes(a, idx), b);
-}
-
-// ------------------------------ TableLookupLanesOrZero
-template <class V, class M>
-HWY_API V TableLookupLanesOrZero(M m, V a, IndicesFromD<DFromV<V>> idx) {
-  return IfThenElseZero(m, TableLookupLanes(a, idx));
-}
-
-// ------------------------------ TwoTablesLookupLanesOr
-template <class D, class V, class M>
-HWY_API V TwoTablesLookupLanesOr(D d, M m, V a, V b, IndicesFromD<D> idx) {
-  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), a);
-}
-
-// ------------------------------ TwoTablesLookupLanesOrZero
-template <class D, class V, class M>
-HWY_API V TwoTablesLookupLanesOrZero(D d, M m, V a, V b, IndicesFromD<D> idx) {
-  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), Zero(d));
-}
-
 // ------------------------------ Per4LaneBlockShuffle
 
 #if (defined(HWY_NATIVE_PER4LANEBLKSHUF_DUP32) == defined(HWY_TARGET_TOGGLE))
@@ -7615,7 +7591,7 @@ HWY_API V BitShuffle(V v, VI idx) {
 #endif  // HWY_NATIVE_BITSHUFFLE
 
 template <class V, class M>
-HWY_API V MaskedOrOrZero(M m, V a, V b) {
+HWY_API V MaskedOr(M m, V a, V b) {
   return IfThenElseZero(m, Or(a, b));
 }
 // ------------------------------ AllBits1/AllBits0

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1026,11 +1026,11 @@ HWY_API TFromD<D> MaskedReduceSum(D d, M m, VFromD<D> v) {
 }
 template <class D, class M>
 HWY_API TFromD<D> MaskedReduceMin(D d, M m, VFromD<D> v) {
-  return ReduceMin(d, IfThenElse(m, v, Set(d, hwy::HighestValue<TFromD<D>>())));
+  return ReduceMin(d, IfThenElse(m, v, Set(d, hwy::PositiveInfOrHighestValue <TFromD<D>>())));
 }
 template <class D, class M>
 HWY_API TFromD<D> MaskedReduceMax(D d, M m, VFromD<D> v) {
-  return ReduceMax(d, IfThenElse(m, v, Set(d, hwy::LowestValue<TFromD<D>>())));
+  return ReduceMax(d, IfThenElse(m, v, Set(d, hwy::NegativeInfOrLowestValue<TFromD<D>>())));
 }
 
 #endif  // HWY_NATIVE_MASKED_REDUCE_SCALAR

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -1013,6 +1013,28 @@ HWY_API TFromD<D> ReduceMax(D d, VFromD<D> v) {
 }
 #endif  // HWY_NATIVE_REDUCE_MINMAX_4_UI8
 
+#if (defined(HWY_NATIVE_MASKED_REDUCE_SCALAR) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MASKED_REDUCE_SCALAR
+#undef HWY_NATIVE_MASKED_REDUCE_SCALAR
+#else
+#define HWY_NATIVE_MASKED_REDUCE_SCALAR
+#endif
+
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceSum(D d, M m, VFromD<D> v) {
+  return ReduceSum(d, IfThenElseZero(m, v));
+}
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceMin(D d, M m, VFromD<D> v) {
+  return ReduceMin(d, IfThenElse(m, v, MaxOfLanes(d, v)));
+}
+template <class D, class M>
+HWY_API TFromD<D> MaskedReduceMax(D d, M m, VFromD<D> v) {
+  return ReduceMax(d, IfThenElseZero(m, v));
+}
+
+#endif  // HWY_NATIVE_MASKED_REDUCE_SCALAR
+
 // ------------------------------ IsEitherNaN
 #if (defined(HWY_NATIVE_IS_EITHER_NAN) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_IS_EITHER_NAN
@@ -6713,6 +6735,30 @@ HWY_API V ReverseBits(V v) {
 }
 #endif  // HWY_NATIVE_REVERSE_BITS_UI16_32_64
 
+// ------------------------------ TableLookupLanesOr
+template <class V, class M>
+HWY_API V TableLookupLanesOr(M m, V a, V b, IndicesFromD<DFromV<V>> idx) {
+  return IfThenElse(m, TableLookupLanes(a, idx), b);
+}
+
+// ------------------------------ TableLookupLanesOrZero
+template <class V, class M>
+HWY_API V TableLookupLanesOrZero(M m, V a, IndicesFromD<DFromV<V>> idx) {
+  return IfThenElseZero(m, TableLookupLanes(a, idx));
+}
+
+// ------------------------------ TwoTablesLookupLanesOr
+template <class D, class V, class M>
+HWY_API V TwoTablesLookupLanesOr(D d, M m, V a, V b, IndicesFromD<D> idx) {
+  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), a);
+}
+
+// ------------------------------ TwoTablesLookupLanesOrZero
+template <class D, class V, class M>
+HWY_API V TwoTablesLookupLanesOrZero(D d, M m, V a, V b, IndicesFromD<D> idx) {
+  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), Zero(d));
+}
+
 // ------------------------------ Per4LaneBlockShuffle
 
 #if (defined(HWY_NATIVE_PER4LANEBLKSHUF_DUP32) == defined(HWY_TARGET_TOGGLE))
@@ -7568,6 +7614,10 @@ HWY_API V BitShuffle(V v, VI idx) {
 
 #endif  // HWY_NATIVE_BITSHUFFLE
 
+template <class V, class M>
+HWY_API V MaskedOrOrZero(M m, V a, V b) {
+  return IfThenElseZero(m, Or(a, b));
+}
 // ------------------------------ AllBits1/AllBits0
 #if (defined(HWY_NATIVE_ALLONES) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_ALLONES

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -4755,6 +4755,8 @@ HWY_API T ReduceMax(D d, const VFromD<D> v) {
 
 #undef HWY_RVV_REDUCE
 
+// TODO: add MaskedReduceSum/Min/Max
+
 // ------------------------------ SumOfLanes
 
 template <class D, HWY_IF_LANES_GT_D(D, 1)>

--- a/hwy/tests/logical_test.cc
+++ b/hwy/tests/logical_test.cc
@@ -146,26 +146,26 @@ HWY_NOINLINE void TestAllTestBit() {
   ForIntegerTypes(ForPartialVectors<TestTestBit>());
 }
 
-struct TestMaskedOrOrZero {
+struct TestMaskedOr {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     const MFromD<D> all_true = MaskTrue(d);
     const auto v1 = Iota(d, 1);
     const auto v2 = Iota(d, 2);
 
-    HWY_ASSERT_VEC_EQ(d, Or(v2, v1), MaskedOrOrZero(all_true, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, Or(v2, v1), MaskedOr(all_true, v1, v2));
 
     const MFromD<D> first_five = FirstN(d, 5);
     const Vec<D> v0 = Zero(d);
 
     const Vec<D> v1_exp = IfThenElse(first_five, Or(v2, v1), v0);
 
-    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedOrOrZero(first_five, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedOr(first_five, v1, v2));
   }
 };
 
 HWY_NOINLINE void TestAllMaskedLogical() {
-  ForAllTypes(ForPartialVectors<TestMaskedOrOrZero>());
+  ForAllTypes(ForPartialVectors<TestMaskedOr>());
 }
 
 struct TestAllBits {

--- a/hwy/tests/logical_test.cc
+++ b/hwy/tests/logical_test.cc
@@ -146,6 +146,28 @@ HWY_NOINLINE void TestAllTestBit() {
   ForIntegerTypes(ForPartialVectors<TestTestBit>());
 }
 
+struct TestMaskedOrOrZero {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const MFromD<D> all_true = MaskTrue(d);
+    const auto v1 = Iota(d, 1);
+    const auto v2 = Iota(d, 2);
+
+    HWY_ASSERT_VEC_EQ(d, Or(v2, v1), MaskedOrOrZero(all_true, v1, v2));
+
+    const MFromD<D> first_five = FirstN(d, 5);
+    const Vec<D> v0 = Zero(d);
+
+    const Vec<D> v1_exp = IfThenElse(first_five, Or(v2, v1), v0);
+
+    HWY_ASSERT_VEC_EQ(d, v1_exp, MaskedOrOrZero(first_five, v1, v2));
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedLogical() {
+  ForAllTypes(ForPartialVectors<TestMaskedOrOrZero>());
+}
+
 struct TestAllBits {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -185,6 +207,7 @@ HWY_BEFORE_TEST(HwyLogicalTest);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllNot);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllLogical);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllTestBit);
+HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllMaskedLogical);
 HWY_EXPORT_AND_TEST_P(HwyLogicalTest, TestAllAllBits);
 
 HWY_AFTER_TEST();

--- a/hwy/tests/reduction_test.cc
+++ b/hwy/tests/reduction_test.cc
@@ -357,23 +357,25 @@ struct TestMaskedReduceSum {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
 
+    using TI = MakeSigned<T>;
+    const Rebind<TI, D> di;
     const Vec<D> v2 = Iota(d, 2);
 
     const size_t N = Lanes(d);
-    auto bool_lanes = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<TI>(N);
     HWY_ASSERT(bool_lanes);
 
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
       T expected = 0;
       for (size_t i = 0; i < N; ++i) {
-        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
         if (bool_lanes[i]) {
           expected += ConvertScalarTo<T>(i + 2);
         }
       }
 
-      const Vec<D> mask_i = Load(d, bool_lanes.get());
-      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+      const auto mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
       // If all elements are disabled the result is implementation defined
       if (AllFalse(d, mask)) {
@@ -394,17 +396,19 @@ struct TestMaskedReduceMin {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
 
+    using TI = MakeSigned<T>;
+    const Rebind<TI, D> di;
     const Vec<D> v2 = Iota(d, 2);
 
     const size_t N = Lanes(d);
-    auto bool_lanes = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<TI>(N);
     HWY_ASSERT(bool_lanes);
 
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
       T expected =
           ConvertScalarTo<T>(N + 3);  // larger than any values in the vector
       for (size_t i = 0; i < N; ++i) {
-        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
         if (bool_lanes[i]) {
           if (expected > ConvertScalarTo<T>(i + 2)) {
             expected = ConvertScalarTo<T>(i + 2);
@@ -412,8 +416,8 @@ struct TestMaskedReduceMin {
         }
       }
 
-      const Vec<D> mask_i = Load(d, bool_lanes.get());
-      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+      const auto mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
       // If all elements are disabled the result is implementation defined
       if (AllFalse(d, mask)) {
@@ -434,16 +438,18 @@ struct TestMaskedReduceMax {
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
     RandomState rng;
 
+    using TI = MakeSigned<T>;
+    const Rebind<TI, D> di;
     const Vec<D> v2 = Iota(d, 2);
 
     const size_t N = Lanes(d);
-    auto bool_lanes = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<TI>(N);
     HWY_ASSERT(bool_lanes);
 
     for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
       T expected = 0;
       for (size_t i = 0; i < N; ++i) {
-        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+        bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
         if (bool_lanes[i]) {
           if (expected < ConvertScalarTo<T>(i + 2)) {
             expected = ConvertScalarTo<T>(i + 2);
@@ -451,8 +457,8 @@ struct TestMaskedReduceMax {
         }
       }
 
-      const Vec<D> mask_i = Load(d, bool_lanes.get());
-      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+      const auto mask_i = Load(di, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
 
       // If all elements are disabled the result is implementation defined
       if (AllFalse(d, mask)) {

--- a/hwy/tests/table_test.cc
+++ b/hwy/tests/table_test.cc
@@ -103,59 +103,6 @@ HWY_NOINLINE void TestAllTableLookupLanes() {
   ForAllTypes(ForPartialVectors<TestTableLookupLanes>());
 }
 
-struct TestTableLookupLanesOr {
-  template <class T, class D>
-#if HWY_TARGET != HWY_SCALARWE
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
-    const RebindToSigned<D> di;
-    using TI = TFromD<decltype(di)>;
-
-    const size_t N = Lanes(d);
-    // Select indices from N-1 counting down
-    auto indices = IndicesFromVec(
-        d, Sub(Set(di, ConvertScalarTo<TI>(N - 1)), Iota(di, 0)));
-
-    auto expected = AllocateAligned<T>(N);
-    auto expected_zero = AllocateAligned<T>(N);
-    auto bool_lanes = AllocateAligned<T>(N);
-    HWY_ASSERT(expected && expected_zero && bool_lanes);
-
-    const auto v1 = Iota(d, 5);
-    const auto v2 = Iota(d, 8);
-
-    RandomState rng;
-
-    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
-      for (size_t i = 0; i < N; ++i) {
-        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
-
-        if (bool_lanes[i]) {
-          expected[i] = ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
-          expected_zero[i] =
-              ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
-        } else {
-          expected[i] = ConvertScalarTo<T>(i + 8);  // v2[i]
-          expected_zero[i] = ConvertScalarTo(0);
-        }
-      }
-
-      const Vec<D> mask_i = Load(d, bool_lanes.get());
-      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
-      HWY_ASSERT_VEC_EQ(d, expected.get(),
-                        TableLookupLanesOr(mask, v1, v2, indices));
-      HWY_ASSERT_VEC_EQ(d, expected_zero.get(),
-                        TableLookupLanesOrZero(mask, v1, indices));
-#else
-  (void) d;
-#endif
-    }
-  }
-};
-
-HWY_NOINLINE void TestAllTableLookupLanesOr() {
-  ForAllTypes(ForPartialVectors<TestTableLookupLanesOr>());
-}
-
 struct TestTwoTablesLookupLanes {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -247,64 +194,6 @@ HWY_NOINLINE void TestAllTwoTablesLookupLanes() {
   ForAllTypes(ForPartialVectors<TestTwoTablesLookupLanes>());
 }
 
-struct TestTwoTablesLookupLanesOr {
-  template <class T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
-    const RebindToSigned<D> di;
-    using TI = TFromD<decltype(di)>;
-
-    const size_t N = Lanes(d);
-    // Select indices from N-1 counting down
-    auto idx_lower = Sub(Set(di, ConvertScalarTo<TI>(N - 1)), Iota(di, 0));
-    auto idx_upper = Add(idx_lower, Set(di, ConvertScalarTo<TI>(N)));
-    auto indices = IndicesFromVec(d, OddEven(idx_upper, idx_lower));
-
-    auto expected = AllocateAligned<T>(N);
-    auto expected_zero = AllocateAligned<T>(N);
-    auto bool_lanes = AllocateAligned<T>(N);
-    HWY_ASSERT(expected && expected_zero && bool_lanes);
-
-    const auto v1 = Iota(d, 5);
-    const auto v2 = Iota(d, 8);
-
-    RandomState rng;
-
-    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
-      for (size_t i = 0; i < N; ++i) {
-        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
-
-        if (bool_lanes[i]) {
-          if (i % 2) {
-            expected[i] =
-                ConvertScalarTo<T>(N - i + 8 - 1);  // v2[N-1, N-2, ...]
-            expected_zero[i] =
-                ConvertScalarTo<T>(N - i + 8 - 1);  // v2[N-1, N-2, ...]
-          } else {
-            expected[i] =
-                ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
-            expected_zero[i] =
-                ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
-          }
-        } else {
-          expected[i] = ConvertScalarTo<T>(i + 5);  // v1[i]
-          expected_zero[i] = ConvertScalarTo(0);
-        }
-      }
-
-      const Vec<D> mask_i = Load(d, bool_lanes.get());
-      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
-      HWY_ASSERT_VEC_EQ(d, expected.get(),
-                        TwoTablesLookupLanesOr(d, mask, v1, v2, indices));
-      HWY_ASSERT_VEC_EQ(d, expected_zero.get(),
-                        TwoTablesLookupLanesOrZero(d, mask, v1, v2, indices));
-    }
-  }
-};
-
-HWY_NOINLINE void TestAllTwoTablesLookupLanesOr() {
-  ForAllTypes(ForPartialVectors<TestTwoTablesLookupLanesOr>());
-}
-
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -316,9 +205,7 @@ namespace hwy {
 namespace {
 HWY_BEFORE_TEST(HwyTableTest);
 HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTableLookupLanes);
-HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTableLookupLanesOr);
 HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTwoTablesLookupLanes);
-HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTwoTablesLookupLanesOr);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/table_test.cc
+++ b/hwy/tests/table_test.cc
@@ -103,6 +103,59 @@ HWY_NOINLINE void TestAllTableLookupLanes() {
   ForAllTypes(ForPartialVectors<TestTableLookupLanes>());
 }
 
+struct TestTableLookupLanesOr {
+  template <class T, class D>
+#if HWY_TARGET != HWY_SCALARWE
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const RebindToSigned<D> di;
+    using TI = TFromD<decltype(di)>;
+
+    const size_t N = Lanes(d);
+    // Select indices from N-1 counting down
+    auto indices = IndicesFromVec(
+        d, Sub(Set(di, ConvertScalarTo<TI>(N - 1)), Iota(di, 0)));
+
+    auto expected = AllocateAligned<T>(N);
+    auto expected_zero = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(expected && expected_zero && bool_lanes);
+
+    const auto v1 = Iota(d, 5);
+    const auto v2 = Iota(d, 8);
+
+    RandomState rng;
+
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+
+        if (bool_lanes[i]) {
+          expected[i] = ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
+          expected_zero[i] =
+              ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
+        } else {
+          expected[i] = ConvertScalarTo<T>(i + 8);  // v2[i]
+          expected_zero[i] = ConvertScalarTo(0);
+        }
+      }
+
+      const Vec<D> mask_i = Load(d, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+      HWY_ASSERT_VEC_EQ(d, expected.get(),
+                        TableLookupLanesOr(mask, v1, v2, indices));
+      HWY_ASSERT_VEC_EQ(d, expected_zero.get(),
+                        TableLookupLanesOrZero(mask, v1, indices));
+#else
+  (void) d;
+#endif
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllTableLookupLanesOr() {
+  ForAllTypes(ForPartialVectors<TestTableLookupLanesOr>());
+}
+
 struct TestTwoTablesLookupLanes {
   template <class T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -194,6 +247,64 @@ HWY_NOINLINE void TestAllTwoTablesLookupLanes() {
   ForAllTypes(ForPartialVectors<TestTwoTablesLookupLanes>());
 }
 
+struct TestTwoTablesLookupLanesOr {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const RebindToSigned<D> di;
+    using TI = TFromD<decltype(di)>;
+
+    const size_t N = Lanes(d);
+    // Select indices from N-1 counting down
+    auto idx_lower = Sub(Set(di, ConvertScalarTo<TI>(N - 1)), Iota(di, 0));
+    auto idx_upper = Add(idx_lower, Set(di, ConvertScalarTo<TI>(N)));
+    auto indices = IndicesFromVec(d, OddEven(idx_upper, idx_lower));
+
+    auto expected = AllocateAligned<T>(N);
+    auto expected_zero = AllocateAligned<T>(N);
+    auto bool_lanes = AllocateAligned<T>(N);
+    HWY_ASSERT(expected && expected_zero && bool_lanes);
+
+    const auto v1 = Iota(d, 5);
+    const auto v2 = Iota(d, 8);
+
+    RandomState rng;
+
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+
+        if (bool_lanes[i]) {
+          if (i % 2) {
+            expected[i] =
+                ConvertScalarTo<T>(N - i + 8 - 1);  // v2[N-1, N-2, ...]
+            expected_zero[i] =
+                ConvertScalarTo<T>(N - i + 8 - 1);  // v2[N-1, N-2, ...]
+          } else {
+            expected[i] =
+                ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
+            expected_zero[i] =
+                ConvertScalarTo<T>(N - i + 5 - 1);  // v1[N-1, N-2, ...]
+          }
+        } else {
+          expected[i] = ConvertScalarTo<T>(i + 5);  // v1[i]
+          expected_zero[i] = ConvertScalarTo(0);
+        }
+      }
+
+      const Vec<D> mask_i = Load(d, bool_lanes.get());
+      const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(d)));
+      HWY_ASSERT_VEC_EQ(d, expected.get(),
+                        TwoTablesLookupLanesOr(d, mask, v1, v2, indices));
+      HWY_ASSERT_VEC_EQ(d, expected_zero.get(),
+                        TwoTablesLookupLanesOrZero(d, mask, v1, v2, indices));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllTwoTablesLookupLanesOr() {
+  ForAllTypes(ForPartialVectors<TestTwoTablesLookupLanesOr>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -205,7 +316,9 @@ namespace hwy {
 namespace {
 HWY_BEFORE_TEST(HwyTableTest);
 HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTableLookupLanes);
+HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTableLookupLanesOr);
 HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTwoTablesLookupLanes);
+HWY_EXPORT_AND_TEST_P(HwyTableTest, TestAllTwoTablesLookupLanesOr);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
Introduces:
- MaskedOrOrZero(m, a, b): returns `a[i] || b[i]` or `zero` if `m[i]` is false.
- TwoTablesLookupLanesOr(d, m, a, b, unspecified): returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where `m[i]` is true, and `a[i]` where `m[i]` is false.
- TwoTablesLookupLanesOrZero(d, m, a, b, unspecified): returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where `m[i]` is true, and zero where `m[i]` is false.
- MaskedReduceSum(d, m, v): returns the sum of all lanes where `m[i]` is `true`.
- MaskedReduceMin(d, m, v): returns the minimum of all lanes where `m[i]` is `true`.
- MaskedReduceMax(d, m, v): returns the maximum of all lanes where `m[i]` is `true`.
- IfNegativeThenNegOrUndefIfZero(mask, v): returns `mask[i] < 0 ? (-v[i]) : ((mask[i] > 0) ? v[i] : impl_defined_val)`, where    `impl_defined_val` is an implementation-defined value that is equal to either 0 or `v[i]`. SVE included only.

Testing is performed for all new operations.