### PR TITLE
Use std::sort in auto_tune.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -847,6 +847,7 @@ endif()  # HWY_TEST_STANDALONE
 set(HWY_TEST_FILES
   hwy/abort_test.cc
   hwy/aligned_allocator_test.cc
+  hwy/auto_tune_test.cc
   hwy/base_test.cc
   hwy/bit_set_test.cc
   hwy/highway_test.cc
@@ -920,7 +921,6 @@ if (HWY_ENABLE_CONTRIB)
 list(APPEND HWY_TEST_LIBS hwy_contrib)
 
 list(APPEND HWY_TEST_FILES
-  hwy/auto_tune_test.cc
   hwy/contrib/algo/copy_test.cc
   hwy/contrib/algo/find_test.cc
   hwy/contrib/algo/transform_test.cc

--- a/meson.build
+++ b/meson.build
@@ -559,6 +559,7 @@ if tests_enabled
     hwy_test_files = files(
         'hwy/abort_test.cc',
         'hwy/aligned_allocator_test.cc',
+        'hwy/auto_tune_test.cc',
         'hwy/base_test.cc',
         'hwy/bit_set_test.cc',
         'hwy/highway_test.cc',
@@ -655,7 +656,6 @@ if tests_enabled
 
     if contrib_enabled
         hwy_contrib_test_files = files(
-            'hwy/auto_tune_test.cc',
             'hwy/contrib/algo/copy_test.cc',
             'hwy/contrib/algo/find_test.cc',
             'hwy/contrib/algo/transform_test.cc',


### PR DESCRIPTION
Considering `auto_tune.h` is in the `hwy` directory, I've removed the dependence on `VQSort`, allowing `auto_tune.h` to be used without the `contrib` library.

The vector it was sorting was at most 14 elements, so I would guess using `VQSort` is a bit overkill anyways.

Closes #2685