### PR TITLE
Fix macOS AdvSIMD_HPFPCvt feature detection compatibility

### DIFF
--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -485,7 +485,10 @@ static int64_t DetectTargets() {
   if (HasCpuFeature("hw.optional.arm.FEAT_AES")) {
     bits |= HWY_NEON;
 
-    if (HasCpuFeature("hw.optional.AdvSIMD_HPFPCvt") &&
+    // Some macOS versions report AdvSIMD_HPFPCvt under a different key.
+    // Check both known variants for compatibility.
+    if ((HasCpuFeature("hw.optional.AdvSIMD_HPFPCvt") ||
+         HasCpuFeature("hw.optional.arm.AdvSIMD_HPFPCvt")) &&
         HasCpuFeature("hw.optional.arm.FEAT_DotProd") &&
         HasCpuFeature("hw.optional.arm.FEAT_BF16")) {
       bits |= HWY_NEON_BF16;


### PR DESCRIPTION
Apple reports the AdvSIMD_HPFPCvt feature under different sysctl keys across macOS versions and systems:
- Some report: hw.optional.AdvSIMD_HPFPCvt
- Others report: hw.optional.arm.AdvSIMD_HPFPCvt

This inconsistency caused NEON_BF16 feature detection to fail on affected systems. Now check both variants to ensure compatibility across all macOS versions.

Fixes CPU feature detection on macOS systems with inconsistent AdvSIMD_HPFPCvt reporting.

Fixes #2599.