### PR TITLE
contrib/thread_pool: fix off-by-one OOB write in File::Read

### DIFF
--- a/hwy/contrib/thread_pool/topology.cc
+++ b/hwy/contrib/thread_pool/topology.cc
@@ -396,7 +396,10 @@ class File {
     size_t pos = 0;
     for (;;) {
       // read instead of `pread`, which might not work for sysfs.
-      const auto bytes_read = read(fd_, buf200 + pos, 200 - pos);
+      // Reserve one byte for the terminating '\0': a full 200-byte read would
+      // leave `200 - pos == 0`, and read() with a zero count returns 0, so the
+      // EOF branch below would write buf200[200], one past the end.
+      const auto bytes_read = read(fd_, buf200 + pos, 199 - pos);
       if (bytes_read == 0) {  // EOF: done
         buf200[pos++] = '\0';
         return pos;
@@ -407,7 +410,7 @@ class File {
         return 0;
       }
       pos += static_cast<size_t>(bytes_read);
-      HWY_ASSERT(pos <= 200);
+      HWY_ASSERT(pos <= 199);
     }
   }
 


### PR DESCRIPTION
## Description

`File::Read` (`hwy/contrib/thread_pool/topology.cc`) fills a caller-provided 200-byte buffer:

```cpp
const auto bytes_read = read(fd_, buf200 + pos, 200 - pos);
if (bytes_read == 0) {  // EOF: done
  buf200[pos++] = '\0';
  return pos;
}
...
pos += static_cast<size_t>(bytes_read);
HWY_ASSERT(pos <= 200);
```

When the file is ≥ 200 bytes, `pos` reaches 200 (the assert passes, and is a no-op in release builds). The next iteration calls `read(fd_, buf200 + 200, 0)`; a zero-count `read` returns 0, so the "EOF" branch runs `buf200[pos++] = '\0'`, writing **`buf200[200]`** — one byte past the end of the array (OOB stack write) — and returns 201.

All call sites pass `char buf200[200]`; two of them read sysfs `cpulist` / `shared_cpu_list`, which can exceed 200 bytes on machines with many or fragmented CPU ranges — so this is reachable on real large-core hosts, not just crafted input. (Local trusted sysfs, so not a remote issue.)

Reproduced with a standalone ASan harness on a ≥200-byte file:
```
ERROR: AddressSanitizer: stack-buffer-overflow WRITE of size 1   (buf200[200])
```

## Fix

Reserve one byte for the terminator — read at most `199 - pos` — so `pos` tops out at 199 and `buf200[pos] = '\0'` stays in bounds (the buffer already only ever held 199 content bytes + a terminator; this makes that explicit). Also tighten the assert to `pos <= 199`.

## Testing

Standalone ASan repro: overflows before the change, clean after (`pos = 200` = 199 content bytes + NUL).
