### PR TITLE
Added SlideUpLanesOr op

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2697,6 +2697,13 @@ The following `ReverseN` must not be called if `Lanes(D()) < N`:
 
     The result of SlideUpLanes is implementation-defined if `N >= Lanes(d)`.
 
+*   <code>V **SlideUpLanesOr**(V lo, D d, V hi, size_t N)</code>: slides up `hi`
+    by `N` lanes and returns `lo[i]` in the lower `N` lanes.
+
+    `SlideUpLanesOr(lo, d, hi, N)` is equivalent to
+    `IfThenElse(FirstN(d, N), lo, SlideUpLanes(d, hi, N))`, but SlideUpLanesOr
+    is more efficient on some targets, including SVE and RVV.
+
 *   <code>V **SlideDownLanes**(D d, V v, size_t N)</code>: slides down `v` by
     `N` lanes
 

--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -4101,6 +4101,17 @@ HWY_API VFromD<D> SlideUpLanes(D d, VFromD<D> v, size_t amt) {
   return detail::Splice(v, Zero(d), FirstN(d, amt));
 }
 
+#ifdef HWY_NATIVE_SLIDE_UP_LANES_OR
+#undef HWY_NATIVE_SLIDE_UP_LANES_OR
+#else
+#define HWY_NATIVE_SLIDE_UP_LANES_OR
+#endif
+
+template <class D>
+HWY_API VFromD<D> SlideUpLanesOr(VFromD<D> lo, D d, VFromD<D> hi, size_t amt) {
+  return detail::Splice(hi, lo, FirstN(d, amt));
+}
+
 // ------------------------------ Slide1Up
 
 #ifdef HWY_NATIVE_SLIDE1_UP_DOWN

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -7114,7 +7114,7 @@ HWY_INLINE Vec<D> Lookup8(D d, const T* HWY_RESTRICT table, VI indices) {
 
     // Now ensure indices for the second half of the table point to the second
     // vector. Note that SVE2_128 and SVE_256 are handled by the fixed-size case
-    // above. The adjustment factor is 0 for 128-bit SIMD, which can happen with
+    // above. The adjustment factor is 0 for 128-bit SIMD, which can happen with
     // 128-bit SVE1 hardware, but we do not know that at compile time.
     using TI = TFromD<decltype(di)>;
     const VI adjust = Set(di, static_cast<TI>(Lanes(d) - 4));
@@ -7180,7 +7180,7 @@ HWY_INLINE Vec<D> Lookup16(D d, const T* HWY_RESTRICT table, VI indices) {
 
     // Now ensure indices for the second half of the table point to the second
     // vector. Note that SVE2_128 and SVE_256 are handled by the fixed-size case
-    // above. The adjustment factor is 0 for 128-bit SIMD, which can happen with
+    // above. The adjustment factor is 0 for 128-bit SIMD, which can happen with
     // 128-bit SVE1 hardware, but we do not know that at compile time.
     using TI = TFromD<decltype(di)>;
     const VI adjust = Set(di, static_cast<TI>(Lanes(d) - 8));
@@ -8003,6 +8003,22 @@ HWY_API VFromD<D> Slide1Down(D d, VFromD<D> v) {
 #endif  // HWY_TARGET != HWY_SCALAR
 
 #endif  // HWY_NATIVE_SLIDE1_UP_DOWN
+
+// ------------------------------ SlideUpLanesOr
+#if (defined(HWY_NATIVE_SLIDE_UP_LANES_OR) == defined(HWY_TARGET_TOGGLE))
+
+#ifdef HWY_NATIVE_SLIDE_UP_LANES_OR
+#undef HWY_NATIVE_SLIDE_UP_LANES_OR
+#else
+#define HWY_NATIVE_SLIDE_UP_LANES_OR
+#endif
+
+template <class D>
+HWY_API VFromD<D> SlideUpLanesOr(VFromD<D> lo, D d, VFromD<D> hi, size_t amt) {
+  return IfThenElse(FirstN(d, amt), lo, SlideUpLanes(d, hi, amt));
+}
+
+#endif  // HWY_NATIVE_SLIDE_UP_LANES_OR
 
 // ------------------------------ SlideUpBlocks
 

--- a/hwy/ops/rvv-inl.h
+++ b/hwy/ops/rvv-inl.h
@@ -3812,6 +3812,18 @@ HWY_API VFromD<D> SlideUpLanes(D d, VFromD<D> v, size_t amt) {
   return detail::SlideUp(Zero(d), v, amt);
 }
 
+#ifdef HWY_NATIVE_SLIDE_UP_LANES_OR
+#undef HWY_NATIVE_SLIDE_UP_LANES_OR
+#else
+#define HWY_NATIVE_SLIDE_UP_LANES_OR
+#endif
+
+template <class D>
+HWY_API VFromD<D> SlideUpLanesOr(VFromD<D> lo, D /*d*/, VFromD<D> hi,
+                                 size_t amt) {
+  return detail::SlideUp(lo, hi, amt);
+}
+
 // ------------------------------ SlideDownLanes
 template <class D>
 HWY_API VFromD<D> SlideDownLanes(D d, VFromD<D> v, size_t amt) {

--- a/hwy/tests/slide_up_down_test.cc
+++ b/hwy/tests/slide_up_down_test.cc
@@ -176,6 +176,40 @@ HWY_NOINLINE void TestAllSlideUpLanes() {
   ForAllTypes(ForPartialVectors<TestSlideUpLanes>());
 }
 
+struct TestSlideUpLanesOr {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<T>(N);
+    auto a_lanes = AllocateAligned<T>(N);
+    auto b_lanes = AllocateAligned<T>(N);
+
+    HWY_ASSERT(expected);
+    HWY_ASSERT(a_lanes);
+    HWY_ASSERT(b_lanes);
+
+    const Rebind<If<IsSigned<T>(), T, MakeSigned<T>>, decltype(d)> d_neg;
+
+    const auto a = BitCast(d, PositiveIota(d_neg, 1));
+    const auto b = BitCast(d, Neg(BitCast(d_neg, a)));
+
+    Store(a, d, a_lanes.get());
+    Store(b, d, b_lanes.get());
+
+    for (size_t i = 0; i < N; i++) {
+      for (size_t j = 0; j < N; j++) {
+        expected[j] = (j < i) ? a_lanes[j] : b_lanes[j - i];
+      }
+
+      HWY_ASSERT_VEC_EQ(d, expected.get(), SlideUpLanesOr(a, d, b, i));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllSlideUpLanesOr() {
+  ForAllTypes(ForPartialVectors<TestSlideUpLanesOr>());
+}
+
 #if !HWY_HAVE_SCALABLE && HWY_TARGET < HWY_EMU128 && !HWY_TARGET_IS_SVE
 // DoTestSlideDownLanes needs to be inlined on targets where
 // DoTestSlideDownLanesWithConstAmt_0_7, DoTestSlideDownLanesWithConstAmt_8_15,
@@ -454,6 +488,7 @@ namespace hwy {
 namespace {
 HWY_BEFORE_TEST(HwySlideUpDownTest);
 HWY_EXPORT_AND_TEST_P(HwySlideUpDownTest, TestAllSlideUpLanes);
+HWY_EXPORT_AND_TEST_P(HwySlideUpDownTest, TestAllSlideUpLanesOr);
 HWY_EXPORT_AND_TEST_P(HwySlideUpDownTest, TestAllSlideDownLanes);
 HWY_EXPORT_AND_TEST_P(HwySlideUpDownTest, TestAllSlide1);
 HWY_EXPORT_AND_TEST_P(HwySlideUpDownTest, TestAllSlideBlocks);


### PR DESCRIPTION
Added the SlideUpLanesOr op as there is a use case for SlideUpLanesOr in the implementation of Partition (which was discussed in issue #3142).