### PR TITLE
Enable VQSORT for RISC-V

### DIFF
--- a/hwy/contrib/sort/shared-inl.h
+++ b/hwy/contrib/sort/shared-inl.h
@@ -147,7 +147,8 @@ static_assert(SortConstants::MaxBufBytes<2>(64) <= 1664, "Unexpectedly high");
 
 #if (HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD) ||                   \
     (HWY_ARCH_ARM_V7 && HWY_IS_DEBUG_BUILD) ||                      \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN)
+    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN) || \
+    (HWY_ARCH_RISCV && HWY_COMPILER_GCC_ACTUAL < 1400)
 #define VQSORT_COMPILER_COMPATIBLE 0
 #else
 #define VQSORT_COMPILER_COMPATIBLE 1


### PR DESCRIPTION
Compile environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip)         gcc/g++ version 14.2.0
alias gcc='gcc -march=rv64gcv'
alias g++='g++ -march=rv64gcv'

Configure build with RVV
meson setup builddir \
  -Dcpp_std=c++17 \
  -Dwarning_level=2 \
  -Dbuildtype=release \
  -Dgtest:cpp_eh=default \
  -Drvv=true

Compile
  meson compile -C builddir -j$(nproc) -v

I found that the project compiles successfully on RISC-V if I remove the HWY_ARCH_RISCV check from the preprocessor conditional.