### PR TITLE
Fixes to compilation errors with RVV with EMU128 or SCALAR baseline

### DIFF
--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -16,7 +16,20 @@
 // RISC-V V vectors (length not known at compile time).
 // External include guard in highway.h - see comment there.
 
+#pragma push_macro("__riscv_v_elen")
+
+// Workaround that ensures that all of the __riscv_vsetvl_* and
+// __riscv_vsetvlmax_* macros in riscv_vector.h are defined when compiling with
+// Clang 20 with dynamic dispatch and a baseline target of SCALAR or EMU128
+#if HWY_COMPILER_CLANG >= 2000 && HWY_COMPILER_CLANG < 2100 && \
+    (!defined(__riscv_v_elen) || __riscv_v_elen < 64)
+#undef __riscv_v_elen
+#define __riscv_v_elen 64
+#endif
+
 #include <riscv_vector.h>
+
+#pragma pop_macro("__riscv_v_elen")
 
 #include "hwy/ops/shared-inl.h"
 

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -681,7 +681,7 @@
 
 #if HWY_COMPILER_CLANG >= 1900
 // https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#181-zvl-minimum-vector-length-standard-extensions
-#define HWY_TARGET_STR "Zvl128b,Zve64d"
+#define HWY_TARGET_STR "arch=+v"
 #else
 // HWY_TARGET_STR remains undefined so HWY_ATTR is a no-op.
 #endif


### PR DESCRIPTION
The changes made in this pull request and pull request #2586 allow dynamic dispatch to be enabled on RISC-V with Clang 20 or later without the `-march=rv64gcv1p0` option if the `-DHWY_HAVE_RUNTIME_DISPATCH_LINUX=1` is specified.

The changes in this pull request fixes issues raised in issue #2554.

Should runtime dispatch be enabled by default on Linux on RISC-V when compiling with Clang 20 or later once the changes in this pull request and pull request #2586 are merged?