### PR TITLE
Use Lanes(d) masks for target SVE2_128

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -1,4 +1,5 @@
 // Copyright 2021 Google LLC
+// Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -391,6 +392,9 @@ HWY_API svbool_t PFalse() { return svpfalse_b(); }
 // arithmetic) can ignore d and use PTrue instead.
 template <class D>
 svbool_t MakeMask(D d) {
+#if (HWY_TARGET == HWY_SVE2_128)
+  return FirstN(d, Lanes(d));
+#endif
   return IsFull(d) ? PTrue(d) : FirstN(d, Lanes(d));
 }
 


### PR DESCRIPTION
In dynamic dispatching, Highway pushes function attributes such as "+sve" onto functions to compile them for specific targets.

Clang and GCC rely on the "-msve-vector-bits=128" option to specialize functions for 128 bit SVE vectors, but this flag applies specialized attributes at a compilation unit granularity, and therefore cannot be pushed to individual functions. The absence of this flag means useful information about the vector length of SVE2_128 functions can be lost to intermediate compiler languages such as LLVM IR.

Using Lanes(d) for SVE2_128 masked intrinsics gives compilers the ability to size the memory ranges affected by intrinsics. This aids the compiler in eliminating redundant load and stores by enabling alias-analysis optimizations.