### PR TITLE
Use svbfdot for ReorderWidenMulAccumulate

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -7352,6 +7352,9 @@ static HWY_INLINE bfloat16x8_t BitCastToRawNeonBF16(bfloat16x8_t raw) {
 // The uint16x4_t or uint16x8_t vector neets to be bitcasted to a bfloat16x4_t
 // or a bfloat16x8_t vector for the vbfdot_f32 and vbfdotq_f32 intrinsics if
 // HWY_NEON_HAVE_F32_TO_BF16C && !HWY_NEON_HAVE_BFLOAT16 is true
+
+// NOTE: vbfdot uses round to odd unless the additional FEAT_EBF16 feature is
+// available and enabled.
 static HWY_INLINE bfloat16x4_t BitCastToRawNeonBF16(uint16x4_t raw) {
   return vreinterpret_bf16_u16(raw);
 }

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -6474,6 +6474,8 @@ HWY_API svfloat32_t MulOddAdd(Simd<float, N, kPow2> /* d */, VBF16 a, VBF16 b,
   return svbfmlalt_f32(c, a, b);
 }
 
+// NOTE: svbfdot uses round to odd unless the additional FEAT_EBF16 feature is
+// available and enabled.
 template <size_t N, int kPow2>
 HWY_API svfloat32_t ReorderWidenMulAccumulate(Simd<float, N, kPow2> d32,
                                               svbfloat16_t a, svbfloat16_t b,


### PR DESCRIPTION
A comment claims there is a difference between SVE and NEON's rounding behaviour for BFDOT. According to the arm developer documentation, both instruction sets have the same rounding to odd behaviour by default when FEAT_EBF16 is not implemented or FPCR.EBF is 0:

https://developer.arm.com/documentation/ddi0602/2025-09/SIMD-FP-Instructions/BFDOT--vector---BFloat16-dot-product-to-single-precision--vector-- https://developer.arm.com/documentation/ddi0602/2025-09/SVE-Instructions/BFDOT--vectors---BFloat16-dot-product-to-single-precision-