### PR TITLE
Fix VQSelect/PartialSort NaN handling for arrays containing real inf

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -286,80 +286,160 @@ void TestPartialSortKEqualsN() {
   }
 }
 
-// VQSelect on a floating-point array containing NaN must still leave a
-// permutation of the input (NaNs allowed anywhere): no value may be created or
-// lost.
+// Shuffled finite values (within float16_t's exact range to avoid overflow to
+// inf), with a few NaN and a few real +inf at spread-out positions. The +inf
+// is the case a by-value sentinel scan confuses with NaN. Returns the NaN count.
 template <typename T>
-void TestSelectWithNaNForType() {
-  const size_t num = AdjustedReps(100000);
-  const size_t k = num / 2;
+std::vector<T> MakeNaNInfInput(size_t num, uint64_t seed, size_t& num_nan) {
+  std::vector<float> vals(num);
+  for (size_t i = 0; i < num; ++i) vals[i] = static_cast<float>(i % 1024);
+  std::mt19937_64 rng(seed);
+  std::shuffle(vals.begin(), vals.end(), rng);
 
   std::vector<T> keys(num);
-  // Not std::iota: emulated float16_t lacks construction from int.
-  for (size_t i = 0; i < num; ++i) {
-    keys[i] = ConvertScalarTo<T>(i);
-  }
-  std::mt19937_64 rng(123456789);
-  std::shuffle(keys.begin(), keys.end(), rng);
+  for (size_t i = 0; i < num; ++i) keys[i] = ConvertScalarTo<T>(vals[i]);
 
-  // Inject NaN at a handful of positions.
   const ScalableTag<T> d;
   const T kNaN = GetLane(NaN(d));
-  size_t injected = 0;
-  for (size_t i = 0; i < num; i += 9999) {
-    keys[i] = kNaN;
-    ++injected;
-  }
-
-  // Multiset of the finite values that a correct partition must preserve.
-  std::vector<T> finite_in;
-  for (T x : keys) {
-    if (x == x) finite_in.push_back(x);  // x != x  <=>  NaN
-  }
-  std::sort(finite_in.begin(), finite_in.end());
-
-  hwy::VQSelect(keys.data(), num, k, hwy::SortAscending());
-
   const T kInf = GetLane(Inf(d));
-  size_t num_inf = 0, num_nan = 0;
-  std::vector<T> finite_out;
-  for (T x : keys) {
-    if (x != x) {
-      ++num_nan;
-    } else if (ScalarAbs(x) == kInf) {  // emulated float16_t lacks unary minus
-      ++num_inf;
-    } else {
-      finite_out.push_back(x);
+  const size_t kNumNaN = 8, kNumInf = 6, kTotal = kNumNaN + kNumInf;
+  for (size_t m = 0; m < kTotal; ++m) {
+    const size_t pos = (m + 1) * num / (kTotal + 1);
+    keys[pos] = (m < kNumNaN) ? kNaN : kInf;
+  }
+  num_nan = kNumNaN;
+  return keys;
+}
+
+// VQSelect must leave a permutation of the input (NaN ordered to the back) with
+// keys[k] matching that order, even with real +inf present. Verification is in
+// float via bit-pattern helpers so T = float16_t works without native f16 ops.
+template <typename T, class Order>
+void TestSelectWithNaNForType(Order order) {
+  const size_t num = AdjustedReps(100000);
+  if (num < 32) return;
+  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
+
+  size_t num_nan;
+  const std::vector<T> input = MakeNaNInfInput<T>(num, 123456789, num_nan);
+
+  // Float reference order (NaN last) and the preserved non-NaN multiset.
+  std::vector<float> ref(num), nonnan_in;
+  for (size_t i = 0; i < num; ++i) ref[i] = ConvertScalarTo<float>(input[i]);
+  for (float x : ref) {
+    if (!ScalarIsNaN(x)) nonnan_in.push_back(x);
+  }
+  std::sort(nonnan_in.begin(), nonnan_in.end());
+  std::sort(ref.begin(), ref.end(), [](float a, float b) {
+    if (ScalarIsNaN(a)) return false;  // NaN sorts to the back
+    if (ScalarIsNaN(b)) return true;
+    return asc ? (a < b) : (a > b);
+  });
+
+  // A finite-region k and a NaN-region k; the latter catches the +inf/NaN
+  // collision (keys[k] must be NaN, not a leaked +inf).
+  for (const size_t k : {num / 2, num - 2}) {
+    std::vector<T> keys = input;
+    hwy::VQSelect(keys.data(), num, k, order);
+
+    size_t got_nan = 0;
+    std::vector<float> nonnan_out;
+    for (T x : keys) {
+      const float f = ConvertScalarTo<float>(x);
+      if (ScalarIsNaN(f)) {
+        ++got_nan;
+      } else {
+        nonnan_out.push_back(f);
+      }
+    }
+    std::sort(nonnan_out.begin(), nonnan_out.end());
+
+    const float got = ConvertScalarTo<float>(keys[k]);
+    const bool kth_ok =
+        (got == ref[k]) || (ScalarIsNaN(got) && ScalarIsNaN(ref[k]));
+    if (got_nan != num_nan || nonnan_out != nonnan_in || !kth_ok) {
+      HWY_ABORT(
+          "VQSelect NaN/inf wrong: nan=%zu/%zu multiset=%d kth=%d "
+          "(sizeof(T)=%zu k=%zu asc=%d)\n",
+          got_nan, num_nan, static_cast<int>(nonnan_out == nonnan_in),
+          static_cast<int>(kth_ok), sizeof(T), k, static_cast<int>(asc));
     }
   }
-  std::sort(finite_out.begin(), finite_out.end());
+}
 
-  if (num_inf != 0) {
-    HWY_ABORT("VQSelect leaked %zu inf into a NaN array (sizeof(T)=%zu)\n",
-              num_inf, sizeof(T));
+// Same for VQPartialSort, also checking the first min(k, num_valid) elements
+// are sorted; k = num exercises k > num_valid.
+template <typename T, class Order>
+void TestPartialSortWithNaNForType(Order order) {
+  const size_t num = AdjustedReps(100000);
+  if (num < 32) return;
+  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
+
+  size_t num_nan;
+  const std::vector<T> input = MakeNaNInfInput<T>(num, 424242, num_nan);
+  const size_t num_valid = num - num_nan;
+
+  std::vector<float> nonnan_in;
+  for (T x : input) {
+    const float f = ConvertScalarTo<float>(x);
+    if (!ScalarIsNaN(f)) nonnan_in.push_back(f);
   }
-  if (num_nan != injected) {
-    HWY_ABORT("VQSelect changed NaN count: got %zu, want %zu (sizeof(T)=%zu)\n",
-              num_nan, injected, sizeof(T));
+  std::sort(nonnan_in.begin(), nonnan_in.end());
+
+  for (const size_t k : {num / 2, num}) {
+    std::vector<T> keys = input;
+    hwy::VQPartialSort(keys.data(), num, k, order);
+
+    size_t got_nan = 0;
+    std::vector<float> nonnan_out;
+    for (T x : keys) {
+      const float f = ConvertScalarTo<float>(x);
+      if (ScalarIsNaN(f)) {
+        ++got_nan;
+      } else {
+        nonnan_out.push_back(f);
+      }
+    }
+    std::sort(nonnan_out.begin(), nonnan_out.end());
+
+    const size_t sorted_len = (k < num_valid) ? k : num_valid;
+    bool prefix_ok = true;
+    for (size_t i = 1; i < sorted_len; ++i) {
+      const float a = ConvertScalarTo<float>(keys[i - 1]);
+      const float b = ConvertScalarTo<float>(keys[i]);
+      if (asc ? (a > b) : (a < b)) {
+        prefix_ok = false;
+        break;
+      }
+    }
+    if (got_nan != num_nan || nonnan_out != nonnan_in || !prefix_ok) {
+      HWY_ABORT(
+          "VQPartialSort NaN/inf wrong: nan=%zu/%zu multiset=%d prefix=%d "
+          "(sizeof(T)=%zu k=%zu asc=%d)\n",
+          got_nan, num_nan, static_cast<int>(nonnan_out == nonnan_in),
+          static_cast<int>(prefix_ok), sizeof(T), k, static_cast<int>(asc));
+    }
   }
-  if (finite_out != finite_in) {
-    HWY_ABORT(
-        "VQSelect did not preserve the finite multiset: result is not a "
-        "permutation of the input (sizeof(T)=%zu)\n",
-        sizeof(T));
-  }
+}
+
+template <typename T>
+void TestSelectAndPartialSortWithNaNForType() {
+  TestSelectWithNaNForType<T>(hwy::SortAscending());
+  TestSelectWithNaNForType<T>(hwy::SortDescending());
+  TestPartialSortWithNaNForType<T>(hwy::SortAscending());
+  TestPartialSortWithNaNForType<T>(hwy::SortDescending());
 }
 
 void TestSelectWithNaN() {
 #if HWY_HAVE_FLOAT16
   if (hwy::HaveFloat16()) {
-    TestSelectWithNaNForType<float16_t>();
+    TestSelectAndPartialSortWithNaNForType<float16_t>();
   }
 #endif
-  TestSelectWithNaNForType<float>();
+  TestSelectAndPartialSortWithNaNForType<float>();
 #if HWY_HAVE_FLOAT64
   if (hwy::HaveFloat64()) {
-    TestSelectWithNaNForType<double>();
+    TestSelectAndPartialSortWithNaNForType<double>();
   }
 #endif
 }

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -1956,43 +1956,40 @@ HWY_INLINE size_t CountAndReplaceNaN(D, Traits, T* HWY_RESTRICT, size_t) {
   return 0;
 }
 
-// Scans the array for sentinel values (st.LastValue) that were substituted for
-// NaN by CountAndReplaceNaN, and replaces exactly `num_nan` of them back to
-// NaN. Unlike Fill() at the tail, this is safe for Select/PartialSort where
-// the sentinels may not have migrated to the back of the array.
+// Compacts non-NaN keys to the front, fills the tail with canonical NaN, and
+// returns the NaN count; Select/PartialSort then operate on keys[0, num-num_nan).
+// Detecting NaN by IsNaN avoids the CountAndReplaceNaN sentinel, whose value
+// (+inf when ascending) is indistinguishable from real +inf after a partial op.
+// In-place CompressStore is safe (the write cursor never overtakes the reader,
+// as in StoreLeftRight); slots past it are cleared by the Fill.
 template <class D, class Traits, typename T, HWY_IF_FLOAT(T)>
-HWY_INLINE void ReplaceSentinelWithNaN(D d, Traits st, T* HWY_RESTRICT keys,
-                                       size_t num, size_t num_nan) {
+HWY_INLINE size_t PartitionNaNToBack(D d, Traits, T* HWY_RESTRICT keys,
+                                     size_t num) {
   const size_t N = Lanes(d);
-  const Vec<D> sentinel = st.LastValue(d);
-  const Vec<D> nan = NaN(d);
-  size_t replaced = 0;
-  size_t i = 0;
+  size_t w = 0, i = 0;
   if (num >= N) {
     for (; i <= num - N; i += N) {
       const Vec<D> v = LoadU(d, keys + i);
-      const Mask<D> is_sentinel = Eq(v, sentinel);
-      const size_t count = CountTrue(d, is_sentinel);
-      BlendedStore(nan, is_sentinel, d, keys + i);
-      replaced += count;
-      if (replaced >= num_nan) return;
+      w += CompressStore(v, Not(IsNaN(v)), d, keys + w);
     }
   }
-
   const size_t remaining = num - i;
   if (remaining != 0) {
-    const Vec<D> v = LoadN(d, keys + i, remaining);
-    const Mask<D> is_sentinel = Eq(v, sentinel);
-    const size_t count = CountTrue(d, is_sentinel);
-    StoreN(IfThenElse(is_sentinel, nan, v), d, keys + i, remaining);
-    replaced += count;
+    const Vec<D> v = LoadN(d, keys + i, remaining);  // pads with non-NaN zero
+    const Mask<D> keep = And(FirstN(d, remaining), Not(IsNaN(v)));
+    const size_t count = CountTrue(d, keep);
+    StoreN(Compress(v, keep), d, keys + w, count);
+    w += count;
   }
-  HWY_DASSERT(replaced == num_nan);
+  Fill(d, GetLane(NaN(d)), num - w, keys + w);
+  return num - w;
 }
 
+// IsNaN is not implemented for non-float, so this is a no-op there.
 template <class D, class Traits, typename T, HWY_IF_NOT_FLOAT(T)>
-HWY_INLINE void ReplaceSentinelWithNaN(D, Traits, T* HWY_RESTRICT, size_t,
-                                       size_t) {}
+HWY_INLINE size_t PartitionNaNToBack(D, Traits, T* HWY_RESTRICT, size_t) {
+  return 0;
+}
 
 }  // namespace detail
 
@@ -2056,21 +2053,25 @@ void PartialSort(D d, Traits st, T* HWY_RESTRICT keys, size_t num, size_t k,
   }
 #endif  // HWY_MAX_BYTES > 64
 
-  const size_t num_nan = detail::CountAndReplaceNaN(d, st, keys, num);
+  // Move NaNs to the back and operate on the non-NaN prefix; k past num_valid
+  // lands in the (already-ordered) NaN region, so clamp the range to num_valid.
+  const size_t num_valid = num - detail::PartitionNaNToBack(d, st, keys, num);
+  const size_t k_valid = (k < num_valid) ? k : num_valid;
+  if (num_valid == 0) return;
 
 #if VQSORT_ENABLED || HWY_IDE
-  if (!detail::HandleSpecialCases(d, st, keys, num, buf)) {  // TODO
+  if (!detail::HandleSpecialCases(d, st, keys, num_valid, buf)) {  // TODO
     uint64_t* HWY_RESTRICT state = hwy::detail::GetGeneratorStateStatic();
     // Introspection: switch to worst-case N*logN heapsort after this many.
     // Should never be reached, so computing log2 exactly does not help.
     const size_t max_levels = 50;
-    // When k == num, selecting all elements is a no-op; skip to avoid
-    // assertion failure in Select, which requires k < num.
-    if (k < num) {
-      detail::Recurse<detail::RecurseMode::kSelect>(d, st, keys, num, buf,
-                                                    state, max_levels, k);
+    // k_valid == num_valid selects all elements (a no-op); skip, as Select
+    // requires k < num.
+    if (k_valid < num_valid) {
+      detail::Recurse<detail::RecurseMode::kSelect>(d, st, keys, num_valid, buf,
+                                                    state, max_levels, k_valid);
     }
-    detail::Recurse<detail::RecurseMode::kSort>(d, st, keys, k, buf, state,
+    detail::Recurse<detail::RecurseMode::kSort>(d, st, keys, k_valid, buf, state,
                                                 max_levels);
   }
 #else   // !VQSORT_ENABLED
@@ -2079,14 +2080,8 @@ void PartialSort(D d, Traits st, T* HWY_RESTRICT keys, size_t num, size_t k,
   if (VQSORT_PRINT >= 1) {
     HWY_WARN("using slow HeapSort because vqsort disabled\n");
   }
-  detail::HeapPartialSort(st, keys, num, k);
+  detail::HeapPartialSort(st, keys, num_valid, k_valid);
 #endif  // VQSORT_ENABLED
-
-  if (num_nan != 0) {
-    // Unlike a full sort, partial sort does not guarantee all sentinels end up
-    // at the back, so we must scan for them rather than blindly overwriting.
-    detail::ReplaceSentinelWithNaN(d, st, keys, num, num_nan);
-  }
 }
 
 template <class D, class Traits, typename T>
@@ -2105,16 +2100,19 @@ void Select(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
   }
 #endif  // HWY_MAX_BYTES > 64
 
-  const size_t num_nan = detail::CountAndReplaceNaN(d, st, keys, num);
+  // Move NaNs to the back and select over the non-NaN prefix; if k is in the
+  // NaN region the postcondition already holds (non-NaN all precede NaN).
+  const size_t num_valid = num - detail::PartitionNaNToBack(d, st, keys, num);
+  if (k >= num_valid) return;
 
 #if VQSORT_ENABLED || HWY_IDE
-  if (!detail::HandleSpecialCases(d, st, keys, num, buf)) {  // TODO
+  if (!detail::HandleSpecialCases(d, st, keys, num_valid, buf)) {  // TODO
     uint64_t* HWY_RESTRICT state = hwy::detail::GetGeneratorStateStatic();
     // Introspection: switch to worst-case N*logN heapsort after this many.
     // Should never be reached, so computing log2 exactly does not help.
     const size_t max_levels = 50;
-    detail::Recurse<detail::RecurseMode::kSelect>(d, st, keys, num, buf, state,
-                                                  max_levels, k);
+    detail::Recurse<detail::RecurseMode::kSelect>(d, st, keys, num_valid, buf,
+                                                  state, max_levels, k);
   }
 #else   // !VQSORT_ENABLED
   (void)d;
@@ -2122,14 +2120,8 @@ void Select(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
   if (VQSORT_PRINT >= 1) {
     HWY_WARN("using slow HeapSort because vqsort disabled\n");
   }
-  detail::HeapSelect(st, keys, num, k);
+  detail::HeapSelect(st, keys, num_valid, k);
 #endif  // VQSORT_ENABLED
-
-  if (num_nan != 0) {
-    // Unlike a full sort, select does not guarantee all sentinels end up at
-    // the back, so we must scan for them rather than blindly overwriting.
-    detail::ReplaceSentinelWithNaN(d, st, keys, num, num_nan);
-  }
 }
 
 // Sorts `keys[0..num-1]` according to the order defined by `st.Compare`.


### PR DESCRIPTION
Follow-up to #3104 (fixes the remaining case in #3098).
  
  **Bug.** #3104 restores NaN after a partial select/sort by scanning for the `st.LastValue` sentinel (`Eq(v, sentinel)`). But that sentinel is `+inf` for ascending so arrays containing real `+inf` alongside NaN still
  corrupt and the wrong slots become NaN. E.g. n=20000 with real `+inf` and `k` in the NaN-rank region, `VQSelect` returns `+inf` where the NaN-last order requires NaN.

  **Fix.** Replace the sentinel scheme on the partial paths with `detail::PartitionNaNToBack` (per @jan-wassenberg's suggestion) - one pass that `CompressStore`s the non-NaN lanes to the front, counts NaN via the mask, fills the tail with
  canonical NaN, then runs the partial op on the prefix `[0, num - num_nan)` (clamping `k`). Detection is by `IsNaN` so there's no sentinel and no `+inf` collision. `Sort()` is unchanged, `ReplaceSentinelWithNaN` is removed.

  **Tests.** `TestSelectWithNaN` now covers `VQSelect` and `VQPartialSort` × ascending/descending × float/double/float16 (runtime-gated) with NaN and real `+inf` present, checking `keys[k]`/sorted prefix and the non-NaN multiset. f16-safe
  via `ConvertScalarTo`/`ScalarIsNaN`/`ScalarIsInf`.

  Verified on aarch64 (NEON, NEON_WITHOUT_AES, EMU128, `HaveFloat16()=1`). The new test fails against the #3104 code and passes here