### PR TITLE
Add ShiftRightAndDemoteTo / RoundingShiftRightAndDemoteTo

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2120,6 +2120,19 @@ obtain the `D` that describes the return type.
     <code>Vec&lt;D&gt; **DemoteTo**(D, V v)</code>: narrows float to half (for
     bf16, it is unspecified whether this truncates or rounds).
 
+*   `V`,`D`: any `(V, D)` accepted by `DemoteTo`, with `V` and `TFromD<D>`
+    integer \
+    <code>Vec&lt;D&gt; **ShiftRightAndDemoteTo**&lt;int kShiftAmt&gt;(D, V
+    v)</code>: equivalent to `DemoteTo(D, ShiftRight<kShiftAmt>(v))`. TODO:
+    implement on SVE2/RVV/LSX/LASX.
+
+*   `V`,`D`: any `(V, D)` accepted by `DemoteTo`, with `V` and `TFromD<D>`
+    integer \
+    <code>Vec&lt;D&gt; **RoundingShiftRightAndDemoteTo**&lt;int kShiftAmt&gt;(D,
+    V v)</code>: equivalent to
+    `DemoteTo(D, RoundingShiftRight<kShiftAmt>(v))`. TODO: implement on
+    SVE2/RVV/LSX/LASX.
+
 #### Single vector promotion
 
 These functions promote a half vector to a full vector. To obtain halves, use

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -5261,6 +5261,136 @@ HWY_API Vec128<uint8_t, N> U8FromU32(Vec128<uint32_t, N> v) {
   return Vec128<uint8_t, N>(vuzp1_u8(w, w));
 }
 
