### PR TITLE
MulRound, MulLower and MulAddLower ops

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -726,6 +726,10 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     truncating it to the lower half for integer inputs. Currently unavailable on
     SVE/RVV; use the equivalent `Mul` instead.
 
+*   `V`: `f`
+    <code>V **MulRound**(V a, V b)</code>: Multiplies `a[i]` by `b[i]` and rounds
+    the result to the nearest int with ties going to even.
+
 *   `V`: `f`, `VI`: `Vec<RebindToSigned<DFromV<V>>>` \
     <code>V **MulByPow2**(V a, VI b)</code>: Multiplies `a[i]` by `2^b[i]`.
 
@@ -755,6 +759,9 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
 *   `V`: `{u,i}` \
     <code>V **MulHigh**(V a, V b)</code>: returns the upper half of `a[i] *
     b[i]` in each lane.
+
+*   <code>V **MulLower**(V a, V b)</code>: returns `a[0] * b[0]` in the
+    first lane and `a[i]` otherwise.
 
 *   `V`: `i16` \
     <code>V **MulFixedPoint15**(V a, V b)</code>: returns the result of
@@ -881,6 +888,9 @@ variants are somewhat slower on Arm, and unavailable for integer inputs; if the
     <code>VW **MulOddAdd**(D d, V a, V b, VW c)</code>: equivalent to and
     potentially more efficient than `MulAdd(PromoteOddTo(d, a), PromoteOddTo(d,
     b), c)`.
+
+*   <code>V **MulAddLower**(V a, V b, V c)</code>: returns `a[0] * b[0] + c[0]`
+    and `a[i]` in all other lanes.
 
 #### Masked arithmetic
 

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -760,9 +760,6 @@ All other ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     <code>V **MulHigh**(V a, V b)</code>: returns the upper half of `a[i] *
     b[i]` in each lane.
 
-*   <code>V **MulLower**(V a, V b)</code>: returns `a[0] * b[0]` in the
-    first lane and `a[i]` otherwise.
-
 *   `V`: `i16` \
     <code>V **MulFixedPoint15**(V a, V b)</code>: returns the result of
     multiplying two Q1.15 fixed-point numbers. This corresponds to doubling the
@@ -889,9 +886,6 @@ variants are somewhat slower on Arm, and unavailable for integer inputs; if the
     potentially more efficient than `MulAdd(PromoteOddTo(d, a), PromoteOddTo(d,
     b), c)`.
 
-*   <code>V **MulAddLower**(V a, V b, V c)</code>: returns `a[0] * b[0] + c[0]`
-    and `a[i]` in all other lanes.
-
 #### Masked arithmetic
 
 All ops in this section return `no` for `mask=false` lanes, and suppress any
@@ -925,6 +919,8 @@ not a concern, these are equivalent to, and potentially more efficient than,
     <code>V **MaskedSatSubOr**(V no, M m, V a, V b)</code>: returns `a[i] +
     b[i]` saturated to the minimum/maximum representable value, or `no[i]` if
     `m[i]` is false.
+*   <code>V **MaskedMulAddOr**(V no, M m, V mul, V x, V add)</code>: returns
+    `mul[i] * x[i] + add[i]` or `no[i]` if `m[i]` is false.
 
 #### Zero masked arithmetic
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -260,12 +260,24 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_x(m, a, b);                             \
   }
+#define HWY_SVE_RETV_ARGMVV_M(BASE, CHAR, BITS, HALF, NAME, OP)            \
+  HWY_API HWY_SVE_V(BASE, BITS)                                            \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
+    return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
+  }
 
 #define HWY_SVE_RETV_ARGVVV(BASE, CHAR, BITS, HALF, NAME, OP) \
   HWY_API HWY_SVE_V(BASE, BITS)                               \
       NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b,  \
            HWY_SVE_V(BASE, BITS) c) {                         \
     return sv##OP##_##CHAR##BITS(a, b, c);                    \
+  }
+
+#define HWY_SVE_RETV_ARGMVVV(BASE, CHAR, BITS, HALF, NAME, OP)           \
+  HWY_API HWY_SVE_V(BASE, BITS)                                          \
+      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b, \
+           HWY_SVE_V(BASE, BITS) c) {                                    \
+    return sv##OP##_##CHAR##BITS##_m(m, a, b, c);                        \
   }
 
 // ------------------------------ Lanes
@@ -1289,6 +1301,31 @@ HWY_SVE_FOREACH_F(HWY_SVE_FMA, NegMulSub, nmad)
 
 #undef HWY_SVE_FMA
 
