### PR TITLE
Support value construction, unary minus, and increment on emulated float16_t

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -1292,6 +1292,24 @@ struct alignas(2) float16_t {
   static constexpr float16_t FromBits(uint16_t bits) {
     return float16_t(F16FromU16BitsTag(), bits);
   }
+
+  // Emulated scalar operators so generic code (e.g. std::iota, unary minus)
+  // also compiles when there is no native _Float16. Construction and
+  // increment/decrement use ConvertScalarTo, defined after the struct, so they
+  // are declared here and defined out-of-class below.
+  template <typename T, HWY_IF_NOT_F16(T)>
+  explicit constexpr float16_t(T arg);
+
+  // Unary minus is an exact sign-bit flip; no conversion needed.
+  constexpr float16_t operator-() const noexcept {
+    return FromBits(static_cast<uint16_t>(bits ^ uint16_t{0x8000}));
+  }
+  constexpr float16_t operator+() const noexcept { return *this; }
+
+  HWY_CXX14_CONSTEXPR float16_t& operator++() noexcept;
+  HWY_CXX14_CONSTEXPR float16_t operator++(int) noexcept;
+  HWY_CXX14_CONSTEXPR float16_t& operator--() noexcept;
+  HWY_CXX14_CONSTEXPR float16_t operator--(int) noexcept;
 #endif  // HWY_HAVE_SCALAR_F16_TYPE
 
   // When backed by a native type, ensure the wrapper behaves like the native
@@ -1701,11 +1719,13 @@ HWY_F16_CONSTEXPR inline std::partial_ordering operator<=>(
 #endif  // HWY_SSE2_HAVE_SCALAR_BF16_TYPE
 
 // Compiler supports __bf16, not necessarily with operators.
+#ifndef HWY_HAVE_SCALAR_BF16_TYPE  // allow override
 #if HWY_ARM_HAVE_SCALAR_BF16_TYPE || HWY_SSE2_HAVE_SCALAR_BF16_TYPE
 #define HWY_HAVE_SCALAR_BF16_TYPE 1
 #else
 #define HWY_HAVE_SCALAR_BF16_TYPE 0
 #endif
+#endif  // HWY_HAVE_SCALAR_BF16_TYPE
 
 #ifndef HWY_HAVE_SCALAR_BF16_OPERATORS
 // Recent enough compiler also has operators. aarch64 clang 18 hits internal
@@ -1772,6 +1792,20 @@ struct alignas(2) bfloat16_t {
   static constexpr bfloat16_t FromBits(uint16_t bits) {
     return bfloat16_t(BF16FromU16BitsTag(), bits);
   }
+
+  // Emulated scalar operators (mirrors float16_t).
+  template <typename T, HWY_IF_NOT_BF16(T)>
+  explicit constexpr bfloat16_t(T arg);
+
+  constexpr bfloat16_t operator-() const noexcept {
+    return FromBits(static_cast<uint16_t>(bits ^ uint16_t{0x8000}));
+  }
+  constexpr bfloat16_t operator+() const noexcept { return *this; }
+
+  HWY_CXX14_CONSTEXPR bfloat16_t& operator++() noexcept;
+  HWY_CXX14_CONSTEXPR bfloat16_t operator++(int) noexcept;
+  HWY_CXX14_CONSTEXPR bfloat16_t& operator--() noexcept;
+  HWY_CXX14_CONSTEXPR bfloat16_t operator--(int) noexcept;
 #endif
 
   // When backed by a native type, ensure the wrapper behaves like the native
@@ -2718,6 +2752,61 @@ HWY_API constexpr TTo ConvertScalarTo(TFrom in) {
                   : 0>(),
           static_cast<TFrom&&>(in)));
 }
+
+#if !HWY_HAVE_SCALAR_F16_TYPE
+// Emulated float16_t operators (declared in the struct). ConvertScalarTo
+// converts any scalar to/from f16 without spelling out the F32/F64 converter.
+template <typename T,
+          hwy::EnableIf<!hwy::IsSame<hwy::RemoveCvRef<T>, hwy::float16_t>()>*>
+constexpr float16_t::float16_t(T arg)
+    : float16_t(ConvertScalarTo<float16_t>(arg)) {}
+
+HWY_CXX14_CONSTEXPR inline float16_t& float16_t::operator++() noexcept {
+  bits = ConvertScalarTo<float16_t>(ConvertScalarTo<float>(*this) + 1.0f).bits;
+  return *this;
+}
+HWY_CXX14_CONSTEXPR inline float16_t float16_t::operator++(int) noexcept {
+  const float16_t result = *this;
+  ++*this;
+  return result;
+}
+HWY_CXX14_CONSTEXPR inline float16_t& float16_t::operator--() noexcept {
+  bits = ConvertScalarTo<float16_t>(ConvertScalarTo<float>(*this) - 1.0f).bits;
+  return *this;
+}
+HWY_CXX14_CONSTEXPR inline float16_t float16_t::operator--(int) noexcept {
+  const float16_t result = *this;
+  --*this;
+  return result;
+}
+#endif  // !HWY_HAVE_SCALAR_F16_TYPE
+
+#if !HWY_HAVE_SCALAR_BF16_TYPE
+// Emulated bfloat16_t operators (mirrors float16_t).
+template <typename T,
+          hwy::EnableIf<!hwy::IsSame<hwy::RemoveCvRef<T>, hwy::bfloat16_t>()>*>
+constexpr bfloat16_t::bfloat16_t(T arg)
+    : bfloat16_t(ConvertScalarTo<bfloat16_t>(arg)) {}
+
+HWY_CXX14_CONSTEXPR inline bfloat16_t& bfloat16_t::operator++() noexcept {
+  bits = ConvertScalarTo<bfloat16_t>(ConvertScalarTo<float>(*this) + 1.0f).bits;
+  return *this;
+}
+HWY_CXX14_CONSTEXPR inline bfloat16_t bfloat16_t::operator++(int) noexcept {
+  const bfloat16_t result = *this;
+  ++*this;
+  return result;
+}
+HWY_CXX14_CONSTEXPR inline bfloat16_t& bfloat16_t::operator--() noexcept {
+  bits = ConvertScalarTo<bfloat16_t>(ConvertScalarTo<float>(*this) - 1.0f).bits;
+  return *this;
+}
+HWY_CXX14_CONSTEXPR inline bfloat16_t bfloat16_t::operator--(int) noexcept {
+  const bfloat16_t result = *this;
+  --*this;
+  return result;
+}
+#endif  // !HWY_HAVE_SCALAR_BF16_TYPE
 
 //------------------------------------------------------------------------------
 // Helper functions

--- a/hwy/base_test.cc
+++ b/hwy/base_test.cc
@@ -846,6 +846,42 @@ struct TestSpecialFloat {
             hwy::EnableIf<!EnableSpecialFloatArithOpTest<T>()>* = nullptr>
   static HWY_INLINE void TestSpecialFloatArithOperators(T /*unused*/) {}
 
+  // The emulated scalar operators (value ctor, unary minus, ++/--) are provided
+  // when the special float lacks a native type. When a native type exists they
+  // are only available if the native operators are (HWY_HAVE_SCALAR_*_OPERATORS).
+  template <class T>
+  static constexpr bool EnableSpecialFloatScalarOpsTest() {
+    return (hwy::IsSame<T, float16_t>() &&
+            (HWY_HAVE_SCALAR_F16_OPERATORS || !HWY_HAVE_SCALAR_F16_TYPE)) ||
+           (hwy::IsSame<T, bfloat16_t>() &&
+            (HWY_HAVE_SCALAR_BF16_OPERATORS || !HWY_HAVE_SCALAR_BF16_TYPE));
+  }
+
+  // Value construction, unary minus, and increment/decrement work for both
+  // special floats on every target, including those that emulate them with a
+  // uint16_t (where these previously failed to compile). Both float16_t and
+  // bfloat16_t now provide them.
+  template <class T,
+            hwy::EnableIf<EnableSpecialFloatScalarOpsTest<T>()>* = nullptr>
+  static HWY_NOINLINE void TestSpecialFloatScalarOps(T /*unused*/) {
+    HWY_ASSERT_EQ(2.0f, ConvertScalarTo<float>(T(2)));    // value ctor from int
+    HWY_ASSERT_EQ(2.5f, ConvertScalarTo<float>(T(2.5)));  // value ctor from double
+    HWY_ASSERT_EQ(-3.0f, ConvertScalarTo<float>(-T(3)));  // unary minus
+    // Start from a value the compiler cannot predict, then PreventElision on
+    // the result so the increment/decrement is not optimized away.
+    T inc = T(Unpredictable1());  // == 1
+    ++inc;                        // 2
+    HWY_ASSERT_EQ(2.0f, ConvertScalarTo<float>(inc));  // pre-increment
+    PreventElision(inc);
+    T dec = T(Unpredictable1());  // == 1
+    --dec;                        // 0
+    HWY_ASSERT_EQ(0.0f, ConvertScalarTo<float>(dec));  // pre-decrement
+    PreventElision(dec);
+  }
+  template <class T,
+            hwy::EnableIf<!EnableSpecialFloatScalarOpsTest<T>()>* = nullptr>
+  static HWY_INLINE void TestSpecialFloatScalarOps(T /*unused*/) {}
+
   template <class T>
   HWY_NOINLINE void operator()(T /*unused*/) const {
     static_assert(IsSpecialFloat<T>(), "IsSpecialFloat<T>() must be true");
@@ -894,6 +930,7 @@ struct TestSpecialFloat {
     HWY_ASSERT(ConvertScalarTo<T>(41984.0f) >= ConvertScalarTo<T>(370.0f));
 
     TestSpecialFloatArithOperators(T());
+    TestSpecialFloatScalarOps(T());
   }
 };
 


### PR DESCRIPTION
Extends the emulated `hwy::float16_t` (the `uint16_t`-backed type used when there is no native `_Float16`, e.g. PowerPC / older compilers) so generic code like `std::iota(v.begin(), v.end(), T{0})` and unary minus compile on those targets. Follows up the discussion in #3112.

Added for the emulated build only (mirroring the native operators):
- converting constructor from any value static-castable to `double` (rounds via `F16FromF64`)
- unary minus (exact sign-bit flip) and unary plus
- pre/post `++` / `--` (via an `F32` round-trip)

All `constexpr` where the converters are; the native path is untouched (everything is behind `#if !HWY_HAVE_SCALAR_F16_TYPE`).

Notes:
- Comparison operators already work for emulated `float16_t`, so this set is enough for `std::iota`, fill, negate, and sort-by-value.
- Binary `+ - * /` are intentionally omitted (Highway converts to `float` before scalar f16 arithmetic).
- `bfloat16_t` has the same gap — happy to mirror it in a follow-up, or fold it in here if you'd prefer parity.

Tested on AArch64 (native) and by forcing `-DHWY_HAVE_SCALAR_F16_TYPE=0` (the emulated path), where `std::iota` over `float16_t` now compiles and runs. `base_test` now covers construction / unary minus / increment for `float16_t` on all targets.
