### PR TITLE
Dont include CTest if HWY_ENABLE_TESTS is off.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,9 +756,10 @@ endif()  # HWY_ENABLE_CONTRIB
 endif()  # HWY_ENABLE_EXAMPLES
 # -------------------------------------------------------- Tests
 
+if(HWY_ENABLE_TESTS)
 include(CTest)
 
-if(BUILD_TESTING AND HWY_ENABLE_TESTS)
+if(BUILD_TESTING)
 enable_testing()
 include(GoogleTest)
 
@@ -952,6 +953,7 @@ endforeach ()
 target_sources(skeleton_test PRIVATE hwy/examples/skeleton.cc)
 
 endif()  # BUILD_TESTING
+endif()  # HWY_ENABLE_TESTS
 
 if (HWY_ENABLE_INSTALL)
   # write hwy-config file to handle `Config` mode


### PR DESCRIPTION
Introduces [the change proposed](https://github.com/google/highway/issues/2833#issuecomment-3705075551) by jan-wassenberg

This change avoids including CTest or creating unused testing targets when HWY_ENABLE_TESTS is off.

Fixes #2833

## Testing done:

1. Ran `cmake -B my_build -S . -G "Visual Studio 17 2022"`
2. Opened the visual studio solution
3. ✅ All test projects were in the solution (including the CTest generated Continuous, Experimental, etc.)
4. Ran `cmake -B my_build -S . -DHWY_ENABLE_TESTS=OFF  -G "Visual Studio 17 2022"`
5. Opened the visual studio solution
6. ✅ No test projects were in the solution (including the CTest generated Continuous, Experimental, etc.)

<img width="364" height="1254" alt="Screenshot 2026-01-03 142846" src="https://github.com/user-attachments/assets/456c106f-4d87-4f33-a434-3da2212f1ab5" />
<img width="370" height="1252" alt="Screenshot 2026-01-03 142925" src="https://github.com/user-attachments/assets/17f9f21e-ff9b-436d-a13e-2847b63a1ca9" />

