### PR TITLE
Optimize auto-detection of `HWY_ARCH_WASM` target

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -390,6 +390,13 @@ You can detect and influence the set of supported targets:
     order to test each supported target. Calling with `b == 0` restores the
     normal `SupportedTargets` behavior.
 
+**Note on `HWY_ARCH_WASM`**. The target is automatically detected and enabled;
+compiler flags such as -msimd128 are not required. This auto-detection
+behavior is consistent with other architectures (e.g., AVX2, NEON).
+Developers wishing to disable the `HWY_ARCH_WASM` target (e.g., to increase
+browser compatibility, or workaround compiler bugs) should use the
+`HWY_DISABLED_TARGETS` macro.
+
 ## Operations
 
 In the following, the argument or return type `V` denotes a vector with `N`
@@ -2908,6 +2915,13 @@ binary will likely crash. This can only happen if:
 *   the baseline does not include the enabled/attainable target(s), which are
     also not supported by the current CPU, and baseline targets (in particular
     `HWY_SCALAR`) were explicitly disabled.
+
+**Note on WebAssembly:**: The browser validates the WebAssembly module during
+instantiation when using `WebAssembly.instantiate` APIs. If SIMD features are
+unsupported, the entire module is rejected. Therefore, dynamic dispatch between
+targets (such as `HWY_SCALAR` and `HWY_WASM`) based on runtime feature detection
+is not feasible, unlike with native targets. Developers should configure the
+`HWY_ARCH_WASM` target at compile time using the `HWY_DISABLED_TARGETS` macro.
 
 ## Advanced configuration macros
 

--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -290,6 +290,10 @@
 #define HWY_ARCH_ARM_OLD 0
 #endif
 
+// Note: The WASM target is auto-detected and enabled; compiler flags like
+// "-msimd128" are not required. This behavior is consistent with other
+// architectures (e.g., AVX2, NEON). To disable HWY_ARCH_WASM, use the
+// HWY_DISABLED_TARGETS macro. For details, see the quick reference manual.
 #if defined(__EMSCRIPTEN__) || defined(__wasm__) || defined(__WASM__)
 #define HWY_ARCH_WASM 1
 #else

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -431,7 +431,7 @@
 // Also check HWY_ARCH to ensure that simulating unknown platforms ends up with
 // HWY_TARGET == HWY_BASELINE_SCALAR.
 
-#if HWY_ARCH_WASM && defined(__wasm_simd128__)
+#if HWY_ARCH_WASM
 #if defined(HWY_WANT_WASM2)
 #define HWY_BASELINE_WASM HWY_WASM_EMU256
 #else


### PR DESCRIPTION
1. removed check for `__wasm_simd128__` macro
2. add documentation in `quick_reference.md` at `Targets` and `Detecting supported targets` section.


As discussed in #2831