### PR TITLE
ci: pin actions to full commit SHAs in meson and multiarch workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install ${{ matrix.extra_deps }}
@@ -260,7 +260,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install ${{ matrix.extra_deps }}
@@ -281,7 +281,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3.0.0
 

--- a/.github/workflows/meson_build_test.yml
+++ b/.github/workflows/meson_build_test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
         # meson on jammy is at version 0.61.2, so install through pipx
       - name: Install build requirements
@@ -86,7 +86,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
         # meson on noble is at 1.3.2
       - name: Install deps
@@ -132,7 +132,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install ninja-build meson libgtest-dev ${{ matrix.extra_deps }}
@@ -179,7 +179,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
         # update the meson gtest wrap because we're going to use a c++17 standard
       - name: Install deps

--- a/.github/workflows/meson_build_test.yml
+++ b/.github/workflows/meson_build_test.yml
@@ -215,9 +215,9 @@ jobs:
             distro: ubuntu_latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6.0.3
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
     - name: Build and test
-      uses: uraimo/run-on-arch-action@v3.1.0
+      uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
       id: build
       with:
         arch: ${{ matrix.arch }}

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install ${{ matrix.extra_deps }}
@@ -106,7 +106,7 @@ jobs:
         with:
           egress-policy: audit  # cannot be block - runner does git checkout
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install deps
         run: |

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -24,9 +24,9 @@ jobs:
             distro: ubuntu_latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6.0.3
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
     - name: Build and test
-      uses: uraimo/run-on-arch-action@v3.1.0
+      uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
       id: build
       with:
         arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Summary

Two workflow files (`meson_build_test.yml`, `multiarch.yml`) used mutable action tag references that can be silently re-pointed to different—potentially malicious—commits.

### Changes

| Workflow | Action | Before | After |
|----------|--------|--------|-------|
| both | `actions/checkout` | `@v6.0.3` | `@9f698171ed81b15d1823a05fc7211befd50c8ae0` |
| both | `uraimo/run-on-arch-action` | `@v3.1.0` | `@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9` |

Original tags kept as comments. The other two workflows (`build_test.yml`, `docs_pages_workflow.yml`) already use pinned SHAs and are unchanged.

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.