+// ------------------------------ MaskedMulAdd
+namespace detail {
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVVV, MaskedMulAdd, mad)
+}
+
+// ------------------------------ MulAddLower
+#if (defined(HWY_NATIVE_MUL_ADD_LOWER) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MUL_ADD_LOWER
+#undef HWY_NATIVE_MUL_ADD_LOWER
+#else
+#define HWY_NATIVE_MUL_ADD_LOWER
+#endif
+
+#define HWY_SVE_MUL_ADD_LOWER(BASE, CHAR, BITS, HALF, NAME, OP)        \
+  HWY_API HWY_SVE_V(BASE, BITS)                                        \
+      NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b,           \
+           HWY_SVE_V(BASE, BITS) c) {                                  \
+    return detail::MaskedMulAdd(svptrue_pat_b##BITS(SV_VL1), a, b, c); \
+  }
+
+HWY_SVE_FOREACH(HWY_SVE_MUL_ADD_LOWER, MulAddLower, _)
+#undef HWY_SVE_MUL_ADD_LOWER
+
+#endif  // HWY_NATIVE_MUL_ADD_LOWER
+
 // ------------------------------ Round etc.
 
 HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGPV, Round, rintn)
@@ -1601,6 +1638,26 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
   return IfThenElse(m, SaturatedSub(a, b), no);
 }
 #endif
