### PR TITLE
Use DotProd and I8MM for NEON targets if enabled on macOS/iOS/iPadOS

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -7651,7 +7651,8 @@ HWY_API Vec32<uint32_t> RearrangeToOddPlusEven(Vec32<uint32_t> sum0,
 
 // ------------------------------ SumOfMulQuadAccumulate
 
-#if HWY_TARGET == HWY_NEON_BF16
+#if HWY_TARGET == HWY_NEON_BF16 || \
+    (HWY_OS_APPLE && HWY_ARCH_ARM_A64 && defined(__ARM_FEATURE_DOTPROD))
 
 #ifdef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
 #undef HWY_NATIVE_I8_I8_SUMOFMULQUADACCUMULATE
@@ -7701,7 +7702,9 @@ HWY_API VFromD<DU32> SumOfMulQuadAccumulate(
 #define HWY_NATIVE_U8_I8_SUMOFMULQUADACCUMULATE
 #endif
 
-#ifdef __ARM_FEATURE_MATMUL_INT8
+#if defined(__ARM_FEATURE_MATMUL_INT8) ||                               \
+    (HWY_TARGET == HWY_NEON_BF16 && HWY_OS_APPLE && HWY_ARCH_ARM_A64 && \
+     HWY_HAVE_RUNTIME_DISPATCH)
 
 template <class DI32, HWY_IF_I32_D(DI32), HWY_IF_V_SIZE_LE_D(DI32, 8)>
 HWY_API VFromD<DI32> SumOfMulQuadAccumulate(

--- a/hwy/ops/set_macros-inl.h
+++ b/hwy/ops/set_macros-inl.h
@@ -557,6 +557,14 @@
 #define HWY_TARGET_STR_FP16 "+fp16"
 #endif
 
+#if HWY_OS_APPLE
+// Enable i8mm for the NEON_BF16 target if compiling for macOS, iOS, or iPadOS
+// as all Apple Silicon CPU's that support BF16 have support for I8MM.
+#define HWY_TARGET_STR_NEON_BF16_EXTRA "+i8mm"
+#else
+#define HWY_TARGET_STR_NEON_BF16_EXTRA ""
+#endif
+
 #if HWY_TARGET == HWY_NEON_WITHOUT_AES
 #if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400
 // Prevents inadvertent use of SVE by GCC 13.4 and earlier, see #2689.
@@ -568,7 +576,8 @@
 #define HWY_TARGET_STR HWY_TARGET_STR_NEON
 #elif HWY_TARGET == HWY_NEON_BF16
 #define HWY_TARGET_STR \
-  HWY_TARGET_STR_FP16 "+bf16+dotprod" HWY_TARGET_STR_NEON
+  HWY_TARGET_STR_FP16  \
+      "+bf16+dotprod" HWY_TARGET_STR_NEON_BF16_EXTRA HWY_TARGET_STR_NEON
 #else
 #error "Logic error, missing case"
 #endif  // HWY_TARGET

--- a/hwy/targets.cc
+++ b/hwy/targets.cc
@@ -491,7 +491,8 @@ static int64_t DetectTargets() {
     if ((HasCpuFeature("hw.optional.AdvSIMD_HPFPCvt") ||
          HasCpuFeature("hw.optional.arm.AdvSIMD_HPFPCvt")) &&
         HasCpuFeature("hw.optional.arm.FEAT_DotProd") &&
-        HasCpuFeature("hw.optional.arm.FEAT_BF16")) {
+        HasCpuFeature("hw.optional.arm.FEAT_BF16") &&
+        HasCpuFeature("hw.optional.arm.FEAT_I8MM")) {
       bits |= HWY_NEON_BF16;
     }
   }


### PR DESCRIPTION
AppleClang will enable the AArch64 FP16 and DotProd extensions by default if compiling for Apple Silicon Macs as all Apple Silicon Macs (but not some older iPad or iPhone models with AArch64 CPU's) have Apple Silicon CPU's that support FP16 and DotProd.

Updated SumOfMulQuadAccumulate in hwy/ops/arm_neon-inl.h to use DotProd if compiling for iOS/macOS/iPadOS on AArch64 and __ARM_FEATURE_DOTPROD is defined as DotProd will be enabled by default if compiling with AppleClang for macOS on Apple Silicon Macs.

Also enabled I8MM for the NEON_BF16 target if compiling for iOS/macOS/iPadOS on Apple Silicon and runtime dispatch is enabled since all Apple Silicon CPU's that support BF16 also support I8MM according to https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64Processors.td.