### PR TITLE
Move i8mm AArch64 intrinsics behind compiler options

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -1,4 +1,5 @@
 // Copyright 2021 Google LLC
+// Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,7 +93,7 @@
 #define HWY_SVE2 (1LL << 23)
 #define HWY_SVE (1LL << 24)
 // Bit 25 reserved for NEON
-#define HWY_NEON_BF16 (1LL << 26)  // fp16/dot/bf16/i8mm (e.g. Neoverse V2/N2)
+#define HWY_NEON_BF16 (1LL << 26)  // fp16/dot/bf16 (e.g. Neoverse V2/N2)
 // Bit 27 reserved for NEON
 #define HWY_NEON (1LL << 28)  // Implies support for AES
 #define HWY_NEON_WITHOUT_AES (1LL << 29)

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -6555,7 +6555,7 @@ HWY_API VFromD<DU32> SumOfMulQuadAccumulate(DU32 /*du32*/, svuint8_t a,
 template <class DI32, HWY_IF_I32_D(DI32)>
 HWY_API VFromD<DI32> SumOfMulQuadAccumulate(DI32 di32, svuint8_t a_u,
                                             svint8_t b_i, svint32_t sum) {
-#if HWY_SVE_HAVE_2
+#if HWY_SVE_HAVE_2 && __ARM_FEATURE_MATMUL_INT8
   (void)di32;
   return svusdot_s32(sum, a_u, b_i);
 #else

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -1,5 +1,5 @@
 // Copyright 2020 Google LLC
-// Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: BSD-3-Clause
 //
@@ -555,8 +555,6 @@
 #define HWY_TARGET_STR_FP16 "+fp16"
 #endif
 
-#define HWY_TARGET_STR_I8MM "+i8mm"
-
 #if HWY_TARGET == HWY_NEON_WITHOUT_AES
 #if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400
 // Prevents inadvertent use of SVE by GCC 13.4 and earlier, see #2689.
@@ -568,7 +566,7 @@
 #define HWY_TARGET_STR HWY_TARGET_STR_NEON
 #elif HWY_TARGET == HWY_NEON_BF16
 #define HWY_TARGET_STR \
-  HWY_TARGET_STR_FP16 HWY_TARGET_STR_I8MM "+bf16+dotprod" HWY_TARGET_STR_NEON
+  HWY_TARGET_STR_FP16 "+bf16+dotprod" HWY_TARGET_STR_NEON
 #else
 #error "Logic error, missing case"
 #endif  // HWY_TARGET
@@ -619,17 +617,15 @@
 #define HWY_HAVE_SCALABLE 1
 #endif
 
-#define HWY_TARGET_STR_I8MM "+i8mm"
-
 // Can use pragmas instead of -march compiler flag
 #if HWY_HAVE_RUNTIME_DISPATCH
 #if HWY_TARGET == HWY_SVE2 || HWY_TARGET == HWY_SVE2_128
 // Static dispatch with -march=armv8-a+sve2+aes, or no baseline, hence dynamic
 // dispatch, which checks for AES support at runtime.
 #if defined(__ARM_FEATURE_SVE2_AES) || (HWY_BASELINE_SVE2 == 0)
-#define HWY_TARGET_STR "+sve2+sve2-aes,+sve" HWY_TARGET_STR_I8MM
+#define HWY_TARGET_STR "+sve2+sve2-aes,+sve"
 #else  // SVE2 without AES
-#define HWY_TARGET_STR "+sve2,+sve" HWY_TARGET_STR_I8MM
+#define HWY_TARGET_STR "+sve2,+sve"
 #endif
 #else  // not SVE2 target
 #define HWY_TARGET_STR "+sve"

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -445,10 +446,6 @@ static int64_t DetectTargets() {
 #elif HWY_ARCH_ARM && HWY_HAVE_RUNTIME_DISPATCH
 namespace arm {
 
-#ifndef HWCAP2_I8MM
-#define HWCAP2_I8MM (1 << 13)
-#endif
-
 #if HWY_ARCH_ARM_A64 && !HWY_OS_APPLE &&        \
     (HWY_COMPILER_GCC || HWY_COMPILER_CLANG) && \
     ((HWY_TARGETS & HWY_ALL_SVE) != 0)
@@ -494,8 +491,7 @@ static int64_t DetectTargets() {
     if ((HasCpuFeature("hw.optional.AdvSIMD_HPFPCvt") ||
          HasCpuFeature("hw.optional.arm.AdvSIMD_HPFPCvt")) &&
         HasCpuFeature("hw.optional.arm.FEAT_DotProd") &&
-        HasCpuFeature("hw.optional.arm.FEAT_BF16") &&
-        HasCpuFeature("hw.optional.arm.FEAT_I8MM")) {
+        HasCpuFeature("hw.optional.arm.FEAT_BF16")) {
       bits |= HWY_NEON_BF16;
     }
   }
@@ -508,7 +504,7 @@ static int64_t DetectTargets() {
 #if defined(HWCAP_ASIMDHP) && defined(HWCAP_ASIMDDP) && defined(HWCAP2_BF16)
     const CapBits hw2 = getauxval(AT_HWCAP2);
     constexpr CapBits kGroupF16Dot = HWCAP_ASIMDHP | HWCAP_ASIMDDP;
-    constexpr CapBits kGroupBF16 = HWCAP2_BF16 | HWCAP2_I8MM;
+    constexpr CapBits kGroupBF16 = HWCAP2_BF16;
     if ((hw & kGroupF16Dot) == kGroupF16Dot &&
         (hw2 & kGroupBF16) == kGroupBF16) {
       bits |= HWY_NEON_BF16;
@@ -529,11 +525,7 @@ static int64_t DetectTargets() {
 #ifndef HWCAP2_SVEAES
 #define HWCAP2_SVEAES (1 << 2)
 #endif
-#ifndef HWCAP2_SVEI8MM
-#define HWCAP2_SVEI8MM (1 << 9)
-#endif
-  constexpr CapBits kGroupSVE2 =
-      HWCAP2_SVE2 | HWCAP2_SVEAES | HWCAP2_SVEI8MM | HWCAP2_I8MM;
+  constexpr CapBits kGroupSVE2 = HWCAP2_SVE2 | HWCAP2_SVEAES;
   const CapBits hw2 = getauxval(AT_HWCAP2);
   if ((hw2 & kGroupSVE2) == kGroupSVE2) {
     bits |= HWY_SVE2;


### PR DESCRIPTION
+bf16 and +i8mm have no relationship, but hardware that does not have access to +i8mm will be barred from using the target HWY_NEON_BF16.

This patch moves vusdotq and vusdot to be gated behind compile time options, similar to how svbfmlalb and svbfmlalt are gated behind +bf16 for the target HWY_SVE2 with HWY_SVE_HAVE_BF16_FEATURE.