### PR TITLE
Made fixes to SVE Min, MaskedMin, and MaskedMax

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -1645,8 +1645,10 @@ HWY_API svbool_t LowerHalfOfMask(D /*d*/, svbool_t m) {
 #endif
 
 namespace detail {
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV, MaskedMin, min)
-HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV, MaskedMax, max)
+HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGMVV, MaskedMin, minnm)
+HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGMVV, MaskedMax, maxnm)
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVV, MaskedMin, min)
+HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGMVV, MaskedMax, max)
 HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV, MaskedAdd, add)
 HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV, MaskedSub, sub)
 HWY_SVE_FOREACH(HWY_SVE_RETV_ARGMVV, MaskedMul, mul)
@@ -1971,9 +1973,8 @@ HWY_API V Min(V a, V b) {
 }
 template <class V, HWY_IF_FLOAT_OR_SPECIAL_V(V)>
 HWY_API V Min(V a, V b) {
-  return IfThenElse(Lt(a, b), a, b);
+  return IfThenElse(Or(Lt(a, b), Ne(b, b)), a, b);
 }
-
 #else
 HWY_SVE_FOREACH_I(HWY_SVE_RETV_ARGPVV, Min, min)
 HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGPVV, Min, minnm)


### PR DESCRIPTION
Updated SVE detail::MaskedMin/detail::MaskedMax ops for floating-point vectors to use svminnm/svmaxnm instead of svmin/svmax for behavioral consistency with Min/Max.

Also fixed the implementation of floating-point Min op for Clang in arm_sve-inl.h to return `a` if `b` is NaN to ensure consistency with the SVE svminnm op.

The fixes in this pull request fix test failures with SVE when compiling with Clang.