### PR TITLE
Made fixes and enhancements to LSX/LASX targets

### DIFF
--- a/hwy/ops/shared-inl.h
+++ b/hwy/ops/shared-inl.h
@@ -703,7 +703,7 @@ HWY_API bool IsAligned(D d, T* ptr) {
 // HWY_IF_U2I_DEMOTE_FROM_LANE_SIZE_V is used to disable the default
 // implementation of unsigned to signed DemoteTo/ReorderDemote2To in
 // generic_ops-inl.h for at least some of the unsigned to signed demotions on
-// SCALAR/EMU128/SSE2/SSSE3/SSE4/AVX2/SVE/SVE2
+// SCALAR/EMU128/SSE2/SSSE3/SSE4/AVX2/SVE/SVE2/LSX/LASX
 
 #undef HWY_IF_U2I_DEMOTE_FROM_LANE_SIZE_V
 #define HWY_IF_U2I_DEMOTE_FROM_LANE_SIZE_V(V) void* = nullptr


### PR DESCRIPTION
Made the following fixes and enhancements to LSX/LASX targets:
- Added platform-specific F16->F32 PromoteTo and F32->F16 DemoteTo on LSX and LASX
- Updated DemoteTo/ReorderDemote2To implementations for I->I, I->U, U->I, and U->U demotions on LSX and LASX
- Updated implementation of SetAtOrAfterFirst and SetOnlyFirst for 16-byte and 32-byte masks on LSX and LASX
- Updated detail::Iota0 and Dup128VecFromValues to use GCC/Clang vector constants instead of loading from a constant array
- Replaced binary literals in loongarch_lsx-inl.h with their equivalent hexadecimal literals
- Updated LSX and LASX implementation of InsertLane to use detail::InsertLaneUsingBroadcastAndBlend if the lane index is not a constant
- Updated implementation of TrailingZeroCount on LSX and LASX
- Added platform-specific implementations of integer Div/Mod on LSX and LASX
- Added platform-specific implementations of integer IfNegativeThenNegOrUndefIfZero on LSX and LASX
- Added platform-specific implementation of Ror on LSX
- Added missing platform-specific implementations of I32/U32/I64/U64 SaturatedAdd/SaturatedSub on LASX
- Added missing platform-specific implementations of integer AbsDiff LASX
- Updated Per4LaneBlockShuffle for 32-byte I64/U64/F64 vectors on LASX to use __lasx_xvpermi_d
