### PR TITLE
Add ShiftRightAndReorderDemote2To / ShiftRightAndOrderedDemote2To

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2267,6 +2267,32 @@ or `ConcatOdd` followed by `PromoteLowerTo`:
     more efficient. Note that integer inputs are saturated to the destination
     range as with `DemoteTo`. Only available if `HWY_TARGET != HWY_SCALAR`.
 
+*   `V`,`D`: any `(V, D)` accepted by `ReorderDemote2To`, with `V` and
+    `TFromD<D>` integer \
+    <code>Vec&lt;D&gt; **ReorderShiftRightAndDemote2To**&lt;int kShiftAmt&gt;(D, V
+    a, V b)</code>: equivalent to `ReorderDemote2To(D, ShiftRight<kShiftAmt>(a),
+    ShiftRight<kShiftAmt>(b))`. TODO: implement on SVE2/RVV/LSX/LASX.
+
+*   `V`,`D`: any `(V, D)` accepted by `ReorderDemote2To`, with `V` and
+    `TFromD<D>` integer \
+    <code>Vec&lt;D&gt; **ReorderRoundingShiftRightAndDemote2To**&lt;int
+    kShiftAmt&gt;(D, V a, V b)</code>: equivalent to `ReorderDemote2To(D,
+    RoundingShiftRight<kShiftAmt>(a), RoundingShiftRight<kShiftAmt>(b))`. TODO:
+    implement on SVE2/RVV/LSX/LASX.
+
+*   `V`,`D`: any `(V, D)` accepted by `OrderedDemote2To`, with `V` and
+    `TFromD<D>` integer \
+    <code>Vec&lt;D&gt; **OrderedShiftRightAndDemote2To**&lt;int kShiftAmt&gt;(D, V
+    a, V b)</code>: equivalent to `OrderedDemote2To(D, ShiftRight<kShiftAmt>(a),
+    ShiftRight<kShiftAmt>(b))`. TODO: implement on SVE2/RVV/LSX/LASX.
+
+*   `V`,`D`: any `(V, D)` accepted by `OrderedDemote2To`, with `V` and
+    `TFromD<D>` integer \
+    <code>Vec&lt;D&gt; **OrderedRoundingShiftRightAndDemote2To**&lt;int
+    kShiftAmt&gt;(D, V a, V b)</code>: equivalent to `OrderedDemote2To(D,
+    RoundingShiftRight<kShiftAmt>(a), RoundingShiftRight<kShiftAmt>(b))`. TODO:
+    implement on SVE2/RVV/LSX/LASX.
+
 *   `V`,`D`: (`u16,u8`), (`u32,u16`), (`u64,u32`), \
     <code>Vec&lt;D&gt; **OrderedTruncate2To**(D d, V a, V b)</code>: as above,
     but converts two inputs, `D` and the output have twice as many lanes as `V`,

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -8540,6 +8540,184 @@ HWY_API VFromD<D> OrderedDemote2To(D dbf16, VFromD<Repartition<float, D>> a,
 }
 #endif  // HWY_NEON_HAVE_F32_TO_BF16C
 
