### PR TITLE
Added SetMask op

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1388,6 +1388,11 @@ encoding depends on the platform).
     `Dup128MaskFromMaskBits(D(), 0)`, but `MaskFalse(D())` is usually more
     efficient.
 
+*   <code>M **SetMask**(D, bool val)</code>: equivalent to
+    `RebindMask(d, MaskFromVec(Set(RebindToSigned<D>(),
+    -static_cast<MakeSigned<TFromD<D>>>(val))))`,
+    but `SetMask(d, val)` is usually more efficient.
+
 #### Convert mask
 
 *   <code>M1 **RebindMask**(D, M2 m)</code>: returns same mask bits as `m`, but

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -407,6 +407,20 @@ HWY_API svbool_t MaskFalse(const D /*d*/) {
   return detail::PFalse();
 }
 
+#ifdef HWY_NATIVE_SET_MASK
+#undef HWY_NATIVE_SET_MASK
+#else
+#define HWY_NATIVE_SET_MASK
+#endif
+
+template <class D>
+HWY_API svbool_t SetMask(D d, bool val) {
+  // The SVE svdup_n_b* intrinsics are equivalent to the FirstN op below if
+  // detail::IsFull(d) is true since svdup_n_b* is simply a wrapper around the
+  // SVE whilelo instruction.
+  return FirstN(d, size_t{0} - static_cast<size_t>(val));
+}
+
 // ================================================== INIT
 
 // ------------------------------ Set

--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -310,6 +310,17 @@ HWY_API Mask1<T> FirstN(D /*tag*/, size_t n) {
   return Mask1<T>::FromBool(n != 0);
 }
 
+#ifdef HWY_NATIVE_SET_MASK
+#undef HWY_NATIVE_SET_MASK
+#else
+#define HWY_NATIVE_SET_MASK
+#endif
+
+template <class D>
+HWY_API MFromD<D> SetMask(D /*d*/, bool val) {
+  return MFromD<D>::FromBool(val);
+}
+
 // ------------------------------ IfVecThenElse
 template <typename T>
 HWY_API Vec1<T> IfVecThenElse(Vec1<T> mask, Vec1<T> yes, Vec1<T> no) {

--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -1004,6 +1004,23 @@ HWY_API MFromD<D> MaskFalse(D /*d*/) {
   return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(0)};
 }
 
+// ------------------------------ SetMask
+#ifdef HWY_NATIVE_SET_MASK
+#undef HWY_NATIVE_SET_MASK
+#else
+#define HWY_NATIVE_SET_MASK
+#endif
+
+template <class D>
+HWY_API MFromD<D> SetMask(D /*d*/, bool val) {
+  constexpr uint64_t kMask = (HWY_MAX_LANES_D(D) < 64)
+                                 ? ((1ULL << (HWY_MAX_LANES_D(D) & 63)) - 1ULL)
+                                 : LimitsMax<uint64_t>();
+
+  return MFromD<D>{static_cast<decltype(MFromD<D>().raw)>(
+      static_cast<uint64_t>(-static_cast<int64_t>(val)) & kMask)};
+}
+
 // ------------------------------ IsNegative (MFromD)
 #ifdef HWY_NATIVE_IS_NEGATIVE
 #undef HWY_NATIVE_IS_NEGATIVE

--- a/hwy/tests/mask_set_test.cc
+++ b/hwy/tests/mask_set_test.cc
@@ -293,6 +293,54 @@ HWY_NOINLINE void TestAllDup128MaskFromMaskBits() {
   ForAllTypes(ForPartialVectors<TestDup128MaskFromMaskBits>());
 }
 
+struct TestSetMask {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const auto expected_false_mask = MaskFalse(d);
+
+    const auto false_mask_1 =
+        SetMask(d, static_cast<bool>(hwy::Unpredictable1() - 1));
+    HWY_ASSERT(AllFalse(d, false_mask_1));
+    HWY_ASSERT(!AllTrue(d, false_mask_1));
+    HWY_ASSERT(CountTrue(d, false_mask_1) == 0);
+    HWY_ASSERT(FindFirstTrue(d, false_mask_1) == -1);
+    HWY_ASSERT(FindLastTrue(d, false_mask_1) == -1);
+    HWY_ASSERT_MASK_EQ(d, expected_false_mask, false_mask_1);
+
+    const auto false_mask_2 = SetMask(d, false);
+    HWY_ASSERT(AllFalse(d, false_mask_2));
+    HWY_ASSERT(!AllTrue(d, false_mask_2));
+    HWY_ASSERT(CountTrue(d, false_mask_2) == 0);
+    HWY_ASSERT(FindFirstTrue(d, false_mask_2) == -1);
+    HWY_ASSERT(FindLastTrue(d, false_mask_2) == -1);
+    HWY_ASSERT_MASK_EQ(d, expected_false_mask, false_mask_2);
+
+    const size_t N = Lanes(d);
+    const auto expected_true_mask = MaskTrue(d);
+
+    const auto true_mask_1 =
+        SetMask(d, static_cast<bool>(hwy::Unpredictable1()));
+    HWY_ASSERT(!AllFalse(d, true_mask_1));
+    HWY_ASSERT(AllTrue(d, true_mask_1));
+    HWY_ASSERT(CountTrue(d, true_mask_1) == N);
+    HWY_ASSERT(FindFirstTrue(d, true_mask_1) == 0);
+    HWY_ASSERT(FindLastTrue(d, true_mask_1) == static_cast<intptr_t>(N - 1));
+    HWY_ASSERT_MASK_EQ(d, expected_true_mask, true_mask_1);
+
+    const auto true_mask_2 = SetMask(d, true);
+    HWY_ASSERT(!AllFalse(d, true_mask_2));
+    HWY_ASSERT(AllTrue(d, true_mask_2));
+    HWY_ASSERT(CountTrue(d, true_mask_2) == N);
+    HWY_ASSERT(FindFirstTrue(d, true_mask_2) == 0);
+    HWY_ASSERT(FindLastTrue(d, true_mask_2) == static_cast<intptr_t>(N - 1));
+    HWY_ASSERT_MASK_EQ(d, expected_true_mask, true_mask_2);
+  }
+};
+
+HWY_NOINLINE void TestAllSetMask() {
+  ForAllTypes(ForPartialVectors<TestSetMask>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -310,6 +358,7 @@ HWY_EXPORT_AND_TEST_P(HwyMaskSetTest, TestAllSetAtOrBeforeFirst);
 HWY_EXPORT_AND_TEST_P(HwyMaskSetTest, TestAllSetOnlyFirst);
 HWY_EXPORT_AND_TEST_P(HwyMaskSetTest, TestAllSetAtOrAfterFirst);
 HWY_EXPORT_AND_TEST_P(HwyMaskSetTest, TestAllDup128MaskFromMaskBits);
+HWY_EXPORT_AND_TEST_P(HwyMaskSetTest, TestAllSetMask);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
Added the SetMask op as `SetMask(d, val)` is more efficient than `RebindMask(d, MaskFromVec(Set(RebindToSigned<D>(), -static_cast<MakeSigned<TFromD<D>>>(val))))` on some targets, including SCALAR, AVX3, RVV, and SVE.

There is also a use case for SetMask in the default implementation of RoundingShiftRightSame, and this change is included in this pull request.

There is also a use case for SetMask in vectorized implementations of the jxl::PerformAlphaBlending, jxl::PerformAlphaWeightedAdd, and jxl::PerformMulBlending in libjxl (which are implemented in lib/jxl/alpha.cc but currently do not take advantage of Google Highway).