### PR TITLE
Fixes for compiler warnings in thread_pool.h

### DIFF
--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -1040,7 +1040,7 @@ class alignas(HWY_ALIGNMENT) ThreadPool {
 
     SetBusy();
 
-    const auto closure = [this, copy](uint64_t task, size_t worker) {
+    const auto closure = [this, copy](HWY_MAYBE_UNUSED uint64_t task, size_t worker) {
       HWY_DASSERT(task == worker);  // one task per worker
       workers_[worker].LatchConfig(copy);
     };

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -1040,7 +1040,8 @@ class alignas(HWY_ALIGNMENT) ThreadPool {
 
     SetBusy();
 
-    const auto closure = [this, copy](HWY_MAYBE_UNUSED uint64_t task, size_t worker) {
+    const auto closure = [this, copy](uint64_t task, size_t worker) {
+      (void)task;
       HWY_DASSERT(task == worker);  // one task per worker
       workers_[worker].LatchConfig(copy);
     };

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -191,7 +191,7 @@ class Config {  // 8 bytes
   WaitType wait_type;
   BarrierType barrier_type;
   bool exit;
-  HWY_MAYBE_UNUSED uint32_t reserved = 0;
+  uint32_t reserved = 0;
 
  private:
   // Prevents inlining DetectSpin() into the ctor.
@@ -307,7 +307,14 @@ class alignas(HWY_ALIGNMENT) Worker {  // HWY_ALIGNMENT bytes
   const size_t num_threads_;
   Worker* const workers_;
 
-  HWY_MAYBE_UNUSED uint8_t padding_[HWY_ALIGNMENT - 64 - sizeof(victims_)];
+#if HWY_COMPILER_CLANG
+  HWY_DIAGNOSTICS(push)
+  HWY_DIAGNOSTICS_OFF(disable : 4700, ignored "-Wunused-private-field")
+#endif
+  uint8_t padding_[HWY_ALIGNMENT - 64 - sizeof(victims_)];
+#if HWY_COMPILER_CLANG
+  HWY_DIAGNOSTICS(pop)
+#endif
 };
 static_assert(sizeof(Worker) == HWY_ALIGNMENT, "");
 

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -214,6 +214,8 @@ class alignas(HWY_ALIGNMENT) Worker {  // HWY_ALIGNMENT bytes
   Worker(const size_t worker, const size_t num_threads,
          const Divisor64& div_workers)
       : worker_(worker), num_threads_(num_threads), workers_(this - worker) {
+    (void)padding_;
+
     HWY_DASSERT(IsAligned(this, HWY_ALIGNMENT));
     HWY_DASSERT(worker <= num_threads);
     const size_t num_workers = static_cast<size_t>(div_workers.GetDivisor());
@@ -307,14 +309,7 @@ class alignas(HWY_ALIGNMENT) Worker {  // HWY_ALIGNMENT bytes
   const size_t num_threads_;
   Worker* const workers_;
 
-#if HWY_COMPILER_CLANG
-  HWY_DIAGNOSTICS(push)
-  HWY_DIAGNOSTICS_OFF(disable : 4700, ignored "-Wunused-private-field")
-#endif
   uint8_t padding_[HWY_ALIGNMENT - 64 - sizeof(victims_)];
-#if HWY_COMPILER_CLANG
-  HWY_DIAGNOSTICS(pop)
-#endif
 };
 static_assert(sizeof(Worker) == HWY_ALIGNMENT, "");
 

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -216,7 +216,7 @@ class alignas(HWY_ALIGNMENT) Worker {  // HWY_ALIGNMENT bytes
       : worker_(worker), num_threads_(num_threads), workers_(this - worker) {
     HWY_DASSERT(IsAligned(this, HWY_ALIGNMENT));
     HWY_DASSERT(worker <= num_threads);
-    const size_t num_workers = div_workers.GetDivisor();
+    const size_t num_workers = static_cast<size_t>(div_workers.GetDivisor());
     num_victims_ = static_cast<uint32_t>(HWY_MIN(kMaxVictims, num_workers));
 
     // Increase gap between coprimes to reduce collisions.
@@ -377,7 +377,7 @@ class alignas(8) Tasks {
   static void DivideRangeAmongWorkers(const uint64_t begin, const uint64_t end,
                                       const Divisor64& div_workers,
                                       Worker* workers) {
-    const size_t num_workers = div_workers.GetDivisor();
+    const size_t num_workers = static_cast<size_t>(div_workers.GetDivisor());
     HWY_DASSERT(num_workers > 1);  // Else Run() runs on the main thread.
     HWY_DASSERT(begin <= end);
     const size_t num_tasks = static_cast<size_t>(end - begin);
@@ -385,8 +385,9 @@ class alignas(8) Tasks {
     // Assigning all remainders to the last worker causes imbalance. We instead
     // give one more to each worker whose index is less. This may be zero when
     // called from `TestTasks`.
-    const size_t min_tasks = div_workers.Divide(num_tasks);
-    const size_t remainder = div_workers.Remainder(num_tasks);
+    const size_t min_tasks = static_cast<size_t>(div_workers.Divide(num_tasks));
+    const size_t remainder =
+        static_cast<size_t>(div_workers.Remainder(num_tasks));
 
     uint64_t my_begin = begin;
     for (size_t worker = 0; worker < num_workers; ++worker) {


### PR DESCRIPTION
Fixes compiler warning with Clang in ThreadPool::SendConfig as the task parameter in the closure lambda is unused in debug builds.