### PR TITLE
Updated docs GitHub workflow

### DIFF
--- a/.github/workflows/docs_pages_workflow.yml
+++ b/.github/workflows/docs_pages_workflow.yml
@@ -11,7 +11,7 @@ jobs:
 
   build_docs_job:
     runs-on: ubuntu-latest
-    container: debian:buster-slim
+    container: debian:bookworm-slim
 
     steps:
 


### PR DESCRIPTION
Updated docs workflow to use debian:bookworm-slim container and updated docs/buildDocs.sh to use a python venv as the version of pip in Debian Bookworm requires `pip install` to run inside of a python venv.