### PR TITLE
Fix sort_test build on toolchains without native float16

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -295,7 +295,10 @@ void TestSelectWithNaNForType() {
   const size_t k = num / 2;
 
   std::vector<T> keys(num);
-  std::iota(keys.begin(), keys.end(), T{0});
+  // Not std::iota: emulated float16_t lacks construction from int.
+  for (size_t i = 0; i < num; ++i) {
+    keys[i] = ConvertScalarTo<T>(i);
+  }
   std::mt19937_64 rng(123456789);
   std::shuffle(keys.begin(), keys.end(), rng);
 
@@ -323,7 +326,7 @@ void TestSelectWithNaNForType() {
   for (T x : keys) {
     if (x != x) {
       ++num_nan;
-    } else if (x == kInf || x == -kInf) {
+    } else if (ScalarAbs(x) == kInf) {  // emulated float16_t lacks unary minus
       ++num_inf;
     } else {
       finite_out.push_back(x);


### PR DESCRIPTION
`sort_test.cc` fails to build where `hwy::float16_t` is emulated: `std::iota` with `T{0}` needs construction from `int`, and `-kInf` needs unary minus (GCC 9–12, Clang 11–15, armv7, ppc64le, LoongArch64, Windows LLVM). Fixes #3112.

- Replace the iota with `ConvertScalarTo<T>`, and `x == kInf || x == -kInf` with `ScalarAbs(x) == kInf`.
- Guard the f16 instantiation with `HWY_HAVE_FLOAT16` (as in `CallAllSortTraits`): f16 `GetLane` does not compile on LSX (noted in #3112).

Errors reproduce under `-DHWY_HAVE_SCALAR_F16_TYPE=0` and compile cleanly with the fix; `sort_test --gtest_filter='*SelectWithNaN*'` passes on AArch64.
