### PR TITLE
Fixes for RVV detection and re-enable RVV with Clang 16 or later or GCC 13 or later

### DIFF
--- a/hwy/aligned_allocator.cc
+++ b/hwy/aligned_allocator.cc
@@ -28,7 +28,7 @@ namespace hwy {
 namespace {
 
 #if HWY_ARCH_RISCV && defined(__riscv_v_intrinsic) && \
-    __riscv_v_intrinsic >= 1000000
+    __riscv_v_intrinsic >= 11000
 // Not actually an upper bound on the size, but this value prevents crossing a
 // 4K boundary (relevant on Andes).
 constexpr size_t kAlignment = HWY_MAX(HWY_ALIGNMENT, 4096);

--- a/hwy/base.h
+++ b/hwy/base.h
@@ -476,7 +476,7 @@ HWY_API void ZeroBytes(void* to, size_t num_bytes) {
 #if HWY_ARCH_X86
 static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 64;  // AVX-512
 #elif HWY_ARCH_RISCV && defined(__riscv_v_intrinsic) && \
-    __riscv_v_intrinsic >= 1000000
+    __riscv_v_intrinsic >= 11000
 // Not actually an upper bound on the size.
 static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 4096;
 #else
@@ -492,7 +492,7 @@ static constexpr HWY_MAYBE_UNUSED size_t kMaxVectorSize = 16;
 #if HWY_ARCH_X86
 #define HWY_ALIGN_MAX alignas(64)
 #elif HWY_ARCH_RISCV && defined(__riscv_v_intrinsic) && \
-    __riscv_v_intrinsic >= 1000000
+    __riscv_v_intrinsic >= 11000
 #define HWY_ALIGN_MAX alignas(8)  // only elements need be aligned
 #else
 #define HWY_ALIGN_MAX alignas(16)

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -649,9 +649,13 @@
 #define HWY_BASELINE_AVX10_2 0
 #endif
 
-// Check for RVV 1.0, though 0.11 (11000) already worked.
-#if HWY_ARCH_RISCV && defined(__riscv_v_intrinsic) && \
-    __riscv_v_intrinsic >= 1000000
+// RVV requires intrinsics 0.11 or later, see #1156.
+
+// Also check that the __riscv_v macro is defined as GCC or Clang will define
+// the __risc_v macro if the RISC-V "V" extension is enabled.
+
+#if HWY_ARCH_RISCV && defined(__riscv_v) && defined(__riscv_v_intrinsic) && \
+    __riscv_v_intrinsic >= 11000
 #define HWY_BASELINE_RVV HWY_RVV
 #else
 #define HWY_BASELINE_RVV 0

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -1188,9 +1188,9 @@ HWY_RVV_FOREACH_I(HWY_RVV_RETV_ARGVV, SaturatedSub, ssub, _ALL)
 #if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400
 #define HWY_RVV_AVOID_VXRM
 // Clang 16 with __riscv_v_intrinsic == 11000 may either require VXRM or avoid.
-// Assume earlier versions avoid.
+// Assume that Clang 16 and earlier avoid VXRM.
 #elif HWY_COMPILER_CLANG && \
-    (HWY_COMPILER_CLANG < 1600 || __riscv_v_intrinsic < 1000000)
+    (HWY_COMPILER_CLANG < 1700 || __riscv_v_intrinsic < 11000)
 #define HWY_RVV_AVOID_VXRM
 #endif
 


### PR DESCRIPTION
Fixes issue #2554 by checking that both `__riscv_v` and `__riscv_v_intrinsic` are defined as Clang 20 and later define `__riscv_v_intrinsic`, even when the RISC-V "V" extension is not enabled.

Also undid the changes made in pull request #2561 as the changes made in pull request #2561 still trigger compiler errors with Clang 20 or later on RISC-V if the RISC-V "V" extension is not enabled and Google Highway is not built with "-DHWY_COMPILE_ONLY_EMU128" or "-DHWY_COMPILE_ONLY_SCALAR".

Also updated rvv-inl.h to assume that the VXRM argument should be avoided with Clang 16 or earlier as the latest Clang 16 release from https://github.com/llvm/llvm-project (16.0.6) without any additional patches expects that the VXRM argument be avoided.