### PR TITLE
Fix integer overflow and missing bounds checks in AlignedNDArray and ImageBase

### DIFF
--- a/hwy/aligned_allocator.h
+++ b/hwy/aligned_allocator.h
@@ -173,8 +173,13 @@ struct AlignedAllocator {
                   "AlignedAllocator only supports integer types");
     static_assert(sizeof(V) <= sizeof(std::size_t),
                   "V n must be smaller or equal size_t to avoid overflow");
+    const size_t count = static_cast<std::size_t>(n);
+    if (HWY_LIKELY(count != 0) && sizeof(value_type) > SIZE_MAX / count) {
+      HWY_ABORT("AlignedAllocator: allocation size overflow "
+                 "(%zu * %zu exceeds size_t)", count, sizeof(value_type));
+    }
     return static_cast<value_type*>(
-        AllocateAlignedBytes(static_cast<std::size_t>(n) * sizeof(value_type)));
+        AllocateAlignedBytes(count * sizeof(value_type)));
   }
 
   template <class V>
@@ -425,6 +430,10 @@ class AlignedNDArray {
     size_t offset = 0;
     size_t shape_index = 0;
     for (const size_t axis_index : indices) {
+      if (HWY_UNLIKELY(axis_index >= shape_[shape_index])) {
+        HWY_ABORT("AlignedNDArray index %zu out of bounds (axis %zu, size %zu)",
+                   axis_index, shape_index, shape_[shape_index]);
+      }
       offset += memory_sizes_[shape_index + 1] * axis_index;
       shape_index++;
     }
@@ -443,6 +452,13 @@ class AlignedNDArray {
     sizes[axis] = 1;
     while (axis > 0) {
       --axis;
+      // Check for integer overflow in dimension multiplication.
+      if (HWY_LIKELY(shape[axis] != 0) &&
+          sizes[axis + 1] > SIZE_MAX / shape[axis]) {
+        HWY_ABORT("AlignedNDArray: dimension overflow at axis %zu "
+                   "(%zu * %zu exceeds size_t)",
+                   axis, sizes[axis + 1], shape[axis]);
+      }
       sizes[axis] = sizes[axis + 1] * shape[axis];
     }
     return sizes;

--- a/hwy/contrib/image/image.cc
+++ b/hwy/contrib/image/image.cc
@@ -34,6 +34,11 @@ size_t ImageBase::VectorSize() {
 
 size_t ImageBase::BytesPerRow(const size_t xsize, const size_t sizeof_t) {
   const size_t vec_size = VectorSize();
+  // Check for integer overflow in xsize * sizeof_t.
+  if (HWY_LIKELY(xsize != 0) && sizeof_t > SIZE_MAX / xsize) {
+    HWY_ABORT("ImageBase::BytesPerRow overflow: xsize=%zu, sizeof_t=%zu",
+              xsize, sizeof_t);
+  }
   size_t valid_bytes = xsize * sizeof_t;
 
   // Allow unaligned accesses starting at the last valid value - this may raise
@@ -67,12 +72,20 @@ ImageBase::ImageBase(const size_t xsize, const size_t ysize,
       ysize_(static_cast<uint32_t>(ysize)),
       bytes_(nullptr, AlignedFreer(&AlignedFreer::DoNothing, nullptr)) {
   HWY_ASSERT(sizeof_t == 1 || sizeof_t == 2 || sizeof_t == 4 || sizeof_t == 8);
+  // Validate dimensions fit in uint32_t to prevent silent truncation.
+  HWY_ASSERT(xsize <= UINT32_MAX);
+  HWY_ASSERT(ysize <= UINT32_MAX);
 
   bytes_per_row_ = 0;
   // Dimensions can be zero, e.g. for lazily-allocated images. Only allocate
   // if nonzero, because "zero" bytes still have padding/bookkeeping overhead.
   if (xsize != 0 && ysize != 0) {
     bytes_per_row_ = BytesPerRow(xsize, sizeof_t);
+    // Check for integer overflow in allocation size.
+    if (bytes_per_row_ > SIZE_MAX / ysize) {
+      HWY_ABORT("ImageBase: allocation overflow (%zu * %zu exceeds size_t)",
+                bytes_per_row_, ysize);
+    }
     bytes_ = AllocateAligned<uint8_t>(bytes_per_row_ * ysize);
     HWY_ASSERT(bytes_.get() != nullptr);
     InitializePadding(sizeof_t, Padding::kRoundUp);


### PR DESCRIPTION
## Summary

This PR fixes multiple integer overflow and missing bounds check issues that can lead to heap-buffer-overflow in `AlignedNDArray` and `ImageBase`.

### Bugs fixed

| # | Component | Issue | Impact |
|---|-----------|-------|--------|
| 1 | `AlignedNDArray::Offset()` | Missing bounds check on axis indices | Heap-buffer-overflow (ASAN confirmed) |
| 2 | `AlignedNDArray::ComputeSizes()` | Integer overflow in dimension multiplication | Undersized allocation → heap corruption (ASAN confirmed) |
| 3 | `AlignedAllocator::allocate()` | `n * sizeof(T)` overflow | Undersized allocation |
| 4 | `ImageBase::BytesPerRow()` | `xsize * sizeof_t` overflow | Incorrect row size calculation |
| 5 | `ImageBase` constructor | `uint32_t` truncation + `bytes_per_row * ysize` overflow | Silent dimension loss + undersized allocation |

### ASAN traces

**Finding 1 — AlignedNDArray OOB:**
```
==158751==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x51d000000e80
WRITE of size 4 at 0x51d000000e80 thread T0
```

**Finding 2 — ComputeSizes overflow:**
```
==160573==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x51a000000680
WRITE of size 4 at 0x51a000000680 thread T0
0x51a000000680 is located 128 bytes after 1408-byte region [0x51a000000080,0x51a000000600)
```

### Fix approach

All overflow checks use the standard pattern `if (a > SIZE_MAX / b)` before multiplication, consistent with existing checks in `AllocateAlignedBytes()`. Bounds checks on `AlignedNDArray::Offset()` use `HWY_ABORT` to match existing error handling style.

### Testing

Verified that existing tests pass and the ASAN-triggering PoCs are properly caught by the new checks.