### PR TITLE
Build profiler_example only if HWY_ENABLE_CONTRIB is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,6 +714,7 @@ set_target_properties(hwy_benchmark
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
 
 # Profiler demo
+if (HWY_ENABLE_CONTRIB)
 add_executable(hwy_profiler_example hwy/examples/profiler_example.cc)
 target_sources(hwy_profiler_example PRIVATE
     hwy/profiler.h)
@@ -723,6 +724,7 @@ target_link_libraries(hwy_profiler_example PRIVATE hwy hwy_contrib)
 target_link_libraries(hwy_profiler_example PRIVATE ${ATOMICS_LIBRARIES})
 set_target_properties(hwy_profiler_example
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
+endif()  # HWY_ENABLE_CONTRIB
 
 endif()  # HWY_ENABLE_EXAMPLES
 # -------------------------------------------------------- Tests


### PR DESCRIPTION
As the profiler example depends on contrib (see issue #2570, commit db1facc), it should only be built if the contrib target is enabled (i.e. if `HWY_ENABLE_CONTRIB` is set to `ON`). Otherwise, Make will fail with a linker error when `HWY_ENABLE_EXAMPLES=ON` and `HWY_ENABLE_CONTRIB=OFF`.