+// ------------------------------ ShiftRightAndDemoteTo (vqshrn, vqshrun)
+// ------------------------------ RoundingShiftRightAndDemoteTo (vqrshrn, vqrshrun)
+
+#ifdef HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#undef HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#else
+#define HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#endif
+
+// TODO: also override on SVE2/RVV/LSX/LASX.
+
+// Macro args: `intrinsic` is the vqshrn/vqshrun family prefix; `op_suffix` is
+// its trailing token (e.g. `_n_s16`); `combine_suffix` is the vcombine trailing
+// token for the source type (e.g. `_s16`); `shift` is `ShiftRight` (non-
+// rounding) or `RoundingShiftRight` (rounding). The intrinsic requires the
+// immediate in [1, sizeof(to_t) * 8]; outside that range we fall back to
+// DemoteTo(d, shift<k>(v)), and the HWY_MIN/HWY_MAX clamp keeps the not-taken
+// intrinsic call well-formed.
+#define HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(intrinsic, name, shift, from_t,   \
+                                            to_t, op_suffix, combine_suffix)  \
+  template <int kShiftAmt, class D, HWY_IF_T_SIZE_D(D, sizeof(to_t)),         \
+            hwy::EnableIf<IsSame<TFromD<D>, to_t>()>* = nullptr>              \
+  HWY_API Vec64<to_t> name(D d, Vec128<from_t> v) {                           \
+    static_assert(0 <= kShiftAmt &&                                           \
+                      kShiftAmt <= static_cast<int>(sizeof(from_t) * 8 - 1),  \
+                  "kShiftAmt is out of range");                               \
+    return (0 < kShiftAmt &&                                                  \
+            kShiftAmt <= static_cast<int>(sizeof(to_t) * 8))                  \
+               ? Vec64<to_t>(intrinsic##op_suffix(                            \
+                     v.raw, HWY_MIN(HWY_MAX(1, kShiftAmt),                    \
+                                    static_cast<int>(sizeof(to_t) * 8))))     \
+               : DemoteTo(d, shift<kShiftAmt>(v));                            \
+  }                                                                           \
+  template <int kShiftAmt, class D, HWY_IF_V_SIZE_LE_D(D, 4),                 \
+            HWY_IF_T_SIZE_D(D, sizeof(to_t)),                                 \
+            hwy::EnableIf<IsSame<TFromD<D>, to_t>()>* = nullptr>              \
+  HWY_API VFromD<D> name(D d, VFromD<Rebind<from_t, D>> v) {                  \
+    static_assert(0 <= kShiftAmt &&                                           \
+                      kShiftAmt <= static_cast<int>(sizeof(from_t) * 8 - 1),  \
+                  "kShiftAmt is out of range");                               \
+    return (0 < kShiftAmt &&                                                  \
+            kShiftAmt <= static_cast<int>(sizeof(to_t) * 8))                  \
+               ? VFromD<D>(intrinsic##op_suffix(                              \
+                     vcombine##combine_suffix(v.raw, v.raw),                  \
+                     HWY_MIN(HWY_MAX(1, kShiftAmt),                           \
+                             static_cast<int>(sizeof(to_t) * 8))))            \
+               : DemoteTo(d, shift<kShiftAmt>(v));                            \
+  }
+
+// Saturating narrow with right shift (signed -> signed).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    int16_t, int8_t, _n_s16, _s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    int32_t, int16_t, _n_s32, _s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    int64_t, int32_t, _n_s64, _s64)
+
+// Saturating narrow with right shift (unsigned -> unsigned).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    uint16_t, uint8_t, _n_u16, _u16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    uint32_t, uint16_t, _n_u32, _u32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrn, ShiftRightAndDemoteTo, ShiftRight,
+                                    uint64_t, uint32_t, _n_u64, _u64)
+
+// Saturating narrow with right shift (signed -> unsigned).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrun, ShiftRightAndDemoteTo, ShiftRight,
+                                    int16_t, uint8_t, _n_s16, _s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrun, ShiftRightAndDemoteTo, ShiftRight,
+                                    int32_t, uint16_t, _n_s32, _s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqshrun, ShiftRightAndDemoteTo, ShiftRight,
+                                    int64_t, uint32_t, _n_s64, _s64)
+
+// Rounding variants.
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int16_t, int8_t,
+                                    _n_s16, _s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int32_t, int16_t,
+                                    _n_s32, _s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int64_t, int32_t,
+                                    _n_s64, _s64)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, uint16_t, uint8_t,
+                                    _n_u16, _u16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, uint32_t, uint16_t,
+                                    _n_u32, _u32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrn, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, uint64_t, uint32_t,
+                                    _n_u64, _u64)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrun, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int16_t, uint8_t,
+                                    _n_s16, _s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrun, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int32_t, uint16_t,
+                                    _n_s32, _s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE(vqrshrun, RoundingShiftRightAndDemoteTo,
+                                    RoundingShiftRight, int64_t, uint32_t,
+                                    _n_s64, _s64)
+
+#undef HWY_NEON_DEF_SHIFT_RIGHT_AND_DEMOTE
+
+// Catch-all fallback for combinations without a fused intrinsic, e.g. uint16
+// to int8 or two-step narrowing such as i32 to i8. The bodies are identical to
+// the generic_ops-inl.h templates of the same name; we duplicate here because
+// HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE suppresses those on NEON.
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ShiftRightAndDemoteTo(DN dn, V v) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return DemoteTo(dn, ShiftRight<kShiftAmt>(v));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> RoundingShiftRightAndDemoteTo(DN dn, V v) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return DemoteTo(dn, RoundingShiftRight<kShiftAmt>(v));
+}
+
 // ------------------------------ Round (IfThenElse, mask, logical)
 
 #if HWY_ARCH_ARM_A64

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -5557,6 +5557,41 @@ HWY_API V RoundingShr(V v, V amt) {
 
 #endif  // HWY_NATIVE_ROUNDING_SHR
 
+// ------------------------------ ShiftRightAndDemoteTo (DemoteTo, ShiftRight)
+
+// NEON overrides this with a fused saturating shift-narrow.
+// TODO: also override on SVE2/RVV/LSX/LASX.
+#if (defined(HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#undef HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#else
+#define HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+#endif
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ShiftRightAndDemoteTo(DN dn, V v) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return DemoteTo(dn, ShiftRight<kShiftAmt>(v));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> RoundingShiftRightAndDemoteTo(DN dn, V v) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return DemoteTo(dn, RoundingShiftRight<kShiftAmt>(v));
+}
+
+#endif  // HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
+
 // ------------------------------ MulEvenAdd (PromoteEvenTo)
 
 // SVE with bf16 and NEON with bf16 override this.

--- a/hwy/tests/shift_test.cc
+++ b/hwy/tests/shift_test.cc
@@ -456,6 +456,75 @@ HWY_NOINLINE void TestAllRoundingShiftRight() {
   ForIntegerTypes(ForPartialVectors<TestRoundingShiftRight>());
 }
 
