### PR TITLE
Use `Sub` instead of `operator-` to support SVE vectors

### DIFF
--- a/hwy/examples/benchmark.cc
+++ b/hwy/examples/benchmark.cc
@@ -186,7 +186,7 @@ struct BenchmarkDelta : public TwoArray {
     for (; i < num_items; i += N) {
       const auto a = Load(df, &a_[i]);
       const auto shifted = LoadU(df, &a_[i - 1]);
-      Store(a - shifted, df, &b_[i]);
+      Store(Sub(a, shifted), df, &b_[i]);
     }
 #else  // 128-bit
     // Slightly better than unaligned loads


### PR DESCRIPTION
Fixes this compilation error on AArch64 (GCC 14):
```
[ 20%] Building CXX object CMakeFiles/hwy_benchmark.dir/hwy/examples/benchmark.cc.o
In file included from highway/hwy/foreach_target.h:218,
                 from highway/hwy/examples/benchmark.cc:26:
highway/hwy/examples/benchmark.cc: In member function ‘hwy::FuncOutput hwy::N_SVE_256::{anonymous}::BenchmarkDelta::operator()(size_t) const’:
highway/hwy/examples/benchmark.cc:189:15: error: invalid operands of types ‘const __SVFloat32_t’ and ‘const __SVFloat32_t’ to binary ‘operator-’
  189 |       Store(a - shifted, df, &b_[i]);
      |             ~ ^ ~~~~~~~
      |             |   |
      |             |   const __SVFloat32_t
      |             const __SVFloat32_t
```
Not entirely sure why this has started failing now...