### PR TITLE
Added workaround for compiler warning in SVE I8/U8 LoadMaskBits

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -5255,8 +5255,10 @@ HWY_API V AverageRound(const V a, const V b) {
 template <class D, HWY_IF_T_SIZE_D(D, 1)>
 HWY_INLINE svbool_t LoadMaskBits(D d, const uint8_t* HWY_RESTRICT bits) {
 #if HWY_COMPILER_CLANG >= 1901 || HWY_COMPILER_GCC_ACTUAL >= 1200
+  typedef svbool_t UnalignedSveMaskT
+      __attribute__((__aligned__(1), __may_alias__));
   (void)d;
-  return *(const svbool_t*)bits;
+  return *reinterpret_cast<const UnalignedSveMaskT*>(bits);
 #else
   // TODO(janwas): with SVE2.1, load to vector, then PMOV
   const RebindToUnsigned<D> du;


### PR DESCRIPTION
Updated SVE I8/U8 LoadMaskBits to cast `bits` to `UnalignedSveMaskT` (which is a typedef of `svbool_t` with the `__aligned__(1)` and `__may_alias__` attributes) using `reinterpret_cast` to work around GCC/Clang compiler warnings.

`*reinterpret_cast<const UnalignedSveMaskT*>(bits)` also assumes that either `Lanes(ScalableTag<uint8_t>()) <= 64` or `Lanes(d) == Lanes(ScalableTag<uint8_t>())` is true, and it is possible for `Lanes(ScalableTag<uint8_t>()) > 64` to be true on the HWY_SVE/HWY_SVE2 targets.

Should an opt-out or opt-in be added for the optimized `*reinterpret_cast<const UnalignedSveMaskT*>(bits)` code path to avoid a crash or undefined behavior in the case where `Lanes(ScalableTag<uint8_t>()) > 64 && Lanes(ScalableTag<uint8_t>()) < Lanes(d)` as `LoadMaskBits(d)` does not expect that any bytes past `bits + 8` be dereferenceable if `Lanes(d) <= 64`?