### PR TITLE
Updated SumOfMulQuadAccumulate to use [s]vusdot[q]_s32 on NEON_BF16/SVE2 plus I8MM fixes

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -6545,9 +6545,10 @@ HWY_API VFromD<DU32> SumOfMulQuadAccumulate(DU32 /*du32*/, svuint8_t a,
 template <class DI32, HWY_IF_I32_D(DI32)>
 HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 di32, svuint8_t a_u,
                                             svint8_t b_i, svint32_t sum) {
-  // TODO: use svusdot_u32 on SVE targets that require support for both SVE2
-  // and SVE I8MM.
-
+#if HWY_SVE_HAVE_2
+  (void)di32;
+  return svusdot_s32(sum, a_u, b_i);
+#else
   const RebindToUnsigned<decltype(di32)> du32;
   const Repartition<uint8_t, decltype(di32)> du8;
 
@@ -6557,6 +6558,7 @@ HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 di32, svuint8_t a_u,
       ShiftLeft<8>(svdot_u32(Zero(du32), a_u, ShiftRight<7>(b_u)));
 
   return BitCast(di32, Sub(result_sum0, result_sum1));
+#endif
 }
 
 #ifdef HWY_NATIVE_I16_I16_SUMOFMULQUADACCUMULATE

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -617,6 +617,8 @@
 #define HWY_HAVE_SCALABLE 1
 #endif
 
+#define HWY_TARGET_STR_I8MM "+i8mm"
+
 // Can use pragmas instead of -march compiler flag
 #if HWY_HAVE_RUNTIME_DISPATCH
 #if HWY_TARGET == HWY_SVE2 || HWY_TARGET == HWY_SVE2_128
@@ -628,7 +630,7 @@
 #define HWY_TARGET_STR "+sve2,+sve" HWY_TARGET_STR_I8MM
 #endif
 #else  // not SVE2 target
-#define HWY_TARGET_STR "+sve" HWY_TARGET_STR_I8MM
+#define HWY_TARGET_STR "+sve"
 #endif
 #else  // !HWY_HAVE_RUNTIME_DISPATCH
 // HWY_TARGET_STR remains undefined

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -494,7 +494,8 @@ static int64_t DetectTargets() {
     if ((HasCpuFeature("hw.optional.AdvSIMD_HPFPCvt") ||
          HasCpuFeature("hw.optional.arm.AdvSIMD_HPFPCvt")) &&
         HasCpuFeature("hw.optional.arm.FEAT_DotProd") &&
-        HasCpuFeature("hw.optional.arm.FEAT_BF16")) {
+        HasCpuFeature("hw.optional.arm.FEAT_BF16") &&
+        HasCpuFeature("hw.optional.arm.FEAT_I8MM")) {
       bits |= HWY_NEON_BF16;
     }
   }


### PR DESCRIPTION
Updated SumOfMulQuadAccumulate(DI32, VU8, VI8, VI32) to use svusdotq_s32 on SVE2 targets and vusdot[q]_s32 on the NEON_BF16 target.

Also fixed hwy/ops/set_macros-inl.h to ensure that HWY_TARGET_STR_I8MM macro is defined on SVE targets to avoid compilation errors if no NEON targets are enabled (such as in scenarios where only static dispatch is used).

Also updated macOS NEON_BF16 detection to check for the `hw.optional.arm.FEAT_I8MM` feature.

According to AArch64 CPU feature information at https://github.com/hrw/arm-socs-table/, https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64Processors.td, and https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64Features.td, the Fujitsu A64FX supports SVE but not I8MM or BF16. On the other hand, the Neoverse V1 supports SVE, I8MM, BF16, but not SVE2.
