### PR TITLE
Switch between wait modes in ThreadPoolTest

### DIFF
--- a/hwy/contrib/thread_pool/thread_pool_test.cc
+++ b/hwy/contrib/thread_pool/thread_pool_test.cc
@@ -451,7 +451,7 @@ TEST(ThreadPoolTest, TestWaitMode) {
   ThreadPool pool(9);
   RandomState rng;
   for (size_t i = 0; i < 100; ++i) {
-    pool.SetWaitMode(Random32(&rng) ? PoolWaitMode::kSpin
+    pool.SetWaitMode((Random32(&rng) & 1u) ? PoolWaitMode::kSpin
                                     : PoolWaitMode::kBlock);
   }
 }


### PR DESCRIPTION
Uses a bitwise AND operation to guarantee an equal probability to switch between wait modes in test.

A simple error I noticed while digging through test codes, I'm assuming this RNG was meant to actually switch between wait modes instead of choosing to switch to PoolWaitMode::kSpin with a 1 in 2^32 chance.