### PR TITLE
Made enhancements to PopulationCount

### DIFF
--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -560,6 +560,19 @@ HWY_API Vec128<T, N> operator^(Vec128<T, N> a, Vec128<T, N> b) {
   return Xor(a, b);
 }
 
+// ------------------------------ PopulationCount
+
+#ifdef HWY_NATIVE_POPCNT
+#undef HWY_NATIVE_POPCNT
+#else
+#define HWY_NATIVE_POPCNT
+#endif
+
+template <typename T, size_t N, HWY_IF_UNSIGNED(T)>
+HWY_API Vec128<T, N> PopulationCount(Vec128<T, N> v) {
+  return Vec128<T, N>{vec_popcnt(v.raw)};
+}
+
 // ================================================== SIGN
 
 // ------------------------------ Neg

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -5266,18 +5266,6 @@ HWY_API VFromD<D> Dup128VecFromValues(D d, TFromD<D> t0, TFromD<D> t1,
                               detail::Vec64ValsWrapper<TFromD<D>>{{t2, t3}})));
 }
 
-// ------------------------------ PopulationCount (ShiftRight)
-
-// Handles LMUL < 2 or capped vectors, which generic_ops-inl cannot.
-template <typename V, class D = DFromV<V>, HWY_IF_U8_D(D),
-          hwy::EnableIf<D().Pow2() < 1 || D().MaxLanes() < 16>* = nullptr>
-HWY_API V PopulationCount(V v) {
-  // See https://arxiv.org/pdf/1611.07612.pdf, Figure 3
-  v = Sub(v, detail::AndS(ShiftRight<1>(v), 0x55));
-  v = Add(detail::AndS(ShiftRight<2>(v), 0x33), detail::AndS(v, 0x33));
-  return detail::AndS(Add(v, ShiftRight<4>(v)), 0x0F);
-}
-
 // ------------------------------ LoadDup128
 
 template <class D>


### PR DESCRIPTION
Updated U8 PopulationCount on RVV to use table lookup using TableLookupLanes for all LMUL values as `v` will be resized to a U8 vector with a LMUL of 1 if the LMUL of `v` is less than 1 to allow the entire lookup table to be used.

Also removed the U8 PopulationCount implementation in rvv-inl.h for vectors that have a LMUL <= 1 as the updated implementation of PopulationCount in this pull request can deal with LMUL <= 1 U8 vectors.

Also updated PPC/Z14/Z15 PopulationCount to use the vec_popcnt intrinsic as PPC8/Z14 have vector population count instructions.

Also updated PopulationCount on SSE2 to avoid table lookup as SSE2 lacks table lookup instructions.