### PR TITLE
Fix for Timer::start() result truncation in thread_pool.h

### DIFF
--- a/hwy/contrib/thread_pool/thread_pool.h
+++ b/hwy/contrib/thread_pool/thread_pool.h
@@ -903,7 +903,7 @@ class alignas(HWY_ALIGNMENT) ThreadPool {
         // Uses the initial config, or the last one set during WorkerRun.
         CallWithConfig(worker_.NextConfig(), WorkerWait(), worker_);
 
-        const size_t before_run = timer::Start();
+        const uint64_t before_run = timer::Start();
         tasks_.WorkerRun(&worker_);
         stats_.NotifyWorkerRun(worker_.Index(), before_run, timer::Stop());
 


### PR DESCRIPTION
Updated `ThreadPool::ThreadFunc::operator()()` in thread_pool.h to change the type of `before_run` to `uint64_t` to fix a bug on 32-bit platforms (which triggers a GCC/Clang compiler warning on 32-bit platforms).