### PR TITLE
Fixes for GCC compiler warnings in spin.h and thread_pool.h

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -148,6 +148,21 @@
 
 #endif  // !HWY_COMPILER_MSVC
 
+#if (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1200) || \
+    (HWY_COMPILER_ICC && !HWY_COMPILER_ICX)
+// The use of __attribute__((unused)) in private class member variables triggers
+// a compiler warning with GCC 11 and earlier and ICC
+
+// GCC 11 and earlier and ICC also do not emit -Wunused-private-field warnings
+// for unused private class member variables
+#define HWY_MEMBER_VAR_MAYBE_UNUSED
+#else
+// Clang and ICX need __attribute__((unused)) in unused private class member
+// variables to suppress -Wunused-private-field warnings unless this warning is
+// ignored by using HWY_DIAGNOSTICS_OFF
+#define HWY_MEMBER_VAR_MAYBE_UNUSED HWY_MAYBE_UNUSED
+#endif
+
 //------------------------------------------------------------------------------
 // Builtin/attributes (no more #include after this point due to namespace!)
 

--- a/hwy/contrib/thread_pool/spin.h
+++ b/hwy/contrib/thread_pool/spin.h
@@ -98,6 +98,7 @@ static inline const char* ToString(SpinType type) {
     case SpinType::kPause:
       return "Pause";
     case SpinType::kSentinel:
+    default:
       return nullptr;
   }
 }

--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -231,7 +231,7 @@ struct Config {  // 4 bytes
 
   SpinType spin_type;
   WaitType wait_type;
-  HWY_MAYBE_UNUSED uint8_t reserved[2];
+  HWY_MEMBER_VAR_MAYBE_UNUSED uint8_t reserved[2];
 };
 static_assert(sizeof(Config) == 4, "");
 
@@ -352,7 +352,8 @@ class alignas(HWY_ALIGNMENT) Worker {  // HWY_ALIGNMENT bytes
   // thread_pool_test requires nonzero epoch.
   uint32_t worker_epoch_ = 1;
 
-  HWY_MAYBE_UNUSED uint8_t padding_[HWY_ALIGNMENT - 64 - sizeof(victims_)];
+  HWY_MEMBER_VAR_MAYBE_UNUSED uint8_t
+      padding_[HWY_ALIGNMENT - 64 - sizeof(victims_)];
 };
 static_assert(sizeof(Worker) == HWY_ALIGNMENT, "");
 
@@ -992,7 +993,8 @@ class alignas(HWY_ALIGNMENT) ThreadPool {
   // passed to `ThreadFunc`. Padding ensures that the workers' cache lines are
   // not unnecessarily invalidated when the main thread writes other members.
   alignas(HWY_ALIGNMENT) pool::Tasks tasks_;
-  HWY_MAYBE_UNUSED char padding_[HWY_ALIGNMENT - sizeof(pool::Tasks)];
+  HWY_MEMBER_VAR_MAYBE_UNUSED char
+      padding_[HWY_ALIGNMENT - sizeof(pool::Tasks)];
 
   // In debug builds, detects if functions are re-entered.
   std::atomic_flag busy_ = ATOMIC_FLAG_INIT;


### PR DESCRIPTION
Added HWY_MEMBER_VAR_MAYBE_UNUSED to hwy/base.h to fix compiler warnings with GCC 11 and earlier and ICC as GCC 11 and earlier and ICC trigger compiler warnings if unused private class member variables have the HWY_MAYBE_UNUSED attribute.

In addition, Clang and ICX need HWY_MAYBE_UNUSED for unused private class member variables to avoid -Wunused-private-field warnings unless these warnings are ignored by using HWY_DIAGNOSTICS_OFF.

hwy/contrib/thread_pool/thread_pool.h has also been updated to use HWY_MEMBER_VAR_MAYBE_UNUSED instead of HWY_MAYBE_UNUSED for unused private class member variables to work around compiler warnings with GCC and Clang.

Also added a default case to `ToString(SpinType)` in hwy/contrib/thread_pool/spin.h to work around a compiler warning with GCC.