### PR TITLE
Fix errors when building with CMake 4.0

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Changed cmake_minimum_required line to `cmake_minimum_required(VERSION 3.10)` in CMakeLists.txt.in to fix errors when configuring Google Highway build with CMake 4.