### PR TITLE
Fix for -Wpragma-clang-attribute warning if VQSort is disabled

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -180,6 +180,17 @@ jobs:
             cxx_flags: -DHWY_DISABLED_TARGETS=0x58
             cxx_standard: 17
 
+          - name: Clang-18 (VQSort disabled)
+            extra_deps: clang-18
+            c_compiler: clang-18
+            cxx_compiler: clang++-18
+            # Disable AVX3_SPR/AVX3_ZEN4 targets in GitHub workflow build with
+            # Clang 16 or later to work around crashes that occur with Clang 16
+            # or later when some of the Google Highway tests are compiled with
+            # all x86 targets enabled
+            cxx_flags: -DHWY_DISABLED_TARGETS=0x58 -DHWY_DISABLE_VQSORT=1
+            cxx_standard: 17
+
           - name: Clang-18 (C++23)
             extra_deps: clang-18
             c_compiler: clang-18

--- a/hwy/contrib/sort/shared-inl.h
+++ b/hwy/contrib/sort/shared-inl.h
@@ -154,7 +154,8 @@ static_assert(SortConstants::MaxBufBytes<2>(64) <= 1664, "Unexpectedly high");
 #define VQSORT_COMPILER_COMPATIBLE 1
 #endif
 
-#if (HWY_TARGET == HWY_SCALAR) || !VQSORT_COMPILER_COMPATIBLE
+#if (HWY_TARGET == HWY_SCALAR) || !VQSORT_COMPILER_COMPATIBLE || \
+    defined(HWY_DISABLE_VQSORT)
 #define VQSORT_ENABLED 0
 #else
 #define VQSORT_ENABLED 1

--- a/hwy/contrib/sort/sorting_networks-inl.h
+++ b/hwy/contrib/sort/sorting_networks-inl.h
@@ -891,6 +891,16 @@ HWY_NOINLINE void SortingNetwork(Traits st, T* HWY_RESTRICT buf, size_t cols) {
 #else
 template <class Base>
 struct SharedTraits : public Base {};
+
+namespace detail {
+
+// Empty function to avoid a possible -Wpragma-clang-attribute warning if
+// compiling with Clang
+static HWY_INLINE HWY_MAYBE_UNUSED void HWY_CONCAT(UnusedSortingNetworksFunc,
+                                                   __LINE__)() {}
+
+}  // namespace detail
+
 #endif  // VQSORT_ENABLED
 
 }  // namespace detail


### PR DESCRIPTION
Resolves issue #2756.

Also updated hwy/contrib/sort/shared-inl.h to allow VQSort to be disabled if `HWY_DISABLE_VQSORT` is defined, even if the compiler and target support VQSort, to detect any compiler warnings or errors if `HWY_DISABLE_VQSORT` is defined.

Also updated GitHub workflow to build Highway with Clang 18 with VQSort disabled to ensure that Google Highway will successfully build if VQSort is disabled.