### PR TITLE
Optimise LoadMaskBits for uint8_t on SVE

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4872,6 +4872,9 @@ HWY_API V AverageRound(const V a, const V b) {
 // `p` points to at least 8 readable bytes, not all of which need be valid.
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
+#if HWY_COMPILER_CLANG || HWY_COMPILER_GCC
+  return *(const svbool_t *)bits;
+#endif
   // TODO(janwas): with SVE2.1, load to vector, then PMOV
   const RebindToUnsigned<D> du;
   const svuint8_t iota = Iota(du, 0);

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4872,8 +4872,7 @@ HWY_API V AverageRound(const V a, const V b) {
 // `p` points to at least 8 readable bytes, not all of which need be valid.
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
-#if (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1901) || \
-    (HWY_COMPILER_GCC && HWY_COMPILER_GCC_ACTUAL >= 1200)
+#if HWY_COMPILER_CLANG >= 1901 || HWY_COMPILER_GCC_ACTUAL >= 1200
   return *(const svbool_t*)bits;
 #endif
   // TODO(janwas): with SVE2.1, load to vector, then PMOV

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4874,7 +4874,7 @@ template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
 #if HWY_COMPILER_CLANG >= 1901 || HWY_COMPILER_GCC_ACTUAL >= 1200
   return *(const svbool_t*)bits;
-#endif
+#else
   // TODO(janwas): with SVE2.1, load to vector, then PMOV
   const RebindToUnsigned<D> du;
   const svuint8_t iota = Iota(du, 0);
@@ -4887,6 +4887,7 @@ HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
   const svuint8_t bit =
       svdupq_n_u8(1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128);
   return TestBit(rep8, bit);
+#endif
 }
 
 template <class D, HWY_IF_T_SIZE_D(D, 2)>

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4873,6 +4873,7 @@ HWY_API V AverageRound(const V a, const V b) {
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
 #if HWY_COMPILER_CLANG >= 1901 || HWY_COMPILER_GCC_ACTUAL >= 1200
+  (void)d;
   return *(const svbool_t*)bits;
 #else
   // TODO(janwas): with SVE2.1, load to vector, then PMOV

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4872,8 +4872,9 @@ HWY_API V AverageRound(const V a, const V b) {
 // `p` points to at least 8 readable bytes, not all of which need be valid.
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
-#if HWY_COMPILER_CLANG || HWY_COMPILER_GCC
-  return *(const svbool_t *)bits;
+#if (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1901) || \
+    (HWY_COMPILER_GCC && HWY_COMPILER_GCC_ACTUAL >= 1200)
+  return *(const svbool_t*)bits;
 #endif
   // TODO(janwas): with SVE2.1, load to vector, then PMOV
   const RebindToUnsigned<D> du;


### PR DESCRIPTION
SVE can load a uint8_t pointer directly into a mask through casting.

This technique is used by Arm and is known to work for GCC and Clang.
See https://gitlab.arm.com/networking/ral/-/blob/7ea3a5f7a03e7a3dd1fecd898db9802d4cd36e89/src/intrinsics.h#L422