### PR TITLE
Fix SVE2_128 MakeMask to avoid duplicate return statement

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -398,10 +398,10 @@ HWY_API svbool_t PFalse() { return svpfalse_b(); }
 // equal minimum and maximum vector lengths as SVE2_128 can.
 template <class D>
 svbool_t MakeMask(D d) {
-#if (HWY_TARGET == HWY_SVE2_128)
-  return FirstN(d, Lanes(d));
+#if HWY_TARGET != HWY_SVE2_128
+  HWY_IF_CONSTEXPR(IsFull(d)) { return PTrue(d); }
 #endif
-  return IsFull(d) ? PTrue(d) : FirstN(d, Lanes(d));
+  return FirstN(d, Lanes(d));
 }
 
 }  // namespace detail


### PR DESCRIPTION
Updated MakeMask to avoid duplicate return statement on SVE2_128.

Also refactored the `IsFull(d)` case to use `HWY_IF_CONSTEXPR(IsFull(d)) { return PTrue(d); }` for SVE targets other than SVE2_128.