### PR TITLE
Fix for compiler error with GCC 9 or earlier

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -129,7 +129,7 @@
 #define HWY_NORETURN __attribute__((noreturn))
 #define HWY_LIKELY(expr) __builtin_expect(!!(expr), 1)
 #define HWY_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
-#if HWY_COMPILER_GCC || __has_builtin(__builtin_unreachable)
+#if HWY_COMPILER_GCC || HWY_HAS_BUILTIN(__builtin_unreachable)
 #define HWY_UNREACHABLE __builtin_unreachable()
 #else
 #define HWY_UNREACHABLE


### PR DESCRIPTION
Replaced `__has_builtin(__builtin_unreachable)` with `HWY_HAS_BUILTIN(__builtin_unreachable)` in hwy/base.h to fix a compiler error with GCC 9 or earlier as `__has_builtin` is not available with GCC 9 or earlier.