### PR TITLE
Fixes to Cuckoo2x2, PHAST, and ctf_aes example on big-endian

### DIFF
--- a/hwy/contrib/hash/cuckoo2x2-inl.h
+++ b/hwy/contrib/hash/cuckoo2x2-inl.h
@@ -119,10 +119,17 @@ class Cuckoo2x2 {
     //   Empty entries (tag=00) can never match (tag always 01 or 10).
     // Note that we have >= 256K buckets, hence bits 0-17 govern the choice of
     // bucket and do not have to be verified.
+#if HWY_IS_BIG_ENDIAN
+    const VU16 fp1 =
+        Or(ShiftRight<2>(DupEven(BitCast(du16, h1))), Set(du16, 0x4000));
+    const VU16 fp2 =
+        Or(ShiftRight<2>(DupEven(BitCast(du16, h2))), Set(du16, 0x8000));
+#else
     const VU16 fp1 =
         Or(ShiftRight<2>(DupOdd(BitCast(du16, h1))), Set(du16, 0x4000));
     const VU16 fp2 =
         Or(ShiftRight<2>(DupOdd(BitCast(du16, h2))), Set(du16, 0x8000));
+#endif
 
     const uint32_t* base = data_.entries.data();
 

--- a/hwy/contrib/hash/phast-inl.h
+++ b/hwy/contrib/hash/phast-inl.h
@@ -182,13 +182,23 @@ class Phast {
     using VU16 = Vec<decltype(du16)>;
 
     // Odd/Even packing allows PromoteEvenTo.
+#if HWY_IS_BIG_ENDIAN
+    const VU16 seeds =
+        OddEven(BitCast(du16, seed1), BitCast(du16, ShiftLeft<16>(seed0)));
+#else
     const VU16 seeds =
         OddEven(BitCast(du16, ShiftLeft<16>(seed1)), BitCast(du16, seed0));
+#endif
     // Use upper 16 bits of hashes because the lower ~19 (for 1M keys and kpb=2)
     // already selected the bucket and thus seed. Odd lanes have hash1 >> 16,
     // even lanes have hash0 >> 16.
+#if HWY_IS_BIG_ENDIAN
+    const VU16 hashes =
+        OddEven(BitCast(du16, ShiftRight<16>(hash1)), BitCast(du16, hash0));
+#else
     const VU16 hashes =
         OddEven(BitCast(du16, hash1), BitCast(du16, ShiftRight<16>(hash0)));
+#endif
     // XOR is weaker than ADD. Mul together does not work.
     const VU16 combined = Add(hashes, seeds);
     const VU16 hashed = Hash16(du16, combined);
@@ -209,9 +219,15 @@ class Phast {
 
     // Add 4*iota to byte_idx, setting the starting offset for each u32 lane.
     // Setting the upper 3 bytes >= 0x80 ensures they are zeroed.
+#if HWY_IS_BIG_ENDIAN
+    const VU8 kBase =
+        Dup128VecFromValues(du8, 0x80, 0x80, 0x80, 3, 0x80, 0x80, 0x80, 7, 0x80,
+                            0x80, 0x80, 11, 0x80, 0x80, 0x80, 15);
+#else
     const VU8 kBase =
         Dup128VecFromValues(du8, 0, 0x80, 0x80, 0x80, 4, 0x80, 0x80, 0x80, 8,
                             0x80, 0x80, 0x80, 12, 0x80, 0x80, 0x80);
+#endif
 
 #if HWY_TARGET == HWY_AVX2
     // AVX2 GatherIndex sets up a mask, but we already have one from kBase.
@@ -225,7 +241,11 @@ class Phast {
 #endif
     // 0-3 in the low byte of each u32 lane; upper bytes are 0.
     const VU8 byte_idx = BitCast(du8, And(bucket_idx, Set(du32, 3)));
+#if HWY_IS_BIG_ENDIAN
+    const VU8 indices = Xor(byte_idx, kBase);
+#else
     const VU8 indices = Or(byte_idx, kBase);
+#endif
     return BitCast(du32, TableLookupBytesOr0(words, indices));
   }
 

--- a/hwy/examples/ctf_aes.cc
+++ b/hwy/examples/ctf_aes.cc
@@ -92,7 +92,7 @@ HWY_ALIGN constexpr uint8_t kPrefix[16] = {
 // 128-bit fixed-width brute-force solver (processes 1 password at a time).
 uint32_t Solve(const uint8_t* ciphertext, const uint8_t* counter,
                uint32_t max_pass, uint8_t* decrypted_flag) {
-  static_assert(HWY_IS_LITTLE_ENDIAN, "Only little-endian supported");
+#if HWY_TARGET != HWY_SCALAR
   // FixedTag<uint8_t, 16> locks the vector width to exactly 128-bit (16 bytes)
   using D = hn::FixedTag<uint8_t, 16>;
   const D d;
@@ -113,7 +113,13 @@ uint32_t Solve(const uint8_t* ciphertext, const uint8_t* counter,
   HWY_ALIGN uint8_t key_bytes[16] = {0};
 
   for (uint32_t p = 0; p < max_pass; ++p) {
+#if HWY_IS_LITTLE_ENDIAN
     CopyBytes(&p, key_bytes, 3);
+#else
+    key_bytes[0] = static_cast<uint8_t>(p & 0xFF);
+    key_bytes[1] = static_cast<uint8_t>((p >> 8) & 0xFF);
+    key_bytes[2] = static_cast<uint8_t>((p >> 16) & 0xFF);
+#endif
 
     V v_key = hn::Load(d, key_bytes);
 
@@ -132,6 +138,15 @@ uint32_t Solve(const uint8_t* ciphertext, const uint8_t* counter,
       return p;
     }
   }
+#else
+  std::cerr << "WARNING: CTF AES Brute-force Challenge is not supported on "
+               "SCALAR target\n";
+
+  (void)ciphertext;
+  (void)counter;
+  (void)max_pass;
+  (void)decrypted_flag;
+#endif
   return static_cast<uint32_t>(-1);
 }
 
@@ -177,8 +192,8 @@ int main() {
   const double t_start = hwy::platform::Now();
   uint32_t found_pass = hwy::RunSolver(decrypted_flag);
   const double t_end = hwy::platform::Now();
-  std::cout << "[SIMD] Found password: "
-            << static_cast<int32_t>(found_pass) << "\n\n";
+  std::cout << "[SIMD] Found password: " << static_cast<int32_t>(found_pass)
+            << "\n\n";
   std::cout << "Decrypted Flag:\n" << decrypted_flag << "\n\n";
 
   const double duration = (t_end - t_start) * 1000.0;  // in ms


### PR DESCRIPTION
Made fixes to Cuckoo2x2 and PHAST implementations to fix test failures on big-endian targets.

Also updated hwy/examples/ctf_aes.cc to allow the ctf_aes example to successfully compile on big-endian targets and the HWY_SCALAR target.

All tests pass on big-endian PPC10 with the changes in this pull request.