### PR TITLE
Added PositiveInfOrHighestValue and NegativeInfOrLowestValue

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -2414,6 +2414,45 @@ constexpr MakeSigned<T> MaxExponentField() {
   return (MakeSigned<T>{1} << ExponentBits<T>()) - 1;
 }
 
+namespace detail {
+
+template <typename T>
+static HWY_INLINE HWY_MAYBE_UNUSED HWY_BITCASTSCALAR_CONSTEXPR T
+NegativeInfOrLowestValue(hwy::FloatTag /* tag */) {
+  return BitCastScalar<T>(
+      static_cast<MakeUnsigned<T>>(SignMask<T>() | ExponentMask<T>()));
+}
+
+template <typename T>
+static HWY_INLINE HWY_MAYBE_UNUSED HWY_BITCASTSCALAR_CONSTEXPR T
+NegativeInfOrLowestValue(hwy::NonFloatTag /* tag */) {
+  return LowestValue<T>();
+}
+
+template <typename T>
+static HWY_INLINE HWY_MAYBE_UNUSED HWY_BITCASTSCALAR_CONSTEXPR T
+PositiveInfOrHighestValue(hwy::FloatTag /* tag */) {
+  return BitCastScalar<T>(ExponentMask<T>());
+}
+
+template <typename T>
+static HWY_INLINE HWY_MAYBE_UNUSED HWY_BITCASTSCALAR_CONSTEXPR T
+PositiveInfOrHighestValue(hwy::NonFloatTag /* tag */) {
+  return HighestValue<T>();
+}
+
+}  // namespace detail
+
+template <typename T>
+HWY_API HWY_BITCASTSCALAR_CONSTEXPR T NegativeInfOrLowestValue() {
+  return detail::NegativeInfOrLowestValue<T>(IsFloatTag<T>());
+}
+
+template <typename T>
+HWY_API HWY_BITCASTSCALAR_CONSTEXPR T PositiveInfOrHighestValue() {
+  return detail::PositiveInfOrHighestValue<T>(IsFloatTag<T>());
+}
+
 //------------------------------------------------------------------------------
 // Additional F16/BF16 operators
 

--- a/hwy/base_test.cc
+++ b/hwy/base_test.cc
@@ -101,6 +101,22 @@ struct TestLowestHighest {
     if (!IsSpecialFloat<T>()) {
       HWY_ASSERT_EQ(std::numeric_limits<T>::lowest(), LowestValue<T>());
       HWY_ASSERT_EQ(std::numeric_limits<T>::max(), HighestValue<T>());
+
+      if (IsFloat<T>()) {
+        HWY_ASSERT(ScalarSignBit(NegativeInfOrLowestValue<T>()));
+        HWY_ASSERT(!ScalarIsFinite(NegativeInfOrLowestValue<T>()));
+        HWY_ASSERT(!ScalarSignBit(PositiveInfOrHighestValue<T>()));
+        HWY_ASSERT(!ScalarIsFinite(PositiveInfOrHighestValue<T>()));
+        HWY_ASSERT(NegativeInfOrLowestValue<T>() <
+                   std::numeric_limits<T>::lowest());
+        HWY_ASSERT(PositiveInfOrHighestValue<T>() >
+                   std::numeric_limits<T>::max());
+      } else {
+        HWY_ASSERT_EQ(std::numeric_limits<T>::lowest(),
+                      NegativeInfOrLowestValue<T>());
+        HWY_ASSERT_EQ(std::numeric_limits<T>::max(),
+                      PositiveInfOrHighestValue<T>());
+      }
     }
   }
 };

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -2917,29 +2917,9 @@ HWY_API T ReduceSum(D d, VFromD<D> v) {
   return sum;
 }
 
-namespace detail {
-template <class D, typename T = TFromD<D>, HWY_IF_FLOAT_OR_SPECIAL(T)>
-T InitReduceMin(D d) {
-  return GetLane(Inf(d));
-}
-template <class D, typename T = TFromD<D>, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
-T InitReduceMin(D d) {
-  return HighestValue<T>();
-}
-
-template <class D, typename T = TFromD<D>, HWY_IF_FLOAT_OR_SPECIAL(T)>
-T InitReduceMax(D d) {
-  return -GetLane(Inf(d));
-}
-template <class D, typename T = TFromD<D>, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
-T InitReduceMax(D d) {
-  return LowestValue<T>();
-}
-}  // namespace detail
-
 template <class D, typename T = TFromD<D>, HWY_IF_REDUCE_D(D)>
 HWY_API T ReduceMin(D d, VFromD<D> v) {
-  T min = detail::InitReduceMin(d);
+  T min = PositiveInfOrHighestValue<T>();
   for (size_t i = 0; i < MaxLanes(d); ++i) {
     min = HWY_MIN(min, v.raw[i]);
   }
@@ -2947,7 +2927,7 @@ HWY_API T ReduceMin(D d, VFromD<D> v) {
 }
 template <class D, typename T = TFromD<D>, HWY_IF_REDUCE_D(D)>
 HWY_API T ReduceMax(D d, VFromD<D> v) {
-  T max = detail::InitReduceMax(d);
+  T max = NegativeInfOrLowestValue<T>();
   for (size_t i = 0; i < MaxLanes(d); ++i) {
     max = HWY_MAX(max, v.raw[i]);
   }


### PR DESCRIPTION
Added `hwy::PositiveInfOrHighestValue<T>()`, which returns positive infinity if `T` is a floating point type or `hwy::HighestValue<T>()` if `T` is an integer type.

Also added `hwy::NegativeInfOrLowestValue<T>()` which returns negative infinity if `T` is a floating point type or `hwy::HighestValue<T>()` if `T` is an integer type.

Also updated EMU128 ReduceMin/ReduceMax to use `hwy::PositiveInfOrHighestValue<T>()` and `hwy::NegativeInfOrLowestValue<T>()`.