### PR TITLE
replace shortened URLs using goo.gl

### DIFF
--- a/g3doc/design_philosophy.md
+++ b/g3doc/design_philosophy.md
@@ -41,9 +41,9 @@
     sizes increase, and matches the direction taken by
     [Arm SVE](https://alastairreid.github.io/papers/sve-ieee-micro-2017.pdf) and
     RiscV V as well as Agner Fog's
-    [ForwardCom instruction set proposal](https://goo.gl/CFizWu). However, some
-    applications may require fixed sizes, so we also guarantee support for <=
-    128-bit vectors in each instruction set.
+    [ForwardCom instruction set proposal](https://goo.gl/CFizW://www.agner.org/optimize/forwardcom.pdf).
+    However, some applications may require fixed sizes, so we also guarantee
+    support for <= 128-bit vectors in each instruction set.
 
 *   The API and its implementation should be usable and efficient with commonly
     used compilers, including MSVC. For example, we write `ShiftLeft<3>(v)`

--- a/hwy/stats.h
+++ b/hwy/stats.h
@@ -82,7 +82,8 @@ class Stats {
     // Logarithmic transform avoids/delays underflow and overflow.
     sum_log_ += std::log(static_cast<double>(x));
 
-    // Online moments. Reference: https://goo.gl/9ha694
+    // Online moments.
+	// Reference: https://www.thinkbrg.com/media/publication/720_McCrary_ImplementingAlgorithms_Whitepaper_20151119_WEB.pdf
     const double d = x - m1_;
     const double d_div_n = d / static_cast<double>(n_);
     const double d2n1_div_n = d * (static_cast<double>(n_) - 1) * d_div_n;


### PR DESCRIPTION
goo.gl service will go away 2025-08-25
https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/