### PR TITLE
Made enhancements to AverageRound

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -5245,8 +5245,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGPVV, AverageRound, rhadd)
 #else
 template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
 HWY_API V AverageRound(const V a, const V b) {
-  return Add(Add(ShiftRight<1>(a), ShiftRight<1>(b)),
-             detail::AndN(Or(a, b), 1));
+  return Sub(Or(a, b), ShiftRight<1>(Xor(a, b)));
 }
 #endif  // HWY_SVE_HAVE_2
 

--- a/hwy/ops/emu128-inl.h
+++ b/hwy/ops/emu128-inl.h
@@ -685,8 +685,7 @@ HWY_API Vec128<T, N> AverageRound(Vec128<T, N> a, Vec128<T, N> b) {
   for (size_t i = 0; i < N; ++i) {
     const T a_val = a.raw[i];
     const T b_val = b.raw[i];
-    a.raw[i] = static_cast<T>(ScalarShr(a_val, 1) + ScalarShr(b_val, 1) +
-                              ((a_val | b_val) & 1));
+    a.raw[i] = static_cast<T>((a_val | b_val) - ScalarShr(a_val ^ b_val, 1));
   }
   return a;
 }

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -5336,10 +5336,7 @@ HWY_API Vec512<T> operator%(Vec512<T> a, Vec512<T> b) {
 
 template <class V, HWY_IF_UI32(TFromV<V>)>
 HWY_API V AverageRound(V a, V b) {
-  using T = TFromV<V>;
-  const DFromV<decltype(a)> d;
-  return Add(Add(ShiftRight<1>(a), ShiftRight<1>(b)),
-             And(Or(a, b), Set(d, T{1})));
+  return Sub(Or(a, b), ShiftRight<1>(Xor(a, b)));
 }
 
 #endif  // HWY_NATIVE_AVERAGE_ROUND_UI64
@@ -5354,10 +5351,7 @@ HWY_API V AverageRound(V a, V b) {
 #if HWY_HAVE_INTEGER64
 template <class V, HWY_IF_UI64(TFromV<V>)>
 HWY_API V AverageRound(V a, V b) {
-  using T = TFromV<V>;
-  const DFromV<decltype(a)> d;
-  return Add(Add(ShiftRight<1>(a), ShiftRight<1>(b)),
-             And(Or(a, b), Set(d, T{1})));
+  return Sub(Or(a, b), ShiftRight<1>(Xor(a, b)));
 }
 #endif
 

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -626,8 +626,7 @@ template <class T, HWY_IF_NOT_FLOAT_NOR_SPECIAL(T)>
 HWY_API Vec1<T> AverageRound(const Vec1<T> a, const Vec1<T> b) {
   const T a_val = a.raw;
   const T b_val = b.raw;
-  return Vec1<T>(static_cast<T>(ScalarShr(a_val, 1) + ScalarShr(b_val, 1) +
-                                ((a_val | b_val) & 1)));
+  return Vec1<T>(static_cast<T>((a_val | b_val) - ScalarShr(a_val ^ b_val, 1)));
 }
 
 // ------------------------------ Absolute value


### PR DESCRIPTION
Updated AverageRound op to use `(a[i] | b[i]) - ((a[i] ^ b[i]) >> 1)` as `(a[i] >> 1) + (b[i] >> 1) + ((a[i] | b[i]) & 1)`  is equal to `(a[i] | b[i]) - ((a[i] ^ b[i]) >> 1)` for all values of `a[i]` and `b[i]` and as  `(a[i] | b[i]) - ((a[i] ^ b[i]) >> 1)` is usually more efficient than `(a[i] >> 1) + (b[i] >> 1) + ((a[i] | b[i]) & 1)`.

Clang 19 also optimizes `(a[i] | b[i]) - ((a[i] ^ b[i]) >> 1)` for I8/U8/I16/U16/I32/U32 vectors down to a SRHADD/URHADD instruction (which is equivalent to AverageRound) on AArch64 when optimizations are enabled according to a Compiler Explorer snippet over at https://godbolt.org/z/eo9T6TaYd.