### PR TITLE
Only include `hwy_list_targets` if top-level build; only build tests if `HWY_ENABLE_TESTS=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,7 @@ if(UNIX AND NOT APPLE)
 endif()
 endif()  # HWY_ENABLE_CONTRIB
 
+if (HWY_ENABLE_TESTS)
 add_library(hwy_test ${HWY_LIBRARY_TYPE} ${HWY_TEST_SOURCES})
 target_link_libraries(hwy_test PUBLIC hwy)
 target_compile_options(hwy_test PRIVATE ${HWY_FLAGS})
@@ -617,7 +618,9 @@ if(UNIX AND NOT APPLE)
   set_property(TARGET hwy_test APPEND_STRING PROPERTY
     LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/hwy/hwy.version")
 endif()
+endif()  # HWY_ENABLE_TESTS
 
+if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 # -------------------------------------------------------- hwy_list_targets
 # Generate a tool to print the compiled-in targets as defined by the current
 # flags. This tool will print to stderr at build time, after building hwy.
@@ -635,6 +638,7 @@ if (NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
 add_custom_command(TARGET hwy_list_targets POST_BUILD
     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:hwy_list_targets> || (exit 0))
 endif()
+endif()  # CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR
 
 # --------------------------------------------------------
 # Allow skipping the following sections for projects that do not need them:


### PR DESCRIPTION
I'm working on integrating Highway with the [Apache Traffic Server](https://github.com/apache/trafficserver). I ran into a few small CMake-related build issues when including Highway as an in-tree vendor'ed copy with some things like examples, docs, tests, etc. removed:

* Tests build even if `HWY_ENABLE_TESTS=OFF`
* The `hwy_list_targets` always builds even if it isn't ultimately called (say, because it's included and not standalone). The Meson build system [does not](https://github.com/google/highway/blob/master/meson.build#L507-L513), and the Bazel build system [marks it as a test](https://github.com/google/highway/blob/master/BUILD#L598-L606).

This PR proposes to try and bring the CMake behavior in-line with Meson and Bazel. 

The current files declares a minimum version of CMake 3.10, so I did not use `PROJECT_IS_TOP_LEVEL`. 