### PR TITLE
Allow EMU128 target on LoongArch

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -688,10 +688,10 @@
 // Choose targets for dynamic dispatch according to one of four policies
 
 // TODO: remove once HWY_LSX is actually supported
-#if HWY_ARCH_LOONGARCH
+#if HWY_ARCH_LOONGARCH && !defined(HWY_COMPILE_ONLY_SCALAR) && \
+    !defined(HWY_COMPILE_ONLY_EMU128)
 #undef HWY_COMPILE_ONLY_STATIC
-#undef HWY_COMPILE_ONLY_EMU128
-#define HWY_COMPILE_ONLY_SCALAR
+#define HWY_COMPILE_ONLY_EMU128
 #endif
 
 #if 1 < (defined(HWY_COMPILE_ONLY_SCALAR) + defined(HWY_COMPILE_ONLY_EMU128) + \


### PR DESCRIPTION
Updated detect_targets.h to allow the EMU128 target to be used on LoongArch if HWY_COMPILE_ONLY_SCALAR is not defined.