### PR TITLE
Made fix to TestDemoteTo

### DIFF
--- a/hwy/tests/demote_test.cc
+++ b/hwy/tests/demote_test.cc
@@ -53,8 +53,7 @@ struct TestDemoteTo {
     RandomState rng;
     for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
       for (size_t i = 0; i < N; ++i) {
-        const uint64_t bits = rng();
-        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        from[i] = RandomFiniteValue<T>(&rng);
         expected[i] = static_cast<ToT>(HWY_MIN(HWY_MAX(min, from[i]), max));
       }
       const auto in = Load(from_d, from.get());


### PR DESCRIPTION
Updated TestDemoteTo to generate random value using `RandomFiniteValue<T>(&rng)` to fix undefined behavior in TestDemoteTo if `from[i]` is a NaN F64 value.