### PR TITLE
Fix LoadInterleaved3 for Vec64<uint16_t> on LoongArch LSX

### DIFF
--- a/hwy/ops/loongarch_lsx-inl.h
+++ b/hwy/ops/loongarch_lsx-inl.h
@@ -990,7 +990,7 @@ HWY_API Vec32<T> ShuffleTwo1230(const Vec32<T> a, const Vec32<T> b) {
 }
 template <typename T, HWY_IF_T_SIZE(T, 2)>
 HWY_API Vec64<T> ShuffleTwo1230(const Vec64<T> a, const Vec64<T> b) {
-  const int16_t _data_idx[] = {10, 11, 2, 1};
+  const int16_t _data_idx[] = {8, 11, 2, 1};
   __m128i shuffle_idx = __lsx_vld(_data_idx, 0);
   auto t0 = __lsx_vshuf_h(shuffle_idx, a.raw, b.raw);
   return Vec64<T>{t0};
@@ -1011,7 +1011,7 @@ HWY_API Vec32<T> ShuffleTwo3012(const Vec32<T> a, const Vec32<T> b) {
 }
 template <typename T, HWY_IF_T_SIZE(T, 2)>
 HWY_API Vec64<T> ShuffleTwo3012(const Vec64<T> a, const Vec64<T> b) {
-  const int16_t _data_idx[] = {8, 9, 0, 3};
+  const int16_t _data_idx[] = {10, 9, 0, 3};
   __m128i shuffle_idx = __lsx_vld(_data_idx, 0);
   return Vec64<T>{__lsx_vshuf_h(shuffle_idx, a.raw, b.raw)};
 }


### PR DESCRIPTION
LoadInterleaved3 on 64-bit uint16_t vectors produced swapped channels 0 and 2 on LSX, corrupting any caller that relied on correct de-interleaving. This is the root cause of https://github.com/libjxl/libjxl/issues/4709.

Fix the index arrays so the expected lanes are returned.

Tested on Arch Linux for Loong64.