### PR TITLE
Updated AVX10.2 implementation of SumsOfAdjQuadAbsDiff

### DIFF
--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2113,8 +2113,8 @@ HWY_INLINE Vec256<uint32_t> SumsOf4(hwy::UnsignedTag /*type_tag*/,
 // ------------------------------ SumsOfAdjQuadAbsDiff
 
 template <int kAOffset, int kBOffset>
-static Vec256<uint16_t> SumsOfAdjQuadAbsDiff(Vec256<uint8_t> a,
-                                             Vec256<uint8_t> b) {
+HWY_API Vec256<uint16_t> SumsOfAdjQuadAbsDiff(Vec256<uint8_t> a,
+                                              Vec256<uint8_t> b) {
   static_assert(0 <= kAOffset && kAOffset <= 1,
                 "kAOffset must be between 0 and 1");
   static_assert(0 <= kBOffset && kBOffset <= 3,


### PR DESCRIPTION
Updated the Vec512 implementation of SumsOfAdjQuadAbsDiff on the AVX10_2 target to use _mm512_mpsadbw_epu8 as AVX10.2 now has support for VMPSADBW for 512-bit vectors (VMPSADBW for 256-bit vectors was introduced in AVX2 and MPSADBW for 128-bit vectors was introduced in SSE4.1).