### PR TITLE
add document so clangd users can manually add the missing `__CLANGD__` macro to fix the `HWY_IDE` macro

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2802,10 +2802,10 @@ instead of `HWY_HAVE_FLOAT64`, which describes the current target.
 
 *   `HWY_IDE` is 0 except when parsed by IDEs; adding it to conditions such as
     `#if HWY_TARGET != HWY_SCALAR || HWY_IDE` avoids code appearing greyed out.\
-    Note for clangd users: [there is no predefined macros in clangd](https://github.com/clangd/clangd/issues/581), so you must
-    manually add `__CLANGD__` macro so we can detect the presence of clangd.
-    This can be easily done by adding a `.clangd` file in your project root and
-    add these two lines:
+    Note for clangd users: [there is no predefined macros in clangd](https://github.com/clangd/clangd/issues/581),
+    so you must manually add `__CLANGD__` macro so we can detect the presence of
+    clangd. This can be easily done by adding these two lines to your project's 
+    `.clangd` file:
     ```
     CompileFlags:
       Add: [-D__CLANGD__]

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -21,8 +21,8 @@
 
 // Add to #if conditions to prevent IDE from graying out code.
 // Note for clangd users: There is no predefined macro in clangd, so you must
-// manually create a `.clangd` file in your project root and add these two
-// lines (without the preceding '// '):
+// manually add these two lines (without the preceding '// ') to your project's
+// `.clangd` file:
 // CompileFlags:
 //   Add: [-D__CLANGD__]
 #if (defined __CDT_PARSER__) || (defined __INTELLISENSE__) || \


### PR DESCRIPTION
clangd does not have any predefined macro: https://github.com/clangd/clangd/issues/581

The `HWY_IDE` macro is defined as:

```cpp
// Add to #if conditions to prevent IDE from graying out code.
#if (defined __CDT_PARSER__) || (defined __INTELLISENSE__) || \
    (defined Q_CREATOR_RUN) || (defined __CLANGD__) ||        \
    (defined GROK_ELLIPSIS_BUILD)
#define HWY_IDE 1
#else
#define HWY_IDE 0
#endif
```

so clangd users must manually add `__CLANGD__` macro. This commit add this information in the doc and comment.

this fixes the https://github.com/google/highway/issues/2789