### PR TITLE
random: fix out-of-bounds Store in VectorXoshiro when count is not a multiple of Lanes

### DIFF
--- a/hwy/contrib/random/random-inl.h
+++ b/hwy/contrib/random/random-inl.h
@@ -210,9 +210,17 @@ class VectorXoshiro {
     auto s1 = Load(tag, state_[{1}].data());
     auto s2 = Load(tag, state_[{2}].data());
     auto s3 = Load(tag, state_[{3}].data());
-    for (std::uint64_t i = 0; i < n; i += Lanes(tag)) {
+    const size_t lanes = Lanes(tag);
+    // Full vectors use the cheap Store; StoreN (which can be expensive on some
+    // targets) is only used once, for the final partial vector.
+    size_t i = 0;
+    for (; i + lanes <= n; i += lanes) {
       const auto next = Update(s0, s1, s2, s3);
       Store(next, tag, result.data() + i);
+    }
+    if (i < n) {
+      const auto next = Update(s0, s1, s2, s3);
+      StoreN(next, tag, result.data() + i, n - i);
     }
     Store(s0, tag, state_[{0}].data());
     Store(s1, tag, state_[{1}].data());
@@ -229,9 +237,15 @@ class VectorXoshiro {
     auto s1 = Load(tag, state_[{1}].data());
     auto s2 = Load(tag, state_[{2}].data());
     auto s3 = Load(tag, state_[{3}].data());
-    for (std::uint64_t i = 0; i < N; i += Lanes(tag)) {
+    const size_t lanes = Lanes(tag);
+    size_t i = 0;
+    for (; i + lanes <= N; i += lanes) {
       const auto next = Update(s0, s1, s2, s3);
       Store(next, tag, result.data() + i);
+    }
+    if (i < N) {
+      const auto next = Update(s0, s1, s2, s3);
+      StoreN(next, tag, result.data() + i, N - i);
     }
     Store(s0, tag, state_[{0}].data());
     Store(s1, tag, state_[{1}].data());
@@ -267,12 +281,21 @@ class VectorXoshiro {
     auto s2 = Load(tag, state_[{2}].data());
     auto s3 = Load(tag, state_[{3}].data());
 
-    for (std::uint64_t i = 0; i < n; i += Lanes(real_tag)) {
+    const size_t lanes = Lanes(real_tag);
+    size_t i = 0;
+    for (; i + lanes <= n; i += lanes) {
       const auto next = Update(s0, s1, s2, s3);
       const auto bits = ShiftRight<11>(next);
       const auto real = ConvertTo(real_tag, bits);
       const auto uniform = Mul(real, MUL_VALUE);
       Store(uniform, real_tag, result.data() + i);
+    }
+    if (i < n) {
+      const auto next = Update(s0, s1, s2, s3);
+      const auto bits = ShiftRight<11>(next);
+      const auto real = ConvertTo(real_tag, bits);
+      const auto uniform = Mul(real, MUL_VALUE);
+      StoreN(uniform, real_tag, result.data() + i, n - i);
     }
 
     Store(s0, tag, state_[{0}].data());
@@ -294,12 +317,21 @@ class VectorXoshiro {
     auto s2 = Load(tag, state_[{2}].data());
     auto s3 = Load(tag, state_[{3}].data());
 
-    for (std::uint64_t i = 0; i < N; i += Lanes(real_tag)) {
+    const size_t lanes = Lanes(real_tag);
+    size_t i = 0;
+    for (; i + lanes <= N; i += lanes) {
       const auto next = Update(s0, s1, s2, s3);
       const auto bits = ShiftRight<11>(next);
       const auto real = ConvertTo(real_tag, bits);
       const auto uniform = Mul(real, MUL_VALUE);
       Store(uniform, real_tag, result.data() + i);
+    }
+    if (i < N) {
+      const auto next = Update(s0, s1, s2, s3);
+      const auto bits = ShiftRight<11>(next);
+      const auto real = ConvertTo(real_tag, bits);
+      const auto uniform = Mul(real, MUL_VALUE);
+      StoreN(uniform, real_tag, result.data() + i, N - i);
     }
 
     Store(s0, tag, state_[{0}].data());

--- a/hwy/contrib/random/random_test.cc
+++ b/hwy/contrib/random/random_test.cc
@@ -246,6 +246,73 @@ void TestNextFixedNUniformDist() {
 #endif  // HWY_HAVE_FLOAT64
 }
 
+// Regression test: sizes that are NOT a multiple of Lanes must be generated
+// correctly and without writing past the end of the result. The final partial
+// vector is handled by a single StoreN; the bulk uses the cheaper Store.
+// https://github.com/google/highway/pull/3165
+void TestNextNRemainder() {
+  const uint64_t seed = GetSeed();
+  const ScalableTag<uint64_t> d;
+  const size_t lanes = Lanes(d);
+
+  // One reference stream per lane, matching VectorXoshiro's interleaving:
+  // result[block * lanes + lane] == stream[lane]'s block-th draw.
+  std::vector<internal::Xoshiro> prototype;
+  prototype.emplace_back(seed);
+  for (size_t i = 1UL; i < lanes; ++i) {
+    auto rng = prototype.back();
+    rng.Jump();
+    prototype.emplace_back(rng);
+  }
+
+  // Dynamic-size overloads, with several sizes that are not multiples of Lanes.
+  const size_t sizes[] = {size_t{1}, lanes + 1, 3 * lanes + 1};
+  for (const size_t n : sizes) {
+    {
+      VectorXoshiro generator{seed};
+      const auto result = generator(n);
+      HWY_ASSERT(result.size() == n);
+      auto reference = prototype;
+      for (size_t i = 0UL; i < n; ++i) {
+        HWY_ASSERT(result[i] == reference[i % lanes]());
+      }
+    }
+#if HWY_HAVE_FLOAT64
+    {
+      VectorXoshiro generator{seed};
+      const auto result = generator.Uniform(n);
+      HWY_ASSERT(result.size() == n);
+      auto reference = prototype;
+      for (size_t i = 0UL; i < n; ++i) {
+        HWY_ASSERT(result[i] == reference[i % lanes].Uniform());
+      }
+    }
+#endif  // HWY_HAVE_FLOAT64
+  }
+
+  // Fixed-size (std::array) overloads with an odd size (never a multiple of
+  // Lanes for Lanes > 1).
+  constexpr size_t kOdd = 1001;
+  {
+    VectorXoshiro generator{seed};
+    const auto result = generator.operator()<kOdd>();
+    auto reference = prototype;
+    for (size_t i = 0UL; i < kOdd; ++i) {
+      HWY_ASSERT(result[i] == reference[i % lanes]());
+    }
+  }
+#if HWY_HAVE_FLOAT64
+  {
+    VectorXoshiro generator{seed};
+    const auto result = generator.Uniform<kOdd>();
+    auto reference = prototype;
+    for (size_t i = 0UL; i < kOdd; ++i) {
+      HWY_ASSERT(result[i] == reference[i % lanes].Uniform());
+    }
+  }
+#endif  // HWY_HAVE_FLOAT64
+}
+
 void TestCachedXorshiro() {
   const uint64_t seed = GetSeed();
 
@@ -448,6 +515,7 @@ HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestCachedXorshiro);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestUniformDist);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestNextNUniformDist);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestNextFixedNUniformDist);
+HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestNextNRemainder);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestUniformCachedXorshiro);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestAesCtrDeterministic);
 HWY_EXPORT_AND_TEST_P(HwyRandomTest, TestAesCtrSeeded);


### PR DESCRIPTION
## What

`VectorXoshiro`'s bulk generators fill an `n`-element result with a loop strided by `Lanes()` that always does a full-vector `Store()`:

```cpp
for (std::uint64_t i = 0; i < n; i += Lanes(tag)) {
  const auto next = Update(s0, s1, s2, s3);
  Store(next, tag, result.data() + i);   // writes Lanes() lanes
}
```

When `n` is not a multiple of `Lanes()`, the final iteration writes up to `Lanes() - 1` elements past the end of `result`. This affects all four bulk paths:

- `operator()(size_t n)` and `Uniform(size_t n)` — `result` is an `AlignedVector` sized exactly `n`. The aligned allocator adds trailing slack, so the overrun usually lands in padding (which is why it isn't observed through the public API every time), but the slack is only `address % kAlias` bytes and can be smaller than the overwrite — a real heap overflow.
- `operator()<N>()` and `Uniform<N>()` — `result` is a stack `std::array<T, N>`; for `N` not a multiple of `Lanes()` this is a stack overwrite.

`random_test` only exercises power-of-two sizes (the file notes "tests do not check for vector remainders"), so CI does not catch it.

## Fix

Use `StoreN(v, d, p, HWY_MIN(Lanes(), n - i))` for the bounded store, matching the existing remainder-handling convention in `contrib` (`intdiv-inl.h`, `algo/transform-inl.h`, `hash/hash_eval.cc`). `StoreN` with a full count is equivalent to `Store`, so the multiple-of-`Lanes()` path is unchanged.

## Testing (`-fsanitize=address,undefined`)

- A minimal harness reproducing the loop over an exactly-sized `std::vector` (`n = Lanes() + 1`) reports, **before** the change:
  ```
  ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 16
      #1 Store<...> hwy/ops/x86_128-inl.h
  0x...058 is located 0 bytes after 24-byte region
  ```
  and exits cleanly with the `StoreN` form.
- `contrib/random/random_test` passes **128/128** under ASan with the fix applied (SSSE3/SSE2/SCALAR targets), confirming no regression.
