### PR TITLE
contrib/algo: fix int16 Count/CountIf overflow on a fully-matching run

### DIFF
--- a/hwy/contrib/algo/count-inl.h
+++ b/hwy/contrib/algo/count-inl.h
@@ -116,7 +116,11 @@ size_t Count(D d, T value, const T* HWY_RESTRICT in, size_t count) {
         VI acc1 = Zero(di);
         VI acc2 = Zero(di);
         VI acc3 = Zero(di);
-        const size_t cap = HWY_MIN(i + 32768 * 4 * N, count);
+        // A matching lane increments acc once per iteration, so the cap must
+        // stay within int16 range (max 32767): the 16-bit pairwise widening is
+        // signed, so unlike the 8-bit path above there is no unsigned form to
+        // recover a 32768th match, which would overflow the signed accumulator.
+        const size_t cap = HWY_MIN(i + 32767 * 4 * N, count);
 
         if constexpr (HWY_NATIVE_MASK) {
           const auto k1 = Set(di, TI{1});
@@ -297,7 +301,11 @@ size_t CountIf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
         VI acc1 = Zero(di);
         VI acc2 = Zero(di);
         VI acc3 = Zero(di);
-        const size_t cap = HWY_MIN(i + 32768 * 4 * N, count);
+        // A matching lane increments acc once per iteration, so the cap must
+        // stay within int16 range (max 32767): the 16-bit pairwise widening is
+        // signed, so unlike the 8-bit path above there is no unsigned form to
+        // recover a 32768th match, which would overflow the signed accumulator.
+        const size_t cap = HWY_MIN(i + 32767 * 4 * N, count);
 
         if constexpr (HWY_NATIVE_MASK) {
           const VI k1 = Set(di, TI{1});

--- a/hwy/contrib/algo/count_value_test.cc
+++ b/hwy/contrib/algo/count_value_test.cc
@@ -146,6 +146,32 @@ void TestAllCountIf() {
   ForAllTypes(ForGE128Vectors<ForeachCountAndMisalign<TestCountIf>>());
 }
 
+// Regression test for a 16-bit accumulator overflow: the inner-loop cap was
+// 32768, so a lane that matched on every one of those iterations reached
+// 32768, overflowing the signed int16 accumulator (to -32768) before it was
+// widened. On HWY_NATIVE_MASK targets the accumulator was fed straight to the
+// signed pairwise widening, so the count was wrong. An all-matching run longer
+// than one cap chunk must still count correctly.
+struct TestLargeMatchingCount {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) const {
+    if (sizeof(T) != 2) return;  // exercises the 16-bit Count path
+    const size_t N = Lanes(d);
+    if (N < 2) return;
+    const size_t count = size_t{32768} * 4 * N;  // one full (pre-fix) cap chunk
+    AlignedFreeUniquePtr<T[]> storage = AllocateAligned<T>(count);
+    HWY_ASSERT(storage);
+    T* in = storage.get();
+    const T value = ConvertScalarTo<T>(7);
+    for (size_t i = 0; i < count; ++i) in[i] = value;
+    HWY_ASSERT_EQ(count, Count(d, value, in, count));
+  }
+};
+
+void TestAllLargeMatchingCount() {
+  ForAllTypes(ForGE128Vectors<TestLargeMatchingCount>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -158,6 +184,7 @@ namespace {
 HWY_BEFORE_TEST(CountTest);
 HWY_EXPORT_AND_TEST_P(CountTest, TestAllCount);
 HWY_EXPORT_AND_TEST_P(CountTest, TestAllCountIf);
+HWY_EXPORT_AND_TEST_P(CountTest, TestAllLargeMatchingCount);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
## Description

The 16-bit `Count` / `CountIf` paths (`hwy/contrib/algo/count-inl.h`) accumulate matches in a signed `int16` SIMD lane, flushing to the `int32` running sum every `32768 * 4 * N` elements:

```cpp
const size_t cap = HWY_MIN(i + 32768 * 4 * N, count);
...
acc0 = MaskedAddOr(acc0, m0, acc0, k1);   // +1 per matching lane, per iteration
...
wide_sum = SatWidenMulPairwiseAccumulate(di32, acc0, mul, wide_sum);
```

The inner loop runs up to 32768 iterations before the flush, so a lane that matches on every iteration reaches **32768** — one past `INT16_MAX` (32767) — overflowing the signed accumulator to `-32768`. On `HWY_NATIVE_MASK` targets `mul == 1` and `acc` is fed straight to the signed pairwise widening, so that lane contributes `-32768` instead of `+32768` (the count is off by 65536 per overflowing lane).

The 8-bit path avoids this by capping at 128 and doing `BitCast(du, acc)` before an **unsigned×signed** 8→16 widening (`uint8` holds 128). There is no unsigned 16→32 pairwise widening, so the 16-bit accumulator must instead stay within signed range.

## Fix

Cap the 16-bit inner loop at **32767** instead of 32768 (both `Count` and `CountIf`), so a fully-matching lane tops out at exactly `INT16_MAX`. This only changes the flush cadence; the total is unaffected. (The non-`HWY_NATIVE_MASK` path already stays valid — it counts down to `-32768`.)

## Testing

Added `TestAllLargeMatchingCount`: an all-matching run of one full cap chunk (`32768 * 4 * Lanes` elements). Built with `-fsanitize=address,undefined` and run on a Zen4 / AVX-512 machine:

- **Before the fix** — fails on the native-mask targets, e.g.:
  ```
  Abort at count_value_test.cc: AVX3_ZEN4 ... lane 0 mismatch:
    expected '0x0000000000400000', got '0xffffffffffc00000'
  ```
  (expected 4,194,304 = 32768·4·32; got a wrapped negative from the overflow).
- **After the fix** — all 24 tests pass across every target (SCALAR, SSE2 … AVX3_ZEN4).
