### PR TITLE
Fix Intel intrinsics typos.

### DIFF
--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -6855,7 +6855,7 @@ HWY_API VFromD<D> DemoteTo(D /* tag */, Vec256<double> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec256<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm256_cvtts_pd_epi32(v.raw)};
+  return VFromD<D>{_mm256_cvttpd_epi32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm256_cvttpd_epi32 with GCC if any
   // values of v[i] are not within the range of an int32_t
@@ -6887,7 +6887,7 @@ HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec256<double> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 16), HWY_IF_U32_D(D)>
 HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec256<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm256_cvtts_pd_epu32(v.raw)};
+  return VFromD<D>{_mm256_cvttpd_epu32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm256_cvttpd_epu32 with GCC if any
   // values of v[i] are not within the range of an uint32_t
@@ -7184,7 +7184,7 @@ HWY_API VFromD<D> ConvertInRangeTo(D /* tag */, VFromD<RebindToFloat<D>> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> ConvertInRangeTo(D /*d*/, Vec256<float> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm256_cvtts_ps_epi32(v.raw)};
+  return VFromD<D>{_mm256_cvttps_epi32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm256_cvttps_epi32 with GCC if any
   // values of v[i] are not within the range of an int32_t
@@ -7220,7 +7220,7 @@ HWY_API VFromD<D> ConvertInRangeTo(D /*d*/, Vec256<float> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_I64_D(D)>
 HWY_API VFromD<D> ConvertInRangeTo(D /*di*/, Vec256<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm256_cvtts_pd_epi64(v.raw)};
+  return VFromD<D>{_mm256_cvttpd_epi64(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm256_cvttpd_epi64 with GCC if any
   // values of v[i] are not within the range of an int64_t

--- a/hwy/ops/x86_512-inl.h
+++ b/hwy/ops/x86_512-inl.h
@@ -5929,7 +5929,7 @@ HWY_API VFromD<D> DemoteTo(D /* tag */, Vec512<double> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec512<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm512_cvtts_pd_epi32(v.raw)};
+  return VFromD<D>{_mm512_cvttpd_epi32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm512_cvttpd_epi32 with GCC if any
   // values of v[i] are not within the range of an int32_t
@@ -5966,7 +5966,7 @@ HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec512<double> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 32), HWY_IF_U32_D(D)>
 HWY_API VFromD<D> DemoteInRangeTo(D /* tag */, Vec512<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm512_cvtts_pd_epu32(v.raw)};
+  return VFromD<D>{_mm512_cvttpd_epu32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm512_cvttpd_epu32 with GCC if any
   // values of v[i] are not within the range of an uint32_t
@@ -6314,7 +6314,7 @@ HWY_API VFromD<D> ConvertInRangeTo(D /* tag */, VFromD<RebindToFloat<D>> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 64), HWY_IF_I32_D(D)>
 HWY_API VFromD<D> ConvertInRangeTo(D /*d*/, Vec512<float> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm512_cvtts_ps_epi32(v.raw)};
+  return VFromD<D>{_mm512_cvttps_epi32(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm512_cvttps_epi32 with GCC if any
   // values of v[i] are not within the range of an int32_t
@@ -6356,7 +6356,7 @@ HWY_API VFromD<D> ConvertInRangeTo(D /*d*/, Vec512<float> v) {
 template <class D, HWY_IF_V_SIZE_D(D, 64), HWY_IF_I64_D(D)>
 HWY_API VFromD<D> ConvertInRangeTo(D /*di*/, Vec512<double> v) {
 #if HWY_X86_HAVE_AVX10_2_OPS
-  return VFromD<D>{_mm512_cvtts_pd_epi64(v.raw)};
+  return VFromD<D>{_mm512_cvttpd_epi64(v.raw)};
 #elif HWY_COMPILER_GCC_ACTUAL
   // Workaround for undefined behavior in _mm512_cvttpd_epi64 with GCC if any
   // values of v[i] are not within the range of an int64_t


### PR DESCRIPTION
Resolves the following compiler errors. Related: https://github.com/google/highway/pull/2695/

Note that for each of these intrinsics, the new name matches the name in the comment a few lines later and the name suggested by clang.

```console
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=x86_64-none-linux-android28 --sysroot=/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DHWY_STATIC_DEFINE -DTOOLCHAIN_MISS_ASM_HWCAP_H -I/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info    -std=c++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wno-builtin-macro-redefined -D__DATE__=\"redacted\" -D__TIMESTAMP__=\"redacted\" -D__TIME__=\"redacted\" -fmerge-all-constants -Wall -Wextra -Wconversion -Wsign-conversion -Wvla -Wnon-virtual-dtor -Wcast-align -Wfloat-overflow-conversion -Wfloat-zero-conversion -Wfor-loop-analysis -Wgnu-redeclared-enum -Winfinite-recursion -Wself-assign -Wstring-conversion -Wtautological-overlap-compare -Wthread-safety-analysis -Wundefined-func-template -fno-cxx-exceptions -fno-slp-vectorize -fno-vectorize -fdiagnostics-show-option -fcolor-diagnostics -Wc++2a-extensions -fmath-errno -fno-exceptions -Wno-psabi -MD -MT CMakeFiles/hwy.dir/hwy/per_target.cc.o -MF CMakeFiles/hwy.dir/hwy/per_target.cc.o.d -o CMakeFiles/hwy.dir/hwy/per_target.cc.o -c /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:84:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_256-inl.h:6922:20: error: use of undeclared identifier '_mm256_cvtts_pd_epi32'; did you mean '_mm256_cvttspd_epi32'?
 6922 |   return VFromD<D>{_mm256_cvtts_pd_epi32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm256_cvttspd_epi32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2satcvtdsintrin.h:93:1: note: '_mm256_cvttspd_epi32' declared here
   93 | _mm256_cvttspd_epi32(__m256d __A) {
      | ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:84:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_256-inl.h:6954:20: error: use of undeclared identifier '_mm256_cvtts_pd_epu32'; did you mean '_mm256_cvttspd_epu32'?
 6954 |   return VFromD<D>{_mm256_cvtts_pd_epu32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm256_cvttspd_epu32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2satcvtdsintrin.h:145:1: note: '_mm256_cvttspd_epu32' declared here
  145 | _mm256_cvttspd_epu32(__m256d __A) {
      | ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:84:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_256-inl.h:7251:20: error: use of undeclared identifier '_mm256_cvtts_ps_epi32'; did you mean '_mm256_cvttsps_epi32'?
 7251 |   return VFromD<D>{_mm256_cvtts_ps_epi32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm256_cvttsps_epi32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2satcvtdsintrin.h:302:1: note: '_mm256_cvttsps_epi32' declared here
  302 | _mm256_cvttsps_epi32(__m256 __A) {
      | ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:84:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_256-inl.h:7287:20: error: use of undeclared identifier '_mm256_cvtts_pd_epi64'; did you mean '_mm256_cvttspd_epi64'?
 7287 |   return VFromD<D>{_mm256_cvtts_pd_epi64(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm256_cvttspd_epi64
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2satcvtdsintrin.h:197:1: note: '_mm256_cvttspd_epi64' declared here
  197 | _mm256_cvttspd_epi64(__m256d __A) {
      | ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:5901:20: error: use of undeclared identifier '_mm512_cvtts_pd_epi32'; did you mean '_mm512_cvttspd_epi32'?
 5901 |   return VFromD<D>{_mm512_cvtts_pd_epi32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm512_cvttspd_epi32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2_512satcvtdsintrin.h:23:46: note: '_mm512_cvttspd_epi32' declared here
   23 | static __inline__ __m256i __DEFAULT_FN_ATTRS _mm512_cvttspd_epi32(__m512d __A) {
      |                                              ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:5938:20: error: use of undeclared identifier '_mm512_cvtts_pd_epu32'; did you mean '_mm512_cvttspd_epu32'?
 5938 |   return VFromD<D>{_mm512_cvtts_pd_epu32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm512_cvttspd_epu32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2_512satcvtdsintrin.h:58:46: note: '_mm512_cvttspd_epu32' declared here
   58 | static __inline__ __m256i __DEFAULT_FN_ATTRS _mm512_cvttspd_epu32(__m512d __A) {
      |                                              ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:6286:20: error: use of undeclared identifier '_mm512_cvtts_ps_epi32'; did you mean '_mm512_cvttsps_epi32'?
 6286 |   return VFromD<D>{_mm512_cvtts_ps_epi32(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm512_cvttsps_epi32
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2_512satcvtdsintrin.h:163:46: note: '_mm512_cvttsps_epi32' declared here
  163 | static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttsps_epi32(__m512 __A) {
      |                                              ^
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:27:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/foreach_target.h:149:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/per_target.cc:28:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/highway.h:688:
In file included from /mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_avx3-inl.h:20:
/mnt/vcpkg-ci/b/highway/src/1.3.0-d8ef17a685.clean/hwy/ops/x86_512-inl.h:6328:20: error: use of undeclared identifier '_mm512_cvtts_pd_epi64'; did you mean '_mm512_cvttspd_epi64'?
 6328 |   return VFromD<D>{_mm512_cvtts_pd_epi64(v.raw)};
      |                    ^~~~~~~~~~~~~~~~~~~~~
      |                    _mm512_cvttspd_epi64
/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/include/avx10_2_512satcvtdsintrin.h:94:46: note: '_mm512_cvttspd_epi64' declared here
   94 | static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttspd_epi64(__m512d __A) {
      |                                              ^
8 errors generated.
```