### PR TITLE
Enhancements to min/max ops, including new MinNumber/MaxNumber ops

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -651,6 +651,7 @@ HWY_TESTS = HWY_CONTRIB_TESTS + (
     ("hwy/tests/", "masked_minmax_test", []),
     ("hwy/tests/", "memory_test", []),
     ("hwy/tests/", "minmax_magnitude_test", []),
+    ("hwy/tests/", "minmax_number_test", []),
     ("hwy/tests/", "minmax_test", []),
     ("hwy/tests/", "minmax128_test", []),
     ("hwy/tests/", "mul_by_pow2_test", []),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,6 +859,7 @@ set(HWY_TEST_FILES
   hwy/tests/masked_minmax_test.cc
   hwy/tests/memory_test.cc
   hwy/tests/minmax_magnitude_test.cc
+  hwy/tests/minmax_number_test.cc
   hwy/tests/minmax_test.cc
   hwy/tests/minmax128_test.cc
   hwy/tests/mul_by_pow2_test.cc

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -709,6 +709,28 @@ is qNaN, and NaN if both are.
 
 *   <code>V **Max**(V a, V b)</code>: returns `max(a[i], b[i])`.
 
+*   <code>V **MinNumber**(V a, V b)</code>: returns `min(a[i], b[i])` if `a[i]`
+    and `b[i]` are both non-NaN.
+
+    If one of `a[i]` or `b[i]` is qNaN and the other value is non-NaN,
+    `MinNumber(a, b)` returns the non-NaN value.
+
+    If one of `a[i]` or `b[i]` is sNaN and the other value is non-NaN, it is
+    implementation-defined whether `MinNumber(a, b)` returns `a[i]` or `b[i]`.
+
+    Otherwise, if `a[i]` and `b[i]` are both NaN, `MinNumber(a, b)` returns NaN.
+
+*   <code>V **MaxNumber**(V a, V b)</code>: returns `max(a[i], b[i])` if `a[i]`
+    and `b[i]` are both non-NaN.
+
+    If one of `a[i]` or `b[i]` is qNaN and the other value is non-NaN,
+    `MaxNumber(a, b)` returns the non-NaN value.
+
+    If one of `a[i]` or `b[i]` is sNaN and the other value is non-NaN, it is
+    implementation-defined whether `MaxNumber(a, b)` returns `a[i]` or `b[i]`.
+
+    Otherwise, if `a[i]` and `b[i]` are both NaN, `MaxNumber(a, b)` returns NaN.
+
 *   <code>V **MinMagnitude**(V a, V b)</code>: returns the number with the
     smaller magnitude if `a[i]` and `b[i]` are both non-NaN values.
 

--- a/hwy/highway_test.cc
+++ b/hwy/highway_test.cc
@@ -396,6 +396,11 @@ struct TestNaN {
     HWY_ASSERT_NAN(d, Min(nan, nan));
     HWY_ASSERT_NAN(d, Max(nan, nan));
 
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(nan, v1));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(nan, v1));
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v1, nan));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v1, nan));
+
     // AbsDiff
     HWY_ASSERT_NAN(d, AbsDiff(nan, v1));
     HWY_ASSERT_NAN(d, AbsDiff(v1, nan));

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -3560,6 +3560,28 @@ HWY_API Vec128<double> Max(Vec128<double> a, Vec128<double> b) {
 HWY_NEON_DEF_FUNCTION_ALL_FLOATS(Max, vmax, _, 2)
 #endif  // HWY_ARCH_ARM_A64
 
+// ------------------------------ MinNumber and MaxNumber
+
+#if !HWY_ARCH_ARM_A64
+
+#ifdef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#undef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#else
+#define HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#endif
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MinNumber(V a, V b) {
+  return Min(IfThenElse(IsNaN(a), b, a), IfThenElse(IsNaN(b), a, b));
+}
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MaxNumber(V a, V b) {
+  return Max(IfThenElse(IsNaN(a), b, a), IfThenElse(IsNaN(b), a, b));
+}
+
+#endif
+
 // ================================================== MEMORY
 
 // ------------------------------ Load 128

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -519,6 +519,37 @@ HWY_API V InterleaveEven(V a, V b) {
 }
 #endif
 
+// ------------------------------ MinNumber/MaxNumber
+
+#if (defined(HWY_NATIVE_FLOAT_MIN_MAX_NUMBER) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#undef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#else
+#define HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#endif
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MinNumber(V a, V b) {
+  return Min(a, b);
+}
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MaxNumber(V a, V b) {
+  return Max(a, b);
+}
+
+#endif
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V MinNumber(V a, V b) {
+  return Min(a, b);
+}
+
+template <class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V)>
+HWY_API V MaxNumber(V a, V b) {
+  return Max(a, b);
+}
+
 // ------------------------------ MinMagnitude/MaxMagnitude
 
 #if (defined(HWY_NATIVE_FLOAT_MIN_MAX_MAGNITUDE) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/loongarch_lasx-inl.h