+
+// ------------------------------ MaskedMul_M
+namespace detail {
+HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV_M, MaskedMul_M, mul);
+}
+
+// ------------------------------ MulLower
+#ifdef HWY_NATIVE_MUL_LOWER
+#undef HWY_NATIVE_MUL_LOWER
+#else
+#define HWY_NATIVE_MUL_LOWER
+#endif
+
+#define HWY_SVE_MUL_LOWER(BASE, CHAR, BITS, HALF, NAME, OP)        \
+  HWY_API HWY_SVE_V(BASE, BITS)                                    \
+      NAME(HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) {     \
+    return detail::MaskedMul_M(svptrue_pat_b##BITS(SV_VL1), a, b); \
+  }
+
+HWY_SVE_FOREACH(HWY_SVE_MUL_LOWER, MulLower, _)
 
 template <class V, HWY_IF_FLOAT_V(V), class M>
 HWY_API V MaskedSqrtOr(V no, M m, V v) {
@@ -2100,6 +2157,18 @@ HWY_API svbool_t IsFinite(const V v) {
       BitCast(di, ShiftRight<hwy::MantissaBits<T>() + 1>(Add(vu, vu)));
   return RebindMask(d, detail::LtN(exp, hwy::MaxExponentField<T>()));
 }
+
+// ------------------------------ MulByPow2/MulByFloorPow2
+
+#define HWY_SVE_MUL_BY_POW2(BASE, CHAR, BITS, HALF, NAME, OP)      \
+  HWY_API HWY_SVE_V(BASE, BITS)                                    \
+      NAME(HWY_SVE_V(BASE, BITS) v, HWY_SVE_V(int, BITS) exp) {    \
+    return sv##OP##_##CHAR##BITS##_x(HWY_SVE_PTRUE(BITS), v, exp); \
+  }
+
+HWY_SVE_FOREACH_F(HWY_SVE_MUL_BY_POW2, MulByPow2, scale)
+
+#undef HWY_SVE_MUL_BY_POW2
 
 // ================================================== MEMORY
 
@@ -6446,7 +6515,9 @@ HWY_API V HighestSetBitIndex(V v) {
 #undef HWY_SVE_RETV_ARGV
 #undef HWY_SVE_RETV_ARGVN
 #undef HWY_SVE_RETV_ARGVV
+#undef HWY_SVE_RETV_ARGMVV_M
 #undef HWY_SVE_RETV_ARGVVV
+#undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T
 #undef HWY_SVE_UNDEFINED
 #undef HWY_SVE_V

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -260,11 +260,6 @@ HWY_SVE_FOREACH_BF16_UNCONDITIONAL(HWY_SPECIALIZE, _, _)
       NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
     return sv##OP##_##CHAR##BITS##_x(m, a, b);                             \
   }
-#define HWY_SVE_RETV_ARGMVV_M(BASE, CHAR, BITS, HALF, NAME, OP)            \
-  HWY_API HWY_SVE_V(BASE, BITS)                                            \
-      NAME(svbool_t m, HWY_SVE_V(BASE, BITS) a, HWY_SVE_V(BASE, BITS) b) { \
-    return sv##OP##_##CHAR##BITS##_m(m, a, b);                             \
-  }
 
 #define HWY_SVE_RETV_ARGVVV(BASE, CHAR, BITS, HALF, NAME, OP) \
   HWY_API HWY_SVE_V(BASE, BITS)                               \
@@ -6488,7 +6483,6 @@ HWY_API V HighestSetBitIndex(V v) {
 #undef HWY_SVE_RETV_ARGV
 #undef HWY_SVE_RETV_ARGVN
 #undef HWY_SVE_RETV_ARGVV
-#undef HWY_SVE_RETV_ARGMVV_M
 #undef HWY_SVE_RETV_ARGVVV
 #undef HWY_SVE_RETV_ARGMVVV
 #undef HWY_SVE_T

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -577,6 +577,22 @@ HWY_API V AddSub(V a, V b) {
   return Add(a, negated_even_b);
 }
 
+#if (defined(HWY_NATIVE_MUL_LOWER) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MUL_LOWER
+#undef HWY_NATIVE_MUL_LOWER
+#else
+#define HWY_NATIVE_MUL_LOWER
+#endif
+
+template <class V>
+HWY_API V MulLower(V a, V b) {
+  const DFromV<V> d;
+  const auto first_mask = FirstN(d, 1);
+  return MaskedMulOr(a, first_mask, a, b);
+}
+
+#endif  // HWY_NATIVE_MUL_LOWER
+
 // ------------------------------ MaskedAddOr etc.
 #if (defined(HWY_NATIVE_MASKED_ARITH) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_MASKED_ARITH
@@ -4352,6 +4368,12 @@ HWY_API V operator*(V x, V y) {
 
 #endif  // HWY_NATIVE_MUL_64
 
+// ------------------------------ MulRound
+template <class V, HWY_IF_FLOAT_V(V)>
+HWY_API V MulRound(V a, V b) {
+  return Round(Mul(a, b));
+}
+
 // ------------------------------ MulAdd / NegMulAdd
 
 #if (defined(HWY_NATIVE_INT_FMA) == defined(HWY_TARGET_TOGGLE))
@@ -4382,6 +4404,23 @@ HWY_API V MulSub(V mul, V x, V sub) {
   return Sub(Mul(mul, x), sub);
 }
 #endif  // HWY_NATIVE_INT_FMA
+
+// ------------------------------ MulAddLower
+#if (defined(HWY_NATIVE_MUL_ADD_LOWER) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MUL_ADD_LOWER
+#undef HWY_NATIVE_MUL_ADD_LOWER
+#else
+#define HWY_NATIVE_MUL_ADD_LOWER
+#endif
+
+template <class V>
+HWY_API V MulAddLower(const V a, const V b, const V c) {
+  const DFromV<V> d;
+  const MFromD<DFromV<V>> LowerMask = FirstN(d, 1);
+  return IfThenElse(LowerMask, MulAdd(a, b, c), a);
+}
+
+#endif  // HWY_NATIVE_MUL_ADD_LOWER
 
 // ------------------------------ Integer MulSub / NegMulSub
 #if (defined(HWY_NATIVE_INT_FMSUB) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -577,22 +577,6 @@ HWY_API V AddSub(V a, V b) {
   return Add(a, negated_even_b);
 }
 
-#if (defined(HWY_NATIVE_MUL_LOWER) == defined(HWY_TARGET_TOGGLE))
-#ifdef HWY_NATIVE_MUL_LOWER
-#undef HWY_NATIVE_MUL_LOWER
-#else
-#define HWY_NATIVE_MUL_LOWER
-#endif
-
-template <class V>
-HWY_API V MulLower(V a, V b) {
-  const DFromV<V> d;
-  const auto first_mask = FirstN(d, 1);
-  return MaskedMulOr(a, first_mask, a, b);
-}
-
-#endif  // HWY_NATIVE_MUL_LOWER
-
 // ------------------------------ MaskedAddOr etc.
 #if (defined(HWY_NATIVE_MASKED_ARITH) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_MASKED_ARITH
@@ -4405,22 +4389,20 @@ HWY_API V MulSub(V mul, V x, V sub) {
 }
 #endif  // HWY_NATIVE_INT_FMA
 
-// ------------------------------ MulAddLower
-#if (defined(HWY_NATIVE_MUL_ADD_LOWER) == defined(HWY_TARGET_TOGGLE))
-#ifdef HWY_NATIVE_MUL_ADD_LOWER
-#undef HWY_NATIVE_MUL_ADD_LOWER
+// ------------------------------ MaskedMulAddOr
+#if (defined(HWY_NATIVE_MASKED_INT_FMA) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MASKED_INT_FMA
+#undef HWY_NATIVE_MASKED_INT_FMA
 #else
-#define HWY_NATIVE_MUL_ADD_LOWER
+#define HWY_NATIVE_MASKED_INT_FMA
 #endif
 
-template <class V>
-HWY_API V MulAddLower(const V a, const V b, const V c) {
-  const DFromV<V> d;
-  const MFromD<DFromV<V>> LowerMask = FirstN(d, 1);
-  return IfThenElse(LowerMask, MulAdd(a, b, c), a);
+template <class V, class M>
+HWY_API V MaskedMulAddOr(V no, M m, V mul, V x, V add) {
+  return IfThenElse(m, MulAdd(mul, x, add), no);
 }
 
-#endif  // HWY_NATIVE_MUL_ADD_LOWER
+#endif  // HWY_NATIVE_MASKED_INT_FMA
 
 // ------------------------------ Integer MulSub / NegMulSub
 #if (defined(HWY_NATIVE_INT_FMSUB) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -379,6 +379,66 @@ HWY_NOINLINE void TestAllFloatExceptions() {
   ForFloatTypes(ForPartialVectors<TestFloatExceptions>());
 }
 
+struct TestMulLower {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const auto v0 = Zero(d);
+
+    HWY_ASSERT_VEC_EQ(d, v0, MulLower(v0, v0));
+
+    const auto v2 = Iota(d, 2);
+    const auto v3 = Iota(d, 3);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+
+    for (size_t i = 0; i < N; ++i) {
+      if (i == 0) {
+        expected[i] = ConvertScalarTo<T>(2 * 3);
+      } else {
+        expected[i] = ConvertScalarTo<T>(i + 2);
+      }
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulLower(v2, v3));
+  }
+};
+
+HWY_NOINLINE void TestAllMulLower() {
+  ForAllTypes(ForPartialVectors<TestMulLower>());
+}
+
+struct TestMulAddLower {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> v0 = Zero(d);
+
+    // Test all zeros
+    HWY_ASSERT_VEC_EQ(d, v0, MulAddLower(v0, v0, v0));
+
+    // Test upper lanes of a being passed through
+    const Vec<D> v1 = Iota(d, 1);
+    const Vec<D> v2 = Iota(d, 2);
+    const Vec<D> v3 = Iota(d, 3);
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+
+    for (size_t i = 0; i < N; ++i) {
+      if (i == 0) {
+        expected[i] = ConvertScalarTo<T>(5);
+      } else {
+        expected[i] = static_cast<T>(i + 1);
+      }
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MulAddLower(v1, v2, v3));
+  }
+};
+
+HWY_NOINLINE void TestAllTestMulAddLower() {
+  ForAllTypes(ForPartialVectors<TestMulAddLower>());
+}
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -394,6 +454,8 @@ HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSub);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivMod);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllFloatExceptions);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMulLower);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllTestMulAddLower);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/masked_arithmetic_test.cc
+++ b/hwy/tests/masked_arithmetic_test.cc
@@ -379,65 +379,54 @@ HWY_NOINLINE void TestAllFloatExceptions() {
   ForFloatTypes(ForPartialVectors<TestFloatExceptions>());
 }
 
