### PR TITLE
Add `HWY_ENABLE_LIST_TARGETS` to control building `hwy_list_targets`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,14 @@ set(HWY_ENABLE_EXAMPLES ON CACHE BOOL "Build examples")
 set(HWY_ENABLE_INSTALL ON CACHE BOOL "Install library")
 set(HWY_ENABLE_TESTS ON CACHE BOOL "Enable HWY tests")
 
+# CMake 3.21 introduces PROJECT_IS_TOP_LEVEL / <PROJECT-NAME>_IS_TOP_LEVEL
+if(NOT DEFINED PROJECT_IS_TOP_LEVEL OR NOT DEFINED ${PROJECT_NAME}_IS_TOP_LEVEL)
+  set(PROJECT_IS_TOP_LEVEL ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  set(${PROJECT_NAME}_IS_TOP_LEVEL ${PROJECT_IS_TOP_LEVEL})
+endif()
+
+set(HWY_ENABLE_LIST_TARGETS ${PROJECT_IS_TOP_LEVEL} CACHE BOOL "Build hwy_list_targets")
+
 if (MSVC)
 set(HWY_TEST_STANDALONE ON CACHE BOOL "Disable use of googletest")
 else()
@@ -625,7 +633,7 @@ if(UNIX AND NOT APPLE)
 endif()
 endif()  # HWY_ENABLE_TESTS
 
-if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if (HWY_ENABLE_LIST_TARGETS)
 # -------------------------------------------------------- hwy_list_targets
 # Generate a tool to print the compiled-in targets as defined by the current
 # flags. This tool will print to stderr at build time, after building hwy.


### PR DESCRIPTION
In #3076, the `hwy_list_targets` target in CMake was altered to only build if it were a top-level project. Some CI systems, notably libjxl, relied on the output of that target automatically running even if not top-level. 

This PR introduces a `HWY_ENABLE_LIST_TARGETS` option to override this new default behavior. For CMake < 3.21, it also sets `PROJECT_IS_TOP_LEVEL` and `<PROJECT-NAME>_IS_TOP_LEVEL` for convenience. 

Tested on:
* EL9's CMake-3.26.5
* Kitware's static-distribution CMake-3.10.3
* Kitware's static-distribution CMake-4.3.3