### PR TITLE
thread_pool.h: avoid ambiguous size types in Config struct

### DIFF
--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -272,7 +272,7 @@ class Config {  // 8 bytes
   SpinType spin_type;
   WaitType wait_type;
   BarrierType barrier_type;
-  bool exit;
+  uint8_t exit;
   uint32_t reserved = 0;
 };
 static_assert(sizeof(Config) == 8, "");


### PR DESCRIPTION
Config must have exact size, but bool is not guaranteed to be 1 byte. Use uint8_t instead, which is always 1 byte. Fixes the build on powerpc-darwin.

Fixes: https://github.com/google/highway/issues/2679