-struct TestMulLower {
+struct TestMaskedMulAdd {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
-    const auto v0 = Zero(d);
+    RandomState rng;
+    const Vec<D> k0 = Zero(d);
+    const Vec<D> v1 = Iota(d, 1);
+    const Vec<D> v2 = Iota(d, 2);
 
-    HWY_ASSERT_VEC_EQ(d, v0, MulLower(v0, v0));
-
-    const auto v2 = Iota(d, 2);
-    const auto v3 = Iota(d, 3);
-
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    using VI = Vec<decltype(di)>;
     const size_t N = Lanes(d);
+    auto bool_lanes = AllocateAligned<TI>(N);
     auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(bool_lanes && expected);
+    HWY_ASSERT_VEC_EQ(d, k0, MaskedMulAddOr(v1, MaskTrue(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOr(v1, MaskTrue(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaskedMulAddOr(v1, MaskTrue(d), v1, k0, v2));
+    HWY_ASSERT_VEC_EQ(d, v1, MaskedMulAddOr(v1, MaskFalse(d), k0, k0, k0));
+    HWY_ASSERT_VEC_EQ(d, v1, MaskedMulAddOr(v1, MaskFalse(d), k0, v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v1, MaskedMulAddOr(v1, MaskFalse(d), v1, k0, v2));
 
     for (size_t i = 0; i < N; ++i) {
-      if (i == 0) {
-        expected[i] = ConvertScalarTo<T>(2 * 3);
+      bool_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+      if (bool_lanes[i]) {
+        expected[i] = ConvertScalarTo<T>((i + 1) * (i + 2));
+      } else {
+        expected[i] = ConvertScalarTo<T>(i + 1);
+      }
+    }
+    const VI mask_i = Load(di, bool_lanes.get());
+    const Mask<D> mask = RebindMask(d, Gt(mask_i, Zero(di)));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOr(v1, mask, v2, v1, k0));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOr(v1, mask, v1, v2, k0));
+
+    for (size_t i = 0; i < N; ++i) {
+      if (bool_lanes[i]) {
+        expected[i] = ConvertScalarTo<T>((i + 2) * (i + 2) + (i + 1));
       } else {
         expected[i] = ConvertScalarTo<T>(i + 2);
       }
     }
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulLower(v2, v3));
+    HWY_ASSERT_VEC_EQ(d, expected.get(), MaskedMulAddOr(v2, mask, v2, v2, v1));
   }
 };
 
-HWY_NOINLINE void TestAllMulLower() {
-  ForAllTypes(ForPartialVectors<TestMulLower>());
-}
-
-struct TestMulAddLower {
-  template <typename T, class D>
-  HWY_NOINLINE void operator()(T /*unused*/, D d) {
-    const Vec<D> v0 = Zero(d);
-
-    // Test all zeros
-    HWY_ASSERT_VEC_EQ(d, v0, MulAddLower(v0, v0, v0));
-
-    // Test upper lanes of a being passed through
-    const Vec<D> v1 = Iota(d, 1);
-    const Vec<D> v2 = Iota(d, 2);
-    const Vec<D> v3 = Iota(d, 3);
-
-    const size_t N = Lanes(d);
-    auto expected = AllocateAligned<T>(N);
-
-    for (size_t i = 0; i < N; ++i) {
-      if (i == 0) {
-        expected[i] = ConvertScalarTo<T>(5);
-      } else {
-        expected[i] = static_cast<T>(i + 1);
-      }
-    }
-
-    HWY_ASSERT_VEC_EQ(d, expected.get(), MulAddLower(v1, v2, v3));
-  }
-};
-
-HWY_NOINLINE void TestAllTestMulAddLower() {
-  ForAllTypes(ForPartialVectors<TestMulAddLower>());
+HWY_NOINLINE void TestAllMaskedMulAdd() {
+  ForAllTypes(ForPartialVectors<TestMaskedMulAdd>());
 }
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -454,8 +443,7 @@ HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllSatAddSub);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllDiv);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllIntegerDivMod);
 HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllFloatExceptions);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMulLower);
-HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllTestMulAddLower);
+HWY_EXPORT_AND_TEST_P(HwyMaskedArithmeticTest, TestAllMaskedMulAdd);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/tests/mul_test.cc
+++ b/hwy/tests/mul_test.cc
@@ -424,6 +424,33 @@ HWY_NOINLINE void TestAllMulOdd() {
   // uint64_t MulOdd is already tested in TestMulEvenOdd64
 }
 
+struct TestMulRound {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> v0 = Zero(d);
+
+    // Test that we correctly get all zeros
+    HWY_ASSERT_VEC_EQ(d, v0, MulRound(v0, v0));
+
+    // Test that we round to closest even in case of tie
+    const Vec<D> v_half = Set(d, ConvertScalarTo<T>(0.5f));
+    const Vec<D> v_1 = Set(d, ConvertScalarTo<T>(1));
+
+    HWY_ASSERT_VEC_EQ(d, v0, MulRound(v_half, v_1));
+
+    // Test arbitrary multiplication
+    const Vec<D> v_2 = Set(d, ConvertScalarTo<T>(6.75));
+    const Vec<D> v_3 = Set(d, ConvertScalarTo<T>(3.33));
+    const Vec<D> expected = Set(d, ConvertScalarTo<T>(22));
+
+    HWY_ASSERT_VEC_EQ(d, expected, MulRound(v_2, v_3));
+  }
+};
+
+HWY_NOINLINE void TestAllMulRound() {
+  ForFloatTypes(ForPartialVectors<TestMulRound>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -439,6 +466,7 @@ HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulHigh);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulFixedPoint15);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulEven);
 HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulOdd);
+HWY_EXPORT_AND_TEST_P(HwyMulTest, TestAllMulRound);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
Adding special multiply operations for `arm_sve-inl.h` and `generic_ops-inl.h`: 
- MulRound multiplies two vectors of floats and returns the answer rounded to the nearest integer
- MulLower multiplies the first lane of both input vectors and passes the lanes of vector a for all other lanes.
- MulAddLower performs a multiply-accumulate operation on the first lane of the input vectors and passes the lanes of vector a for all other lanes.

Tests have been added for the operations.