### PR TITLE
Fixes MSVC compiler bug on single lane broadcast

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -6962,7 +6962,11 @@ HWY_API Vec128<T, N> Broadcast(const Vec128<T, N> v) {
 template <int kLane, typename T, size_t N, HWY_IF_UI32(T)>
 HWY_API Vec128<T, N> Broadcast(const Vec128<T, N> v) {
   static_assert(0 <= kLane && kLane < N, "Invalid lane");
-  return Vec128<T, N>{_mm_shuffle_epi32(v.raw, 0x55 * kLane)};
+  HWY_IF_CONSTEXPR(N == 1){
+    return Vec128<T, N>{v};  // Workaround for MSVC compiler bug on single lane integer broadcast
+  }else{
+    return Vec128<T, N>{_mm_shuffle_epi32(v.raw, 0x55 * kLane)};
+  }
 }
 
 template <int kLane, typename T, size_t N, HWY_IF_UI64(T)>


### PR DESCRIPTION
Adds a workaround for an MSVC compiler bug that occurs during single-lane integer broadcasts.

The workaround returns the original vector when broadcasting from a single lane to avoid the compiler issue, since broadcasting a the value of a single-lane vector to another single-lane vector is essentially a no-op.