### PR TITLE
Fix C++23-only attribute warning for HWY_ASSUME

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -228,7 +228,7 @@ namespace hwy {
 // Better:
 //   HWY_ASSUME(x == 2);
 //   HWY_ASSUME(y == 3);
-#if HWY_HAS_CPP_ATTRIBUTE(assume)
+#if (HWY_CXX_LANG >= 202302L) && HWY_HAS_CPP_ATTRIBUTE(assume)
 #define HWY_ASSUME(expr) [[assume(expr)]]
 #elif HWY_COMPILER_MSVC || HWY_COMPILER_ICC
 #define HWY_ASSUME(expr) __assume(expr)


### PR DESCRIPTION
clang with `-Wpedantic` issues a `-Wc++23-attribute-extensions` warning in the strict C++ <=20 mode.