### PR TITLE
Fix DivCeil overflow and reject zero divisors

### DIFF
--- a/hwy/base.h
+++ b/hwy/base.h
@@ -2822,9 +2822,9 @@ HWY_API uint32_t LemireMod(uint32_t in, uint32_t range) {
 template <typename T1, typename T2>
 constexpr T1 DivCeil(T1 a, T2 b) {
 #if HWY_CXX_LANG >= 201703L
-  HWY_DASSERT(b != T2{0});
+  HWY_ASSERT(b != T2{0});
 #endif
-  return (a + b - 1) / b;
+  return a == T1{0} ? T1{0} : T1{1} + (a - T1{1}) / b;
 }
 
 // Works for any non-zero `align`; if a power of two, compiler emits ADD+AND.
@@ -3097,7 +3097,8 @@ HWY_API int64_t Mul128(int64_t a, int64_t b, int64_t* HWY_RESTRICT upper) {
 class Divisor {
  public:
   explicit Divisor(uint32_t divisor) : divisor_(divisor) {
-    if (divisor <= 1) return;
+    HWY_ASSERT(divisor != 0);
+    if (divisor == 1) return;
 
     const uint32_t len =
         static_cast<uint32_t>(31 - Num0BitsAboveMS1Bit_Nonzero32(divisor - 1));
@@ -3155,7 +3156,8 @@ class Divisor {
 class Divisor64 {
  public:
   explicit Divisor64(uint64_t divisor) : divisor_(divisor) {
-    if (divisor <= 1) return;
+    HWY_ASSERT(divisor != 0);
+    if (divisor == 1) return;
 
     const uint64_t len =
         static_cast<uint64_t>(63 - Num0BitsAboveMS1Bit_Nonzero64(divisor - 1));
@@ -3214,7 +3216,9 @@ class Divisor64 {
 // No Div128 available, use built-in 64-bit division on each call.
 class Divisor64 {
  public:
-  explicit Divisor64(uint64_t divisor) : divisor_(divisor) {}
+  explicit Divisor64(uint64_t divisor) : divisor_(divisor) {
+    HWY_ASSERT(divisor != 0);
+  }
 
   uint64_t GetDivisor() const { return divisor_; }
 

--- a/hwy/base_test.cc
+++ b/hwy/base_test.cc
@@ -256,6 +256,21 @@ HWY_NOINLINE void TestAllPopCount() {
   HWY_ASSERT_EQ(size_t{64}, PopCount(0xFFFFFFFFFFFFFFFFull));
 }
 
+HWY_NOINLINE void TestAllDivCeil() {
+  static_assert(DivCeil(size_t{0}, size_t{1}) == size_t{0},
+                "DivCeil must handle zero dividends");
+  static_assert(DivCeil(size_t{7}, size_t{7}) == size_t{1},
+                "DivCeil must remain constexpr");
+
+  HWY_ASSERT_EQ(size_t{0}, DivCeil(size_t{0}, size_t{1}));
+  HWY_ASSERT_EQ(size_t{0}, DivCeil(size_t{0}, size_t{7}));
+  HWY_ASSERT_EQ(size_t{1}, DivCeil(size_t{1}, size_t{7}));
+  HWY_ASSERT_EQ(size_t{2}, DivCeil(size_t{8}, size_t{7}));
+
+  constexpr size_t kMax = std::numeric_limits<size_t>::max();
+  HWY_ASSERT_EQ(kMax / size_t{2} + size_t{1}, DivCeil(kMax, size_t{2}));
+}
+
 // Exhaustive test for small/large dividends and divisors
 HWY_NOINLINE void TestAllDivisor() {
   // Small d, small n
@@ -949,6 +964,32 @@ HWY_AFTER_NAMESPACE();
 #if HWY_ONCE
 namespace hwy {
 namespace {
+#ifdef GTEST_HAS_DEATH_TEST
+#if HWY_CXX_LANG >= 201703L
+TEST(BaseDeathTest, DivCeilByZero) {
+  ASSERT_DEATH({ (void)DivCeil(size_t{1}, size_t{0}); }, "Assert b != T2");
+}
+#endif  // HWY_CXX_LANG >= 201703L
+
+TEST(BaseDeathTest, DivisorZero) {
+  ASSERT_DEATH(
+      {
+        Divisor divisor(0);
+        (void)divisor;
+      },
+      "Assert divisor != 0");
+}
+
+TEST(BaseDeathTest, Divisor64Zero) {
+  ASSERT_DEATH(
+      {
+        Divisor64 divisor(0);
+        (void)divisor;
+      },
+      "Assert divisor != 0");
+}
+#endif  // GTEST_HAS_DEATH_TEST
+
 HWY_BEFORE_TEST(BaseTest);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestUnreachable);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllLimits);
@@ -957,6 +998,7 @@ HWY_EXPORT_AND_TEST_P(BaseTest, TestAllType);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllIsSame);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllBitScan);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllPopCount);
+HWY_EXPORT_AND_TEST_P(BaseTest, TestAllDivCeil);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllDivisor);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllDivisor64);
 HWY_EXPORT_AND_TEST_P(BaseTest, TestAllScalarShr);


### PR DESCRIPTION
Fixes two edge cases in `hwy/base.h`:

- `DivCeil` used `(a + b - 1) / b`, which can overflow for large `a`. This switches it to the equivalent `a == 0 ? 0 : 1 + (a - 1) / b` form.
- `Divisor` and `Divisor64` accepted zero through the `<= 1` fast path. They now assert on zero and keep the `1` fast path explicit. The `Divisor64` fallback path gets the same check.

Tests:

- `./cmake-out/tests/base_test`
- C++11 and C++17 header compile probes for `DivCeil`
- Header-only `HWY_HAVE_DIV128=0` probe for the `Divisor64` fallback path