### PR TITLE
Fixes to NEON PerBlock2x2MatMul and matmul_op_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -907,6 +907,7 @@ set(HWY_TEST_FILES
   hwy/tests/masked_arithmetic_test.cc
   hwy/tests/masked_compare_test.cc
   hwy/tests/masked_minmax_test.cc
+  hwy/tests/matmul_op_test.cc
   hwy/tests/memory_test.cc
   hwy/tests/minmax_magnitude_test.cc
   hwy/tests/minmax_number_test.cc

--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -10959,27 +10959,23 @@ namespace detail {  // for code folding
 }  // namespace detail
 
 // ------------------------------ PerBlock2x2MatMul (Neon hardware overrides)
-#if defined(__ARM_FEATURE_MATMUL_INT8) ||           \
-    (HWY_TARGET == HWY_NEON_BF16 && HWY_OS_APPLE && \
-     HWY_HAVE_RUNTIME_DISPATCH)
-template <size_t N>
-HWY_API Vec128<int32_t, N> PerBlock2x2MatMul(
-    Simd<int32_t, N, 0> /* d */,
-    Vec128<int8_t, N * 4> a,
-    Vec128<int8_t, N * 4> b,
-    Vec128<int32_t, N> c) {
-  return Vec128<int32_t, N>{vmmlaq_s32(c.raw, a.raw, b.raw)};
+#if defined(__ARM_FEATURE_MATMUL_INT8) || \
+    (HWY_TARGET == HWY_NEON_BF16 && HWY_OS_APPLE && HWY_HAVE_RUNTIME_DISPATCH)
+template <class DI32, HWY_IF_I32_D(DI32), HWY_IF_V_SIZE_D(DI32, 16)>
+HWY_API VFromD<DI32> PerBlock2x2MatMul(DI32 /* d */,
+                                       VFromD<Repartition<int8_t, DI32>> a,
+                                       VFromD<Repartition<int8_t, DI32>> b,
+                                       VFromD<DI32> c) {
+  return VFromD<DI32>{vmmlaq_s32(c.raw, a.raw, b.raw)};
 }
 #endif
 
 #if defined(__ARM_FEATURE_BF16_VECTOR_ARITHMETIC) || HWY_TARGET == HWY_NEON_BF16
-template <size_t N>
-HWY_API Vec128<float, N> PerBlock2x2MatMul(
-    Simd<float, N, 0> /* d */,
-    Vec128<hwy::bfloat16_t, N * 2> a,
-    Vec128<hwy::bfloat16_t, N * 2> b,
-    Vec128<float, N> c) {
-  return Vec128<float, N>{vbfmmlaq_f32(c.raw, a.raw, b.raw)};
+template <class DF32, HWY_IF_F32_D(DF32), HWY_IF_V_SIZE_D(DF32, 16)>
+HWY_API VFromD<DF32> PerBlock2x2MatMul(
+    DF32 /* d */, VFromD<Repartition<hwy::bfloat16_t, DF32>> a,
+    VFromD<Repartition<hwy::bfloat16_t, DF32>> b, VFromD<DF32> c) {
+  return VFromD<DF32>{vbfmmlaq_f32(c.raw, a.raw, b.raw)};
 }
 #endif
 

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -7746,55 +7746,6 @@ HWY_API V Per4LaneBlockShuffle(V v) {
 }
 #endif
 
-// ------------------------------ PerBlock2x2MatMul
-#if HWY_TARGET != HWY_SCALAR || HWY_IDE
-
-#if !HWY_NATIVE_PER_BLOCK_2X2_MATMUL_INT8
-template <class DI32, HWY_IF_I32_D(DI32), HWY_IF_V_SIZE_GT_D(DI32, 8)>
-HWY_API VFromD<DI32> PerBlock2x2MatMul(DI32 di32,
-                                       VFromD<Repartition<int8_t, DI32>> a,
-                                       VFromD<Repartition<int8_t, DI32>> b,
-                                       VFromD<DI32> c) {
-  const Repartition<int8_t, decltype(di32)> di8;
-
-  const auto vi32_a = BitCast(di32, a);
-  const auto vi32_b = BitCast(di32, b);
-
-  const auto a0 = BitCast(di8, DupEven(vi32_a));
-  const auto a1 = BitCast(di8, DupOdd(vi32_a));
-
-  const auto b0 = BitCast(di8, Per4LaneBlockShuffle<2, 0, 2, 0>(vi32_b));
-  const auto b1 = BitCast(di8, Per4LaneBlockShuffle<3, 1, 3, 1>(vi32_b));
-
-  return SumOfMulQuadAccumulate(di32, a1, b1,
-                                SumOfMulQuadAccumulate(di32, a0, b0, c));
-}
-#endif
-
-#if !HWY_NATIVE_PER_BLOCK_2X2_MATMUL_BF16
-template <class DF32, HWY_IF_F32_D(DF32), HWY_IF_V_SIZE_GT_D(DF32, 8)>
-HWY_API VFromD<DF32> PerBlock2x2MatMul(
-    DF32 df32, VFromD<Repartition<hwy::bfloat16_t, DF32>> a,
-    VFromD<Repartition<hwy::bfloat16_t, DF32>> b, VFromD<DF32> c) {
-  const Repartition<hwy::bfloat16_t, decltype(df32)> dbf16;
-
-  const auto vf32_a = BitCast(df32, a);
-  const auto vf32_b = BitCast(df32, b);
-
-  const auto a0 = BitCast(dbf16, DupEven(vf32_a));
-  const auto a1 = BitCast(dbf16, DupOdd(vf32_a));
-
-  const auto b0 = BitCast(dbf16, Per4LaneBlockShuffle<2, 0, 2, 0>(vf32_b));
-  const auto b1 = BitCast(dbf16, Per4LaneBlockShuffle<3, 1, 3, 1>(vf32_b));
-
-  return Add(
-      Add(WidenMulPairwiseAdd(df32, a1, b1), WidenMulPairwiseAdd(df32, a0, b0)),
-      c);
-}
-#endif
-
-#endif  // HWY_TARGET != HWY_SCALAR
-
 // ------------------------------ PairwiseAdd128/PairwiseSub128
 //                                (Per4LaneBlockShuffle)
 #if (defined(HWY_NATIVE_PAIRWISE_ADD_128) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -7746,6 +7746,55 @@ HWY_API V Per4LaneBlockShuffle(V v) {
 }
 #endif
 
+// ------------------------------ PerBlock2x2MatMul
+#if HWY_TARGET != HWY_SCALAR || HWY_IDE
+
+#if !HWY_NATIVE_PER_BLOCK_2X2_MATMUL_INT8
+template <class DI32, HWY_IF_I32_D(DI32), HWY_IF_V_SIZE_GT_D(DI32, 8)>
+HWY_API VFromD<DI32> PerBlock2x2MatMul(DI32 di32,
+                                       VFromD<Repartition<int8_t, DI32>> a,
+                                       VFromD<Repartition<int8_t, DI32>> b,
+                                       VFromD<DI32> c) {
+  const Repartition<int8_t, decltype(di32)> di8;
+
+  const auto vi32_a = BitCast(di32, a);
+  const auto vi32_b = BitCast(di32, b);
+
+  const auto a0 = BitCast(di8, DupEven(vi32_a));
+  const auto a1 = BitCast(di8, DupOdd(vi32_a));
+
+  const auto b0 = BitCast(di8, Per4LaneBlockShuffle<2, 0, 2, 0>(vi32_b));
+  const auto b1 = BitCast(di8, Per4LaneBlockShuffle<3, 1, 3, 1>(vi32_b));
+
+  return SumOfMulQuadAccumulate(di32, a1, b1,
+                                SumOfMulQuadAccumulate(di32, a0, b0, c));
+}
+#endif
+
+#if !HWY_NATIVE_PER_BLOCK_2X2_MATMUL_BF16
+template <class DF32, HWY_IF_F32_D(DF32), HWY_IF_V_SIZE_GT_D(DF32, 8)>
+HWY_API VFromD<DF32> PerBlock2x2MatMul(
+    DF32 df32, VFromD<Repartition<hwy::bfloat16_t, DF32>> a,
+    VFromD<Repartition<hwy::bfloat16_t, DF32>> b, VFromD<DF32> c) {
+  const Repartition<hwy::bfloat16_t, decltype(df32)> dbf16;
+
+  const auto vf32_a = BitCast(df32, a);
+  const auto vf32_b = BitCast(df32, b);
+
+  const auto a0 = BitCast(dbf16, DupEven(vf32_a));
+  const auto a1 = BitCast(dbf16, DupOdd(vf32_a));
+
+  const auto b0 = BitCast(dbf16, Per4LaneBlockShuffle<2, 0, 2, 0>(vf32_b));
+  const auto b1 = BitCast(dbf16, Per4LaneBlockShuffle<3, 1, 3, 1>(vf32_b));
+
+  return Add(
+      Add(WidenMulPairwiseAdd(df32, a1, b1), WidenMulPairwiseAdd(df32, a0, b0)),
+      c);
+}
+#endif
+
+#endif  // HWY_TARGET != HWY_SCALAR
+
 // ------------------------------ PairwiseAdd128/PairwiseSub128
 //                                (Per4LaneBlockShuffle)
 #if (defined(HWY_NATIVE_PAIRWISE_ADD_128) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/tests/matmul_op_test.cc
+++ b/hwy/tests/matmul_op_test.cc
@@ -35,7 +35,7 @@ namespace {
 struct TestInt8PerBlock2x2MatMul {
   template <typename TN, class DN>
   HWY_NOINLINE void operator()(TN /*unused*/, DN dn) {
-#if HWY_NATIVE_PER_BLOCK_2X2_MATMUL_INT8
+#if HWY_TARGET != HWY_SCALAR
     static_assert(IsSame<TN, int32_t>(), "TN should be int32_t");
     const Repartition<int8_t, DN> di8;
     using VI8 = Vec<decltype(di8)>;
@@ -62,10 +62,10 @@ struct TestInt8PerBlock2x2MatMul {
     // Scalar emulation loop (matching hardware svmmla interleaving)
     for (size_t block = 0; block < N; block += 4) {
       const size_t block_i8 = block * 4;
-      for (int i = 0; i < 2; ++i) {
-        for (int j = 0; j < 2; ++j) {
+      for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
           int32_t sum = 0;
-          for (int k = 0; k < 8; ++k) {
+          for (size_t k = 0; k < 8; ++k) {
             sum += static_cast<int32_t>(in_a[block_i8 + i * 8 + k]) *
                    static_cast<int32_t>(in_b[block_i8 + j * 8 + k]);
           }
@@ -93,7 +93,7 @@ HWY_NOINLINE void TestAllInt8PerBlock2x2MatMul() {
 struct TestBf16PerBlock2x2MatMul {
   template <typename TN, class DN>
   HWY_NOINLINE void operator()(TN /*unused*/, DN dn) {
-#if HWY_NATIVE_PER_BLOCK_2X2_MATMUL_BF16
+#if HWY_TARGET != HWY_SCALAR
     static_assert(IsSame<TN, float>(), "TN should be float");
     const Repartition<hwy::bfloat16_t, DN> dbf;
     using VBF = Vec<decltype(dbf)>;
@@ -117,10 +117,10 @@ struct TestBf16PerBlock2x2MatMul {
 
     for (size_t block = 0; block < N; block += 4) {
       const size_t block_bf = block * 2;
-      for (int i = 0; i < 2; ++i) {
-        for (int j = 0; j < 2; ++j) {
+      for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
           float sum = 0.0f;
-          for (int k = 0; k < 4; ++k) {
+          for (size_t k = 0; k < 4; ++k) {
             sum += hwy::ConvertScalarTo<float>(in_a[block_bf + i * 4 + k]) *
                    hwy::ConvertScalarTo<float>(in_b[block_bf + j * 4 + k]);
           }

--- a/hwy/tests/matmul_op_test.cc
+++ b/hwy/tests/matmul_op_test.cc
@@ -35,7 +35,7 @@ namespace {
 struct TestInt8PerBlock2x2MatMul {
   template <typename TN, class DN>
   HWY_NOINLINE void operator()(TN /*unused*/, DN dn) {
-#if HWY_TARGET != HWY_SCALAR
+#if HWY_NATIVE_PER_BLOCK_2X2_MATMUL_INT8
     static_assert(IsSame<TN, int32_t>(), "TN should be int32_t");
     const Repartition<int8_t, DN> di8;
     using VI8 = Vec<decltype(di8)>;
@@ -93,7 +93,7 @@ HWY_NOINLINE void TestAllInt8PerBlock2x2MatMul() {
 struct TestBf16PerBlock2x2MatMul {
   template <typename TN, class DN>
   HWY_NOINLINE void operator()(TN /*unused*/, DN dn) {
-#if HWY_TARGET != HWY_SCALAR
+#if HWY_NATIVE_PER_BLOCK_2X2_MATMUL_BF16
     static_assert(IsSame<TN, float>(), "TN should be float");
     const Repartition<hwy::bfloat16_t, DN> dbf;
     using VBF = Vec<decltype(dbf)>;


### PR DESCRIPTION
Added default implementation of PerBlock2x2MatMul in generic_ops-inl.h for targets other than HWY_SCALAR where `HWY_NATIVE_PER_BLOCK_2X2_MATMUL_BF16` is 0.

Also made fix to `d` argument type to PerBlock2x2MatMul implementation in arm_neon-inl.h as there are Simd tags other than `Simd<int32_t, 4, 0>` such as `Simd<int32_t, 2, 1>` and `Simd<int32_t, 1, 2>` that are tags for 16-byte SIMD vectors.

Also added matmul_op_test.cc to CMakeLists.txt.

Also enabled TestInt8PerBlock2x2MatMul and TestBf16PerBlock2x2MatMul for all targets except for HWY_SCALAR.

Also fixed compiler warnings in matmul_op_test.cc.