### PR TITLE
Add native futex support for FreeBSD via _umtx_op

### DIFF
--- a/hwy/contrib/thread_pool/futex.h
+++ b/hwy/contrib/thread_pool/futex.h
@@ -21,8 +21,8 @@
 // use with shared-memory mappings).
 //
 // Futex equivalents: https://outerproduct.net/futex-dictionary.html; we
-// support Linux/Emscripten/Apple/Windows and C++20 std::atomic::wait, plus a
-// NanoSleep fallback.
+// support Linux/Emscripten/FreeBSD/Apple/Windows and C++20 std::atomic::wait,
+// plus a NanoSleep fallback.
 
 #include <time.h>
 
@@ -74,6 +74,16 @@
 #endif
 #ifndef FUTEX_WAKE_PRIVATE
 #define FUTEX_WAKE_PRIVATE (FUTEX_WAKE | 128)
+#endif
+
+#elif HWY_OS_FREEBSD && !defined(HWY_DISABLE_FUTEX)
+#include <sys/param.h>  // __FreeBSD_version
+#if __FreeBSD_version >= 600000
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/umtx.h>
+#else
+#define HWY_DISABLE_FUTEX
 #endif
 
 #elif HWY_OS_APPLE && !defined(HWY_DISABLE_FUTEX)
@@ -172,6 +182,20 @@ static inline uint32_t BlockUntilDifferent(
     }
   }
 
+#elif HWY_OS_FREEBSD && !defined(HWY_DISABLE_FUTEX)  // >= 6.0
+  // _umtx_op with UMTX_OP_WAIT_UINT_PRIVATE: process-private futex on FreeBSD.
+  volatile void* address =
+      const_cast<volatile void*>(static_cast<const volatile void*>(&current));
+  for (;;) {
+    const uint32_t next = current.load(acq);
+    if (next != prev) return next;
+    const int ret = _umtx_op(address, UMTX_OP_WAIT_UINT_PRIVATE,
+                             static_cast<unsigned long>(prev), nullptr, nullptr);
+    if (ret == -1) {
+      HWY_DASSERT(errno == EAGAIN || errno == EINTR);
+    }
+  }
+
 #elif HWY_OS_WIN && !defined(HWY_DISABLE_FUTEX)
   // It is always safe to cast to void.
   volatile void* address =
@@ -232,6 +256,13 @@ static inline void WakeAll(std::atomic<uint32_t>& current) {
   const auto ret = syscall(SYS_futex, address, FUTEX_WAKE_PRIVATE, max_to_wake,
                            nullptr, nullptr, 0);
   HWY_DASSERT(ret >= 0);  // number woken
+  (void)ret;
+
+#elif HWY_OS_FREEBSD && !defined(HWY_DISABLE_FUTEX)  // >= 6.0
+  void* address = static_cast<void*>(&current);
+  const int ret = _umtx_op(address, UMTX_OP_WAKE_PRIVATE, INT_MAX, nullptr,
+                           nullptr);
+  HWY_DASSERT(ret >= 0);
   (void)ret;
 
 #elif HWY_OS_WIN && !defined(HWY_DISABLE_FUTEX)


### PR DESCRIPTION

## Summary

- Add native kernel-level futex support on FreeBSD using `_umtx_op` with `UMTX_OP_WAIT_UINT_PRIVATE` / `UMTX_OP_WAKE_PRIVATE`, replacing the NanoSleep polling fallback
- Guard with `__FreeBSD_version >= 600000` to gracefully degrade on pre-6.0 systems

## Test plan

- [ ] Existing `thread_pool_test` passes on FreeBSD (covers `BlockUntilDifferent` / `WakeAll` via `PoolWaitMode::kBlock`)
- [ ] Verify `HWY_DISABLE_FUTEX` fallback still works when defined manually
- [ ] CI (Linux/macOS/Windows) unaffected — changes are `#elif HWY_OS_FREEBSD` guarded


🐘 Generated with Crush