### PR TITLE
Fix build on ppc64/s390x

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -354,9 +354,11 @@ void TestSelectWithNaN() {
   }
 #endif
   TestSelectWithNaNForType<float>();
+#if HWY_HAVE_FLOAT64
   if (hwy::HaveFloat64()) {
     TestSelectWithNaNForType<double>();
   }
+#endif
 }
 
 }  // namespace

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -348,9 +348,11 @@ void TestSelectWithNaNForType() {
 }
 
 void TestSelectWithNaN() {
+#if HWY_HAVE_FLOAT16
   if (hwy::HaveFloat16()) {
     TestSelectWithNaNForType<float16_t>();
   }
+#endif
   TestSelectWithNaNForType<float>();
   if (hwy::HaveFloat64()) {
     TestSelectWithNaNForType<double>();


### PR DESCRIPTION
Fix is needed after 636d64d8 since said platforms do not support F16 and fail during compilation:
```
hwy/contrib/sort/sort_test.cc:298:39: error: no matching constructor for initialization of 'hwy::float16_t'
  298 |   std::iota(keys.begin(), keys.end(), T{0});
```