+// ------------------------------ ReorderShiftRightAndDemote2To (vqshrn, vqshrun)
+// ------------------------------ OrderedShiftRightAndDemote2To (ReorderDemote2To)
+
+#ifdef HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#undef HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#else
+#define HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#endif
+
+// TODO: also override on SVE2/RVV/LSX/LASX.
+
+// Macro args: `intrinsic` is the vqshrn/vqshrun family prefix; `op_suffix` is
+// its trailing token (e.g. `_n_s16`); `shift` is `ShiftRight` (non-rounding) or
+// `RoundingShiftRight` (rounding). The intrinsic requires the immediate in
+// [1, sizeof(to_t) * 8]; outside that range we fall back to
+// ReorderDemote2To(d, shift<k>(a), shift<k>(b)), and the HWY_MIN/HWY_MAX clamp
+// keeps the not-taken intrinsic call well-formed. On AArch64 we fuse the second
+// input into the high half with the `_high` form, matching ReorderDemote2To.
+#if HWY_ARCH_ARM_A64
+#define HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(intrinsic, name, shift,  \
+                                                     from_t, to_t, op_suffix) \
+  template <int kShiftAmt, class D, HWY_IF_T_SIZE_D(D, sizeof(to_t)),         \
+            hwy::EnableIf<IsSame<TFromD<D>, to_t>()>* = nullptr>              \
+  HWY_API Vec128<to_t> name(D d, Vec128<from_t> a, Vec128<from_t> b) {        \
+    static_assert(0 <= kShiftAmt &&                                           \
+                      kShiftAmt <= static_cast<int>(sizeof(from_t) * 8 - 1),  \
+                  "kShiftAmt is out of range");                               \
+    return (0 < kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(to_t) * 8)) \
+               ? Vec128<to_t>(intrinsic##_high##op_suffix(                    \
+                     intrinsic##op_suffix(                                    \
+                         a.raw, HWY_MIN(HWY_MAX(1, kShiftAmt),                \
+                                        static_cast<int>(sizeof(to_t) * 8))), \
+                     b.raw,                                                   \
+                     HWY_MIN(HWY_MAX(1, kShiftAmt),                           \
+                             static_cast<int>(sizeof(to_t) * 8))))            \
+               : ReorderDemote2To(d, shift<kShiftAmt>(a),                     \
+                                  shift<kShiftAmt>(b));                       \
+  }
+#else
+#define HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(intrinsic, name, shift,   \
+                                                     from_t, to_t, op_suffix)  \
+  template <int kShiftAmt, class D, HWY_IF_T_SIZE_D(D, sizeof(to_t)),          \
+            hwy::EnableIf<IsSame<TFromD<D>, to_t>()>* = nullptr>               \
+  HWY_API Vec128<to_t> name(D d, Vec128<from_t> a, Vec128<from_t> b) {         \
+    static_assert(0 <= kShiftAmt &&                                            \
+                      kShiftAmt <= static_cast<int>(sizeof(from_t) * 8 - 1),   \
+                  "kShiftAmt is out of range");                                \
+    return (0 < kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(to_t) * 8))  \
+               ? Combine(                                                      \
+                     d,                                                        \
+                     Vec64<to_t>(intrinsic##op_suffix(                         \
+                         b.raw, HWY_MIN(HWY_MAX(1, kShiftAmt),                 \
+                                        static_cast<int>(sizeof(to_t) * 8)))), \
+                     Vec64<to_t>(intrinsic##op_suffix(                         \
+                         a.raw, HWY_MIN(HWY_MAX(1, kShiftAmt),                 \
+                                        static_cast<int>(sizeof(to_t) * 8))))) \
+               : ReorderDemote2To(d, shift<kShiftAmt>(a),                      \
+                                  shift<kShiftAmt>(b));                        \
+  }
+#endif
+
+// Saturating narrow with right shift (signed -> signed).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int16_t, int8_t,
+                                             _n_s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int32_t, int16_t,
+                                             _n_s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int64_t, int32_t,
+                                             _n_s64)
+
+// Saturating narrow with right shift (unsigned -> unsigned).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, uint16_t, uint8_t,
+                                             _n_u16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, uint32_t, uint16_t,
+                                             _n_u32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrn,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, uint64_t, uint32_t,
+                                             _n_u64)
+
+// Saturating narrow with right shift (signed -> unsigned).
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrun,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int16_t, uint8_t,
+                                             _n_s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrun,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int32_t, uint16_t,
+                                             _n_s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(vqshrun,
+                                             ReorderShiftRightAndDemote2To,
+                                             ShiftRight, int64_t, uint32_t,
+                                             _n_s64)
+
+// Rounding variants.
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight, int16_t,
+    int8_t, _n_s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight, int32_t,
+    int16_t, _n_s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight, int64_t,
+    int32_t, _n_s64)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    uint16_t, uint8_t, _n_u16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    uint32_t, uint16_t, _n_u32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrn, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    uint64_t, uint32_t, _n_u64)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrun, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    int16_t, uint8_t, _n_s16)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrun, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    int32_t, uint16_t, _n_s32)
+HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2(
+    vqrshrun, ReorderRoundingShiftRightAndDemote2To, RoundingShiftRight,
+    int64_t, uint32_t, _n_s64)
+
+#undef HWY_NEON_DEF_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+
+// Catch-all fallback for combinations without a fused intrinsic, e.g. uint16
+// to int8 or two-step narrowing such as i32 to i8, and for partial vectors.
+// The bodies match the generic_ops-inl.h templates of the same name; we
+// duplicate here because HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2 suppresses
+// those on NEON.
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ReorderShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return ReorderDemote2To(dn, ShiftRight<kShiftAmt>(a),
+                          ShiftRight<kShiftAmt>(b));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ReorderRoundingShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return ReorderDemote2To(dn, RoundingShiftRight<kShiftAmt>(a),
+                          RoundingShiftRight<kShiftAmt>(b));
+}
+
+// Ordered forwards to Reorder because ReorderDemote2To is ordered on NEON.
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> OrderedShiftRightAndDemote2To(DN dn, V a, V b) {
+  return ReorderShiftRightAndDemote2To<kShiftAmt>(dn, a, b);
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> OrderedRoundingShiftRightAndDemote2To(DN dn, V a, V b) {
+  return ReorderRoundingShiftRightAndDemote2To<kShiftAmt>(dn, a, b);
+}
+
 // ================================================== CRYPTO
 
 // (aarch64 or Arm7) and (__ARM_FEATURE_AES or HWY_HAVE_RUNTIME_DISPATCH).

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -5592,6 +5592,69 @@ HWY_API VFromD<DN> RoundingShiftRightAndDemoteTo(DN dn, V v) {
 
 #endif  // HWY_NATIVE_SHIFT_RIGHT_AND_DEMOTE
 
+// ------------------------------ ReorderShiftRightAndDemote2To (ReorderDemote2To)
+// ------------------------------ OrderedShiftRightAndDemote2To (OrderedDemote2To)
+
+// NEON overrides these with a fused saturating shift-narrow.
+// TODO: also override on SVE2/RVV/LSX/LASX.
+#if (defined(HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2) == \
+     defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#undef HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#else
+#define HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+#endif
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ReorderShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return ReorderDemote2To(dn, ShiftRight<kShiftAmt>(a),
+                          ShiftRight<kShiftAmt>(b));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> ReorderRoundingShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return ReorderDemote2To(dn, RoundingShiftRight<kShiftAmt>(a),
+                          RoundingShiftRight<kShiftAmt>(b));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> OrderedShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return OrderedDemote2To(dn, ShiftRight<kShiftAmt>(a),
+                          ShiftRight<kShiftAmt>(b));
+}
+
+template <int kShiftAmt, class DN, class V, HWY_IF_NOT_FLOAT_NOR_SPECIAL_D(DN),
+          HWY_IF_NOT_FLOAT_NOR_SPECIAL_V(V),
+          hwy::EnableIf<(sizeof(TFromD<DN>) < sizeof(TFromV<V>))>* = nullptr>
+HWY_API VFromD<DN> OrderedRoundingShiftRightAndDemote2To(DN dn, V a, V b) {
+  using T = TFromV<V>;
+  static_assert(
+      0 <= kShiftAmt && kShiftAmt <= static_cast<int>(sizeof(T) * 8 - 1),
+      "kShiftAmt is out of range");
+  return OrderedDemote2To(dn, RoundingShiftRight<kShiftAmt>(a),
+                          RoundingShiftRight<kShiftAmt>(b));
+}
+
+#endif  // HWY_NATIVE_SHIFT_RIGHT_AND_REORDER_DEMOTE2
+
 // ------------------------------ MulEvenAdd (PromoteEvenTo)
 
 // SVE with bf16 and NEON with bf16 override this.

--- a/hwy/tests/demote_test.cc
+++ b/hwy/tests/demote_test.cc
@@ -780,6 +780,86 @@ HWY_NOINLINE void TestAllOrderedDemote2To() {
   // ForSpecialTypes(ForShrinkableVectors<TestFloatOrderedDemote2To>());
 }
 
+class TestShiftRightAndDemote2To {
+#if HWY_TARGET != HWY_SCALAR
+
+ private:
+  // The fused ops must match the unfused reference on the same target, so the
+  // lane order is identical and we can compare directly without sorting.
+  template <int kShiftAmt, class DN, class D, class V = VFromD<D>>
+  static HWY_INLINE void Verify(DN dn, D /*d*/, V a, V b, const char* filename,
+                                const int line) {
+    AssertVecEqual(dn,
+                   ReorderDemote2To(dn, ShiftRight<kShiftAmt>(a),
+                                    ShiftRight<kShiftAmt>(b)),
+                   ReorderShiftRightAndDemote2To<kShiftAmt>(dn, a, b), filename,
+                   line);
+    AssertVecEqual(dn,
+                   ReorderDemote2To(dn, RoundingShiftRight<kShiftAmt>(a),
+                                    RoundingShiftRight<kShiftAmt>(b)),
+                   ReorderRoundingShiftRightAndDemote2To<kShiftAmt>(dn, a, b),
+                   filename, line);
+    AssertVecEqual(dn,
+                   OrderedDemote2To(dn, ShiftRight<kShiftAmt>(a),
+                                    ShiftRight<kShiftAmt>(b)),
+                   OrderedShiftRightAndDemote2To<kShiftAmt>(dn, a, b), filename,
+                   line);
+    AssertVecEqual(dn,
+                   OrderedDemote2To(dn, RoundingShiftRight<kShiftAmt>(a),
+                                    RoundingShiftRight<kShiftAmt>(b)),
+                   OrderedRoundingShiftRightAndDemote2To<kShiftAmt>(dn, a, b),
+                   filename, line);
+  }
+
+  template <typename T, class D, class DN>
+  static void DoTest(DN dn, T /*t*/, D d) {
+    using TN = TFromD<DN>;
+    const size_t N = Lanes(d);
+    const size_t twiceN = N * 2;
+    auto from = AllocateAligned<T>(twiceN);
+    HWY_ASSERT(from);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < twiceN; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+      }
+      const auto a = Load(d, from.get());
+      const auto b = Load(d, from.get() + N);
+
+      Verify<0>(dn, d, a, b, __FILE__, __LINE__);
+      Verify<1>(dn, d, a, b, __FILE__, __LINE__);
+      Verify<static_cast<int>(sizeof(TN) * 4)>(dn, d, a, b, __FILE__, __LINE__);
+      Verify<static_cast<int>(sizeof(TN) * 8 - 1)>(dn, d, a, b, __FILE__,
+                                                   __LINE__);
+      Verify<static_cast<int>(sizeof(TN) * 8)>(dn, d, a, b, __FILE__, __LINE__);
+      Verify<static_cast<int>(sizeof(T) * 8 - 1)>(dn, d, a, b, __FILE__,
+                                                  __LINE__);
+    }
+  }
+#endif
+
+ public:
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*t*/, D d) {
+#if HWY_TARGET != HWY_SCALAR
+    const RepartitionToNarrow<D> dn;
+    const RebindToSigned<decltype(dn)> dn_i;
+    const RebindToUnsigned<decltype(dn)> dn_u;
+
+    DoTest(dn_i, T(), d);
+    DoTest(dn_u, T(), d);
+#else
+    (void)d;
+#endif
+  }
+};
+
+HWY_NOINLINE void TestAllShiftRightAndDemote2To() {
+  ForUI163264(ForShrinkableVectors<TestShiftRightAndDemote2To>());
+}
+
 struct TestI32F64 {
   template <typename TF, class DF>
   HWY_NOINLINE void operator()(TF /*unused*/, const DF df) {
@@ -847,6 +927,7 @@ HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteUI64ToFloat);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToBF16);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllReorderDemote2To);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllOrderedDemote2To);
+HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllShiftRightAndDemote2To);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllI32F64);
 HWY_AFTER_TEST();
 #endif  //  !HWY_IS_MSAN


### PR DESCRIPTION
Implements `ShiftRightAndReorderDemote2To` and `ShiftRightAndOrderedDemote2To`, with their rounding variants, for #2628. These are the `Demote2To` follow-up to #3056. NEON fuses the shift and the saturating narrow into one instruction (`vqshrn`/`vqshrun`/`vqrshrn`/`vqrshrun`, using the `_high` form for the second vector); other targets fall back to `ReorderDemote2To(d, [Rounding]ShiftRight<k>(a), ...)` and the Ordered equivalent.

SVE2/RVV/LSX/LASX overrides are left as a TODO per the issue thread.
