### PR TITLE
Add -Wno-gnu-zero-variadic-macro-arguments to nowarn options.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,11 +23,14 @@ is_subproj = meson.is_subproject()
 tests_enabled = get_option('tests').disable_auto_if(is_subproj).allowed()
 examples_enabled = get_option('examples').disable_auto_if(is_subproj).allowed()
 
-hwy_nowarn_args = []
+cpp = meson.get_compiler('cpp')
+
+hwy_nowarn_args = cpp.get_supported_arguments([
+  '-Wno-gnu-zero-variadic-macro-arguments', # Disable gnu variadic macro warning.
+])
+
 hwy_cpp_args = []
 hwy_link_args = []
-
-cpp = meson.get_compiler('cpp')
 
 pkg = import('pkgconfig')
 


### PR DESCRIPTION
Check that the compiler supports it. Variadic macros of the form:
  FOO(a, b, c, ## __VA_ARGS__)

are a gnu extension, where an empty set of arguments will automatically supress the trailing comma. Clang supports this also, but if this flag isn't set it will generate a warning, and with -Werror, fail the build.

We know the usage is intentional and safe so disable these warnings.