### PR TITLE
Use `LoadN` for short BF16 dot product inputs instead of scalar conversion

### DIFF
--- a/hwy/contrib/dot/dot-inl.h
+++ b/hwy/contrib/dot/dot-inl.h
@@ -174,12 +174,30 @@ struct Dot {
         (kAssumptions & kMultipleOfVector) != 0;
     constexpr bool kIsPaddedToVector = (kAssumptions & kPaddedToVector) != 0;
 
-    // Won't be able to do a full vector load without padding => partial load.
+    // Won't be able to do a full vector load without padding. Use a scalar
+    // loop under Clang. GCC has very suboptimal codegen for scalar BF16->float
+    // conversions, so use vector ops with LoadN instead.
+    // TODO: https://github.com/google/highway/pull/2703
     if (!kIsAtLeastOneVector && !kIsMultipleOfVector && !kIsPaddedToVector &&
         HWY_UNLIKELY(num_elements < NF)) {
+#if HWY_COMPILER_GCC_ACTUAL
       const VF a = LoadN(df, pa, num_elements);
       const VF b = PromoteTo(df, LoadN(dbfh, pb, num_elements));
       return ReduceSum(df, Mul(a, b));
+#else
+      // Only 2x unroll to avoid excessive code size.
+      float sum0 = 0.0f;
+      float sum1 = 0.0f;
+      size_t i = 0;
+      for (; i + 2 <= num_elements; i += 2) {
+        sum0 += pa[i + 0] * ConvertScalarTo<float>(pb[i + 0]);
+        sum1 += pa[i + 1] * ConvertScalarTo<float>(pb[i + 1]);
+      }
+      for (; i < num_elements; ++i) {
+        sum1 += pa[i] * ConvertScalarTo<float>(pb[i]);
+      }
+      return sum0 + sum1;
+#endif
     }
 
     // Compiler doesn't make independent sum* accumulators, so unroll manually.
@@ -270,14 +288,30 @@ struct Dot {
         (kAssumptions & kMultipleOfVector) != 0;
     constexpr bool kIsPaddedToVector = (kAssumptions & kPaddedToVector) != 0;
 
-    // Won't be able to do a full vector load without padding => partial load.
+    // Won't be able to do a full vector load without padding. Use a scalar
+    // loop under Clang. GCC has very suboptimal codegen for scalar BF16->float
+    // conversions, so use vector ops with LoadN instead.
+    // TODO: https://github.com/google/highway/pull/2703
     if (!kIsAtLeastOneVector && !kIsMultipleOfVector && !kIsPaddedToVector &&
         HWY_UNLIKELY(num_elements < N)) {
+#if HWY_COMPILER_GCC_ACTUAL
       const auto a = LoadN(d, pa, num_elements);
       const auto b = LoadN(d, pb, num_elements);
       V sum1 = Zero(df32);
       V sum0 = ReorderWidenMulAccumulate(df32, a, b, Zero(df32), sum1);
       return ReduceSum(df32, Add(sum0, sum1));
+#else
+      float sum0 = 0.0f;  // Only 2x unroll to avoid excessive code size for..
+      float sum1 = 0.0f;  // this unlikely(?) case.
+      for (; i + 2 <= num_elements; i += 2) {
+        sum0 += F32FromBF16(pa[i + 0]) * F32FromBF16(pb[i + 0]);
+        sum1 += F32FromBF16(pa[i + 1]) * F32FromBF16(pb[i + 1]);
+      }
+      if (i < num_elements) {
+        sum1 += F32FromBF16(pa[i]) * F32FromBF16(pb[i]);
+      }
+      return sum0 + sum1;
+#endif
     }
 
     // See comment in the other Compute() overload. Unroll 2x, but we need


### PR DESCRIPTION
Resolves issue #2699.

This changes the fallback logic for inputs with fewer elements than that of a full vector's lane count to use partial vector loads with implicit zeroing (via `LoadN`) instead of scalar loads and conversions.

I think these should be fairly conservative changes, as the main vector loops remain untouched. An alternative approach would be to generalize the final boundary handling code for < `N` remaining elements to use `LoadN` instead of `FirstN`+"adjusted" `LoadU`, which would remove the need for such an initial special case in the first place. Since I don't have access to enough exotic testing hardware to know how/if this would affect performance on non-x64/arm64 systems, I skipped on doing that. 🙂

It's possible that the use of `ReorderWidenMulAccumulate` should be replaced with explicit `Promote(Upper|Lower)To` and multiplication since the input sums will always be zero, but I am not sure how much it matters in practice. This just mirrors what's in the main loops.

Rationale/background:

Falling back to scalar conversion of `__bf16` to `float` elements will on GCC 13+ end up silently generating a call to the `__extendbfsf2` library function per conversion, rather than just zero-extending to 32 bits and shifting left by 16. This both bloats the generated code and has a substantial runtime cost; on x64 it takes take more time to process 8 BF16 elements with the scalar fallback path than it takes to process 1024 BF16 elements in the vector path..!

Partial vector loads are introduced for the following dot product function overloads:

 * `bfloat16_t` vs. `bfloat16_t` (used `F32FromBF16`)
 * `float` vs. `bfloat16_t` (used `ConvertScalarTo<float>` which transitively calls `F32FromBF16`)

Some before/after graphs from a Sapphire Rapids system:

`bfloat16_t` vs. `bfloat16_t`:

Before:
<img width="1024" height="768" alt="dot_product_bfloat16_vs_bfloat16" src="https://github.com/user-attachments/assets/babb0a11-1df5-4d81-b77f-af7f27f26e8c" />

After:
<img width="1024" height="768" alt="dot_product_bfloat16_vs_bfloat16" src="https://github.com/user-attachments/assets/211c58f2-4222-4171-9899-202c3c6d0bcc" />

`float` vs. `bfloat16_t`:

Before:
<img width="1024" height="768" alt="dot_product_float_vs_bfloat16" src="https://github.com/user-attachments/assets/422866f2-c963-492b-a14b-8fa791ac4871" />

After:
<img width="1024" height="768" alt="dot_product_float_vs_bfloat16" src="https://github.com/user-attachments/assets/5f1ca45e-b57e-4b38-a778-a0999963e0c5" />
