### PR TITLE
Detect when using a JetBrains IDE and set `HWY_IDE` accordingly

### DIFF
--- a/hwy/detect_compiler_arch.h
+++ b/hwy/detect_compiler_arch.h
@@ -27,7 +27,7 @@
 //   Add: [-D__CLANGD__]
 #if (defined __CDT_PARSER__) || (defined __INTELLISENSE__) || \
     (defined Q_CREATOR_RUN) || (defined __CLANGD__) ||        \
-    (defined GROK_ELLIPSIS_BUILD)
+    (defined GROK_ELLIPSIS_BUILD) || (defined __JETBRAINS_IDE__)
 #define HWY_IDE 1
 #else
 #define HWY_IDE 0


### PR DESCRIPTION
This prevents newer versions of CLion from getting very confused and showing a sea of errors when editing files that use multi-target compilation.

Could also have used `__CLION_IDE__`, but this is subsumed by the `__JETBRAINS_IDE__` definition, so using the latter instead.

Btw this is the only place I've seen "Lisp-style" `(defined FOO)` in the code, but I kept it consistent in case it's done for a reason 👀 