+++ b/hwy/ops/loongarch_lasx-inl.h
@@ -778,6 +778,22 @@ HWY_API Vec256<double> Max(const Vec256<double> a, const Vec256<double> b) {
   return Vec256<double>{__lasx_xvfmax_d(a.raw, b.raw)};
 }
 
+// ------------------------------ MinMagnitude and MaxMagnitude
+
+HWY_API Vec256<float> MinMagnitude(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{__lasx_xvfmina_s(a.raw, b.raw)};
+}
+HWY_API Vec256<double> MinMagnitude(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{__lasx_xvfmina_d(a.raw, b.raw)};
+}
+
+HWY_API Vec256<float> MaxMagnitude(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{__lasx_xvfmaxa_s(a.raw, b.raw)};
+}
+HWY_API Vec256<double> MaxMagnitude(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{__lasx_xvfmaxa_d(a.raw, b.raw)};
+}
+
 // ------------------------------ Iota
 
 namespace detail {

--- a/hwy/ops/loongarch_lsx-inl.h
+++ b/hwy/ops/loongarch_lsx-inl.h
@@ -2634,6 +2634,34 @@ HWY_API Vec128<double, N> Max(Vec128<double, N> a, Vec128<double, N> b) {
   return Vec128<double, N>{__lsx_vfmax_d(a.raw, b.raw)};
 }
 
+// ------------------------------ MinMagnitude and MaxMagnitude
+
+#ifdef HWY_NATIVE_FLOAT_MIN_MAX_MAGNITUDE
+#undef HWY_NATIVE_FLOAT_MIN_MAX_MAGNITUDE
+#else
+#define HWY_NATIVE_FLOAT_MIN_MAX_MAGNITUDE
+#endif
+
+template <size_t N>
+HWY_API Vec128<float, N> MinMagnitude(Vec128<float, N> a, Vec128<float, N> b) {
+  return Vec128<float, N>{__lsx_vfmina_s(a.raw, b.raw)};
+}
+template <size_t N>
+HWY_API Vec128<double, N> MinMagnitude(Vec128<double, N> a,
+                                       Vec128<double, N> b) {
+  return Vec128<double, N>{__lsx_vfmina_d(a.raw, b.raw)};
+}
+
+template <size_t N>
+HWY_API Vec128<float, N> MaxMagnitude(Vec128<float, N> a, Vec128<float, N> b) {
+  return Vec128<float, N>{__lsx_vfmaxa_s(a.raw, b.raw)};
+}
+template <size_t N>
+HWY_API Vec128<double, N> MaxMagnitude(Vec128<double, N> a,
+                                       Vec128<double, N> b) {
+  return Vec128<double, N>{__lsx_vfmaxa_d(a.raw, b.raw)};
+}
+
 // ------------------------------ Non-temporal stores
 
 // Same as aligned stores on non-x86.

--- a/hwy/ops/wasm_128-inl.h
+++ b/hwy/ops/wasm_128-inl.h
@@ -903,6 +903,24 @@ HWY_API Vec128<double, N> Max(Vec128<double, N> a, Vec128<double, N> b) {
   return Vec128<double, N>{wasm_f64x2_pmax(b.raw, a.raw)};
 }
 
+// ------------------------------ MinNumber and MaxNumber
+
+#ifdef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#undef HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#else
+#define HWY_NATIVE_FLOAT_MIN_MAX_NUMBER
+#endif
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MinNumber(V a, V b) {
+  return Min(a, IfThenElse(IsNaN(b), a, b));
+}
+
+template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
+HWY_API V MaxNumber(V a, V b) {
+  return Max(a, IfThenElse(IsNaN(b), a, b));
+}
+
 // ------------------------------ Integer multiplication
 
 // Unsigned

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -204,7 +204,6 @@ struct Mask256 {
 template <typename T>
 using Full256 = Simd<T, 32 / sizeof(T), 0>;
 
-
 // ------------------------------ Zero
 
 // Cannot use VFromD here because it is defined in terms of Zero.
@@ -1786,6 +1785,68 @@ HWY_API Vec256<float> Max(const Vec256<float> a, const Vec256<float> b) {
 HWY_API Vec256<double> Max(const Vec256<double> a, const Vec256<double> b) {
   return Vec256<double>{_mm256_max_pd(a.raw, b.raw)};
 }
+
+// ------------------------------ MinNumber and MaxNumber
+
+#if HWY_X86_HAVE_AVX10_2_OPS
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec256<float16_t> MinNumber(Vec256<float16_t> a, Vec256<float16_t> b) {
+  return Vec256<float16_t>{_mm256_minmax_ph(a.raw, b.raw, 0x14)};
+}
+#endif
+HWY_API Vec256<float> MinNumber(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{_mm256_minmax_ps(a.raw, b.raw, 0x14)};
+}
+HWY_API Vec256<double> MinNumber(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{_mm256_minmax_pd(a.raw, b.raw, 0x14)};
+}
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec256<float16_t> MaxNumber(Vec256<float16_t> a, Vec256<float16_t> b) {
+  return Vec256<float16_t>{_mm256_minmax_ph(a.raw, b.raw, 0x15)};
+}
+#endif
+HWY_API Vec256<float> MaxNumber(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{_mm256_minmax_ps(a.raw, b.raw, 0x15)};
+}
+HWY_API Vec256<double> MaxNumber(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{_mm256_minmax_pd(a.raw, b.raw, 0x15)};
+}
+
+#endif
+
+// ------------------------------ MinMagnitude and MaxMagnitude
+
+#if HWY_X86_HAVE_AVX10_2_OPS
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec256<float16_t> MinMagnitude(Vec256<float16_t> a,
+                                       Vec256<float16_t> b) {
+  return Vec256<float16_t>{_mm256_minmax_ph(a.raw, b.raw, 0x16)};
+}
+#endif
+HWY_API Vec256<float> MinMagnitude(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{_mm256_minmax_ps(a.raw, b.raw, 0x16)};
+}
+HWY_API Vec256<double> MinMagnitude(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{_mm256_minmax_pd(a.raw, b.raw, 0x16)};
+}
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec256<float16_t> MaxMagnitude(Vec256<float16_t> a,
+                                       Vec256<float16_t> b) {
+  return Vec256<float16_t>{_mm256_minmax_ph(a.raw, b.raw, 0x17)};
+}
+#endif
+HWY_API Vec256<float> MaxMagnitude(Vec256<float> a, Vec256<float> b) {
+  return Vec256<float>{_mm256_minmax_ps(a.raw, b.raw, 0x17)};
+}
+HWY_API Vec256<double> MaxMagnitude(Vec256<double> a, Vec256<double> b) {
+  return Vec256<double>{_mm256_minmax_pd(a.raw, b.raw, 0x17)};
+}
+
+#endif
 
 // ------------------------------ Iota
 

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -1734,6 +1734,68 @@ HWY_API Vec512<double> Max(Vec512<double> a, Vec512<double> b) {
   return Vec512<double>{_mm512_max_pd(a.raw, b.raw)};
 }
 
+// ------------------------------ MinNumber and MaxNumber
+
+#if HWY_X86_HAVE_AVX10_2_OPS
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec512<float16_t> MinNumber(Vec512<float16_t> a, Vec512<float16_t> b) {
+  return Vec512<float16_t>{_mm512_minmax_ph(a.raw, b.raw, 0x14)};
+}
+#endif
+HWY_API Vec512<float> MinNumber(Vec512<float> a, Vec512<float> b) {
+  return Vec512<float>{_mm512_minmax_ps(a.raw, b.raw, 0x14)};
+}
+HWY_API Vec512<double> MinNumber(Vec512<double> a, Vec512<double> b) {
+  return Vec512<double>{_mm512_minmax_pd(a.raw, b.raw, 0x14)};
+}
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec512<float16_t> MaxNumber(Vec512<float16_t> a, Vec512<float16_t> b) {
+  return Vec512<float16_t>{_mm512_minmax_ph(a.raw, b.raw, 0x15)};
+}
+#endif
+HWY_API Vec512<float> MaxNumber(Vec512<float> a, Vec512<float> b) {
+  return Vec512<float>{_mm512_minmax_ps(a.raw, b.raw, 0x15)};
+}
+HWY_API Vec512<double> MaxNumber(Vec512<double> a, Vec512<double> b) {
+  return Vec512<double>{_mm512_minmax_pd(a.raw, b.raw, 0x15)};
+}
+
+#endif
+
+// ------------------------------ MinMagnitude and MaxMagnitude
+
+#if HWY_X86_HAVE_AVX10_2_OPS
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec512<float16_t> MinMagnitude(Vec512<float16_t> a,
+                                       Vec512<float16_t> b) {
+  return Vec512<float16_t>{_mm512_minmax_ph(a.raw, b.raw, 0x16)};
+}
+#endif
+HWY_API Vec512<float> MinMagnitude(Vec512<float> a, Vec512<float> b) {
+  return Vec512<float>{_mm512_minmax_ps(a.raw, b.raw, 0x16)};
+}
+HWY_API Vec512<double> MinMagnitude(Vec512<double> a, Vec512<double> b) {
+  return Vec512<double>{_mm512_minmax_pd(a.raw, b.raw, 0x16)};
+}
+
+#if HWY_HAVE_FLOAT16
+HWY_API Vec512<float16_t> MaxMagnitude(Vec512<float16_t> a,
+                                       Vec512<float16_t> b) {
+  return Vec512<float16_t>{_mm512_minmax_ph(a.raw, b.raw, 0x17)};
+}
+#endif
+HWY_API Vec512<float> MaxMagnitude(Vec512<float> a, Vec512<float> b) {
+  return Vec512<float>{_mm512_minmax_ps(a.raw, b.raw, 0x17)};
+}
+HWY_API Vec512<double> MaxMagnitude(Vec512<double> a, Vec512<double> b) {
+  return Vec512<double>{_mm512_minmax_pd(a.raw, b.raw, 0x17)};
+}
+
+#endif
+
 // ------------------------------ Integer multiplication
 
 // Unsigned

--- a/hwy/tests/minmax_number_test.cc
+++ b/hwy/tests/minmax_number_test.cc
@@ -1,0 +1,173 @@
+// Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For faster build on Arm. We still test SVE, SVE2, and NEON.
+#ifndef HWY_DISABLED_TARGETS
+#define HWY_DISABLED_TARGETS (HWY_NEON_WITHOUT_AES | HWY_SVE_256 | HWY_SVE2_128)
+#endif
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "tests/minmax_number_test.cc"
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/nanobenchmark.h"  // Unpredictable1
+#include "hwy/tests/test_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+namespace {
+
+struct TestUnsignedMinMaxNumber {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const Vec<D> v0 = Zero(d);
+    // Leave headroom such that v1 < v2 even after wraparound.
+    const Vec<D> mod = And(Iota(d, 0), Set(d, LimitsMax<T>() >> 1));
+    const Vec<D> v1 = Add(mod, Set(d, static_cast<T>(1)));
+    const Vec<D> v2 = Add(mod, Set(d, static_cast<T>(2)));
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaxNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v0, MinNumber(v1, v0));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v1, v0));
+
+    const Vec<D> vmin = Set(d, static_cast<T>(Unpredictable1() - 1));  // 0
+    const Vec<D> vmax = Set(d, LimitsMax<T>());
+
+    const Vec<D> actual_min1 = MinNumber(vmin, vmax);
+    const Vec<D> actual_min2 = MinNumber(vmax, vmin);
+#if HWY_TARGET_IS_SVE
+    // lvalue and `PreventElision` work around incorrect codegen on SVE2.
+    PreventElision(GetLane(actual_min1));
+    PreventElision(GetLane(actual_min2));
+#endif
+    HWY_ASSERT_VEC_EQ(d, vmin, actual_min1);
+    HWY_ASSERT_VEC_EQ(d, vmin, actual_min2);
+
+    const Vec<D> actual_max1 = MaxNumber(vmin, vmax);
+    const Vec<D> actual_max2 = MaxNumber(vmax, vmin);
+    HWY_ASSERT_VEC_EQ(d, vmax, actual_max1);
+    HWY_ASSERT_VEC_EQ(d, vmax, actual_max2);
+  }
+};
+
+HWY_NOINLINE void TestMinMaxNumberU() {
+  ForUnsignedTypes(ForPartialVectors<TestUnsignedMinMaxNumber>());
+}
+
+struct TestSignedMinMaxNumber {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    // Leave headroom such that v1 < v2 even after wraparound.
+    const Vec<D> mod =
+        And(Iota(d, 0), Set(d, ConvertScalarTo<T>(LimitsMax<T>() >> 1)));
+    const Vec<D> v1 = Add(mod, Set(d, ConvertScalarTo<T>(1)));
+    const Vec<D> v2 = Add(mod, Set(d, ConvertScalarTo<T>(2)));
+    const Vec<D> v_neg = Sub(Zero(d), v1);
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaxNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v_neg, MinNumber(v1, v_neg));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v1, v_neg));
+
+    const Vec<D> v0 = Set(d, static_cast<T>(Unpredictable1() - 1));
+    const Vec<D> vmin = Or(v0, Set(d, LimitsMin<T>()));
+    const Vec<D> vmax = Or(v0, Set(d, LimitsMax<T>()));
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(v0, vmin));
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(vmin, v0));
+    HWY_ASSERT_VEC_EQ(d, v0, MaxNumber(v0, vmin));
+    HWY_ASSERT_VEC_EQ(d, v0, MaxNumber(vmin, v0));
+
+    const Vec<D> actual_min1 = MinNumber(vmin, vmax);
+    const Vec<D> actual_min2 = MinNumber(vmax, vmin);
+    HWY_ASSERT_VEC_EQ(d, vmin, actual_min1);
+    HWY_ASSERT_VEC_EQ(d, vmin, actual_min2);
+
+    HWY_ASSERT_VEC_EQ(d, vmax, MaxNumber(vmin, vmax));
+    HWY_ASSERT_VEC_EQ(d, vmax, MaxNumber(vmax, vmin));
+  }
+};
+
+HWY_NOINLINE void TestMinMaxNumberI() {
+  ForSignedTypes(ForPartialVectors<TestSignedMinMaxNumber>());
+}
+
+struct TestFloatMinMaxNumber {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    using TU = MakeUnsigned<T>;
+    constexpr TU kQNaNBits =
+        static_cast<TU>(ExponentMask<T>() | (ExponentMask<T>() >> 1));
+
+    const RebindToUnsigned<D> du;
+    const Vec<D> vnan = BitCast(d, Set(du, kQNaNBits));
+
+    const Vec<D> v1 = Iota(d, Unpredictable1());
+    const Vec<D> v2 = Iota(d, Unpredictable1() + 1);
+    const Vec<D> v3 = Or(v1, vnan);
+    const Vec<D> v4 = Or(v2, vnan);
+    const Vec<D> v_neg = Iota(d, -ConvertScalarTo<T>(Lanes(d)));
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v2, MaxNumber(v1, v2));
+    HWY_ASSERT_VEC_EQ(d, v_neg, MinNumber(v1, v_neg));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v1, v_neg));
+
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v1, v4));
+    HWY_ASSERT_VEC_EQ(d, v2, MinNumber(v2, v3));
+    HWY_ASSERT_VEC_EQ(d, v2, MinNumber(v3, v2));
+    HWY_ASSERT_VEC_EQ(d, v1, MinNumber(v4, v1));
+
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v1, v4));
+    HWY_ASSERT_VEC_EQ(d, v2, MaxNumber(v2, v3));
+    HWY_ASSERT_VEC_EQ(d, v2, MaxNumber(v3, v2));
+    HWY_ASSERT_VEC_EQ(d, v1, MaxNumber(v4, v1));
+
+    const Vec<D> v0 = Zero(d);
+    const Vec<D> vmin = Set(d, ConvertScalarTo<T>(-1E30));
+    const Vec<D> vmax = Set(d, ConvertScalarTo<T>(1E30));
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(v0, vmin));
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(vmin, v0));
+    HWY_ASSERT_VEC_EQ(d, v0, MaxNumber(v0, vmin));
+    HWY_ASSERT_VEC_EQ(d, v0, MaxNumber(vmin, v0));
+
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(vmin, vmax));
+    HWY_ASSERT_VEC_EQ(d, vmin, MinNumber(vmax, vmin));
+
+    HWY_ASSERT_VEC_EQ(d, vmax, MaxNumber(vmin, vmax));
+    HWY_ASSERT_VEC_EQ(d, vmax, MaxNumber(vmax, vmin));
+  }
+};
+
+HWY_NOINLINE void TestMinMaxNumberF() {
+  ForFloatTypes(ForPartialVectors<TestFloatMinMaxNumber>());
+}
+
+}  // namespace
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace hwy {
+namespace {
+HWY_BEFORE_TEST(HwyMinMaxNumberTest);
+HWY_EXPORT_AND_TEST_P(HwyMinMaxNumberTest, TestMinMaxNumberU);
+HWY_EXPORT_AND_TEST_P(HwyMinMaxNumberTest, TestMinMaxNumberI);
+HWY_EXPORT_AND_TEST_P(HwyMinMaxNumberTest, TestMinMaxNumberF);
+HWY_AFTER_TEST();
+}  // namespace
+}  // namespace hwy
+HWY_TEST_MAIN();
+#endif  // HWY_ONCE


### PR DESCRIPTION
Added the MinNumber and MaxNumber ops, which have the following semantics:
- If `a[i]` and `b[i]` are both non-NaN, `MinNumber(a, b)` is equivalent to `Min(a, b)` and `MaxNumber(a, b)` is equivalent to `Max(a, b)`
- If one of `a[i]` or `b[i]` is qNaN and the other value is a non-NaN, the non-NaN value is returned by the MinNumber and MaxNumber ops
- If both `a[i]` and `b[i]` are both NaN, MinNumber and MaxNumber both return NaN
- Otherwise, if one of `a[i]` or `b[i]` is sNaN and the other value is a non-NaN, it is implementation-defined whether MinNumber or MaxNumber returns `a[i]` or `b[i]`

`MinNumber(a, b)` is equivalent to IEEE 754-2019 minimumNumber if neither `a[i]` nor `b[i]` are sNaN and `MaxNumber(a, b)` is equivalent to IEEE 754-2019 maximumNumber if neither `a[i]` nor `b[i]` are sNaN.

Also added target-specific implementations for MinMagnitude and MaxMagnitude on the AVX10_2/LSX/LASX targets as AVX10.2/LSX/LASX have instructions for MaxMagnitude/MinMagnitude.