### PR TITLE
bit_set.h header is needed when building with threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ set(HWY_SOURCES
     hwy/aligned_allocator.h
     hwy/auto_tune.h
     hwy/base.h
+    hwy/bit_set.h
     hwy/cache_control.h
     hwy/detect_compiler_arch.h  # private
     hwy/detect_targets.h  # private

--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,7 @@ hwy_headers = files(
     'hwy/aligned_allocator.h',
     'hwy/auto_tune.h',
     'hwy/base.h',
+    'hwy/bit_set.h',
     'hwy/cache_control.h',
     'hwy/detect_compiler_arch.h',  # private
     'hwy/detect_targets.h',  # private


### PR DESCRIPTION
Ensure it is installed by default. Another option is to only install it if contrib is enabled.