### PR TITLE
Fixes to SVE BF16 MulEvenAdd and WidenMulEven

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -6450,6 +6450,7 @@ template <size_t N, int kPow2>
 HWY_API svfloat32_t MulEvenAdd(Simd<float, N, kPow2> dw, VBF16 a, VBF16 b,
                                const svfloat32_t c) {
 #if HWY_SVE_HAVE_BF16_FEATURE
+  (void)dw;
   return svbfmlalb_f32(c, a, b);
 #else
   return MulAdd(PromoteEvenTo(dw, a), PromoteEvenTo(dw, b), c);
@@ -6520,7 +6521,7 @@ template <size_t N, int kPow2>
 HWY_API svfloat32_t WidenMulEven(Simd<float, N, kPow2> dw, VBF16 a, VBF16 b) {
 #if HWY_SVE_HAVE_BF16_FEATURE
   (void)dw;
-  return MulEvenAdd(dw, Zero(dw), a, b);
+  return MulEvenAdd(dw, a, b, Zero(dw));
 #else
   // Same as MulEvenAdd, but without generating a zero argument.
   return Mul(PromoteEvenTo(dw, a), PromoteEvenTo(dw, b));


### PR DESCRIPTION
Corrected BF16 WidenMulEven to fix compiler errors if SVE BF16 is enabled.

In addition, fixed compiler warning in BF16 MulEvenAdd to fix compiler warning if SVE BF16 is enabled.