+template <typename ToT>
+struct TestShiftRightAndDemoteTo {
+  template <int kShiftAmt, class DTo, class V>
+  static HWY_INLINE void Verify(DTo to_d, V in, const char* filename,
+                                const int line) {
+    AssertVecEqual(to_d, DemoteTo(to_d, ShiftRight<kShiftAmt>(in)),
+                   ShiftRightAndDemoteTo<kShiftAmt>(to_d, in), filename, line);
+    AssertVecEqual(to_d, DemoteTo(to_d, RoundingShiftRight<kShiftAmt>(in)),
+                   RoundingShiftRightAndDemoteTo<kShiftAmt>(to_d, in), filename,
+                   line);
+  }
+
+  template <typename T, class DFrom>
+  HWY_NOINLINE void operator()(T /*unused*/, DFrom from_d) {
+    static_assert(sizeof(T) > sizeof(ToT), "Input type must be wider");
+    const Rebind<ToT, DFrom> to_d;
+
+    using TU = MakeUnsigned<T>;
+    const auto iota1 = Add(Iota(from_d, T{0}), Set(from_d, T{1}));
+    const auto seq_neg = Add(iota1, SignBit(from_d));
+    const auto seq_sat =
+        Or(Xor(iota1, Set(from_d, static_cast<T>(0x6ED498B16EC87C63ULL &
+                                                 LimitsMax<TU>()))),
+           Set(from_d, T{1}));
+
+    Verify<0>(to_d, iota1, __FILE__, __LINE__);
+    Verify<0>(to_d, seq_neg, __FILE__, __LINE__);
+    Verify<1>(to_d, iota1, __FILE__, __LINE__);
+    Verify<1>(to_d, seq_neg, __FILE__, __LINE__);
+    Verify<1>(to_d, seq_sat, __FILE__, __LINE__);
+    Verify<static_cast<int>(sizeof(ToT) * 4)>(to_d, seq_neg, __FILE__,
+                                              __LINE__);
+    Verify<static_cast<int>(sizeof(ToT) * 8 - 1)>(to_d, seq_sat, __FILE__,
+                                                  __LINE__);
+    Verify<static_cast<int>(sizeof(ToT) * 8)>(to_d, seq_sat, __FILE__,
+                                              __LINE__);
+    Verify<static_cast<int>(sizeof(T) * 8 - 1)>(to_d, seq_neg, __FILE__,
+                                                __LINE__);
+  }
+};
+
+HWY_NOINLINE void TestAllShiftRightAndDemoteTo() {
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<uint8_t>> from_i16_to_u8;
+  from_i16_to_u8(int16_t());
+  from_i16_to_u8(uint16_t());
+
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<int8_t>> from_i16_to_i8;
+  from_i16_to_i8(int16_t());
+  from_i16_to_i8(uint16_t());
+
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<uint16_t>> from_i32_to_u16;
+  from_i32_to_u16(int32_t());
+  from_i32_to_u16(uint32_t());
+
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<int16_t>> from_i32_to_i16;
+  from_i32_to_i16(int32_t());
+  from_i32_to_i16(uint32_t());
+
+#if HWY_HAVE_INTEGER64
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<uint32_t>> from_i64_to_u32;
+  from_i64_to_u32(int64_t());
+  from_i64_to_u32(uint64_t());
+
+  const ForDemoteVectors<TestShiftRightAndDemoteTo<int32_t>> from_i64_to_i32;
+  from_i64_to_i32(int64_t());
+  from_i64_to_i32(uint64_t());
+#endif
+}
+
 struct TestVariableRoundingShr {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D d) {
@@ -755,6 +824,7 @@ HWY_BEFORE_TEST(HwyShiftTest);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllShifts);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllVariableShifts);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllRoundingShiftRight);
+HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllShiftRightAndDemoteTo);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllVariableRoundingShr);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllMaskedShift);
 HWY_EXPORT_AND_TEST_P(HwyShiftTest, TestAllMultiRotateRight);


### PR DESCRIPTION
Implements `ShiftRightAndDemoteTo` and `RoundingShiftRightAndDemoteTo` for #2628. NEON fuses both steps into one saturating shift-narrow (`vqshrn`/`vqshrun`/`vqrshrn`/`vqrshrun`); other targets fall back to `DemoteTo(d, [Rounding]ShiftRight<k>(v))`.

The `Demote2To` variants and SVE2/RVV/LSX/LASX overrides will follow in separate PRs per the issue thread.
