### PR TITLE
aligned_allocator: don't ZeroBytes a null buffer in AlignedNDArray ctor

### DIFF
--- a/hwy/aligned_allocator.h
+++ b/hwy/aligned_allocator.h
@@ -377,6 +377,14 @@ class AlignedNDArray {
     memory_shape_[axes - 1] = RoundUpTo(memory_shape_[axes - 1], VectorBytes());
     memory_sizes_ = ComputeSizes(memory_shape_);
     buffer_ = hwy::AllocateAligned<T>(memory_size());
+    // AllocateAligned returns nullptr if the allocation failed or the byte
+    // count (memory_size() * sizeof(T)) overflowed size_t. ZeroBytes is memset,
+    // so zeroing a null buffer is a null-pointer write (UB); abort with a clear
+    // message instead, mirroring the overflow check in ComputeSizes().
+    if (HWY_UNLIKELY(buffer_.get() == nullptr)) {
+      HWY_ABORT("AlignedNDArray: failed to allocate %zu elements",
+                memory_size());
+    }
     hwy::ZeroBytes(buffer_.get(), memory_size() * sizeof(T));
   }
 


### PR DESCRIPTION
## What

`AlignedNDArray`'s constructor zero-fills its buffer without checking that the allocation succeeded:

```cpp
buffer_ = hwy::AllocateAligned<T>(memory_size());
hwy::ZeroBytes(buffer_.get(), memory_size() * sizeof(T));
```

`AllocateAligned()` returns `nullptr` when the allocation fails **or** when the byte count `items * sizeof(T)` overflows `size_t` — a contract that `detail::AllocateAlignedItems()` implements (it returns `nullptr` on `check != items`, "overflowed") and that `aligned_allocator_test` exercises (`TestOverflow`). `ZeroBytes()` is `__builtin_memset`, so zeroing a null buffer is a null-pointer write (undefined behavior).

Note that `ComputeSizes()` guards only the element-count product against `size_t` overflow, not the `* sizeof(T)` scaling, so for `sizeof(T) > 1` there is a range where `memory_size()` fits in `size_t` but `memory_size() * sizeof(T)` does not — the constructor then memsets through a null pointer.

## Fix

Guard the buffer and `HWY_ABORT` with a clear message on failure, mirroring the `size_t`-overflow check already present in `ComputeSizes()`. Every free path in this file already null-checks (`FreeAlignedBytes`, `DeleteAlignedArray`); this brings the constructor in line.

## Reproduction (`-fsanitize=address,undefined`)

```cpp
hwy::AlignedNDArray<double, 1> a({(size_t{1} << 61) + 1});
```

(The element count fits in `size_t` so `ComputeSizes` does not abort, but `items * sizeof(double)` overflows, so `AllocateAligned` returns `nullptr`.)

**Before:**
```
hwy/base.h:441:19: runtime error: null pointer passed as argument 1, which is declared to never be null
    #2 hwy::AlignedNDArray<double, 1ul>::AlignedNDArray(...) hwy/aligned_allocator.h:380
AddressSanitizer: SEGV on unknown address 0x000000000000 ... caused by a WRITE memory access
```

**After:** the constructor aborts with `AlignedNDArray: failed to allocate <N> elements`; no undefined behavior.

## Testing

- `aligned_allocator_test` passes 19/19 under `-Db_sanitize=address,undefined` (including `TestAlignedNDArray`, `TestAlignedNDArrayAlignment`, and `TestOverflow`).
- Valid allocations are unaffected: the buffer is non-null, so `ZeroBytes` runs exactly as before.
