### PR TITLE
Fix compilation on ppc64le and s390x with gcc-12

### DIFF
--- a/hwy/contrib/thread_pool/spin.h
+++ b/hwy/contrib/thread_pool/spin.h
@@ -158,6 +158,8 @@ static HWY_INLINE uint32_t SpinUntilDifferent(SpinMode mode,
     case SpinMode::kPause:
       return Spin_Pause(prev, current, reps);
   }
+
+  return 0;
 }
 
 }  // namespace hwy

--- a/hwy/contrib/thread_pool/spin_test.cc
+++ b/hwy/contrib/thread_pool/spin_test.cc
@@ -59,7 +59,7 @@ TEST(SpinTest, TestPingPong) {
   pool.Run(0, 2, [&](uint64_t task, size_t thread) {
     HWY_ASSERT(task == thread);
     if (task == 0) {  // new thread
-      size_t my_reps;
+      size_t my_reps = 0;
       (void)SpinUntilDifferent(mode, 0, thread_active[0], my_reps);
       reps1.store(my_reps);
       if (!NanoSleep(20 * 1000 * 1000)) {
@@ -73,7 +73,7 @@ TEST(SpinTest, TestPingPong) {
       // Release the thread.
       thread_active[0].store(1, std::memory_order_release);
       // Wait for it to finish.
-      size_t my_reps;
+      size_t my_reps = 0;
       (void)SpinUntilDifferent(mode, 0, thread_done[0], my_reps);
       reps2.store(my_reps);
     }


### PR DESCRIPTION
Currently getting the following errors on a native machine with gcc-12 after [this PR](https://github.com/google/highway/pull/2471/files): 
```
spin.h:162:1: error: control reaches end of non-void function [-Werror=return-type]
  162 | }

error: ‘my_reps’ may be used uninitialized [-Werror=maybe-uninitialized]
spin_test.cc:76:14: note: ‘my_reps’ was declared here
spin_test.cc:76:14: note: ‘my_reps’ was declared here
```
