### PR TITLE
bit_pack: fix Pack16<11>/<13> round-trip and harden the test mask

### DIFF
--- a/hwy/contrib/bit_pack/bit_pack-inl.h
+++ b/hwy/contrib/bit_pack/bit_pack-inl.h
@@ -1898,10 +1898,14 @@ struct Pack16<11> {
     const VU16 rawD = OrAnd(downD, ShiftRight<4>(packed9), hi3);
     const VU16 rawE = OrAnd(downE, ShiftRight<4>(packedA), hi3);
 
-    // Shift MSB into the top 3-of-11 and mask.
-    const VU16 rawF = Or(downF, Xor3(And(ShiftRight<7>(packed8), hi3),
-                                     And(ShiftRight<6>(packed9), hi3),
-                                     And(ShiftRight<5>(packedA), hi3)));
+    // Shift MSB into the top 3-of-11 and mask. Each of packed8/9/A holds one of
+    // rawF's three top bits in its MSB (bit 15); mask each shifted term to its
+    // own target position so the adjacent rawD/rawE top bits (packed9 bit 14,
+    // packedA bits 13-14) that the shifts also bring into the 0x700 window do
+    // not leak into rawF.
+    const VU16 rawF = Or(downF, Xor3(And(ShiftRight<7>(packed8), Set(d, 0x100u)),
+                                     And(ShiftRight<6>(packed9), Set(d, 0x200u)),
+                                     And(ShiftRight<5>(packedA), Set(d, 0x400u))));
 
     StoreU(raw0, d, raw + 0 * N);
     StoreU(raw1, d, raw + 1 * N);
@@ -2119,8 +2123,11 @@ struct Pack16<13> {
     packedB = OrAnd(packedB, ShiftLeft<2>(rawD), next);
     packedC = OrAnd(packedC, ShiftLeft<2>(rawE), next);
 
-    // Scatter upper 5 bits of rawF into the upper bits.
-    next = ShiftLeft<3>(next);  // = 0x8000u
+    // Scatter upper 5 bits of rawF into the MSB of each of packed8..C.
+    // NB: next is 0x7C00 here (five-bit group), so ShiftLeft<3> would be 0xE000,
+    // not 0x8000 -- that would also overwrite bits 13-14 (the top of the rawA..E
+    // groups) with rawF's lower bits. Set the MSB-only mask explicitly.
+    next = Set(d, 0x8000u);
     packed8 = OrAnd(packed8, ShiftLeft<7>(rawF), next);
     packed9 = OrAnd(packed9, ShiftLeft<6>(rawF), next);
     packedA = OrAnd(packedA, ShiftLeft<5>(rawF), next);
@@ -2184,21 +2191,23 @@ struct Pack16<13> {
     const VU16 raw5 = OrAnd(down5, ShiftLeft<3>(packed8), hi5);
     const VU16 raw6 = OrAnd(down6, ShiftLeft<3>(packed9), hi5);
     const VU16 raw7 = OrAnd(down7, ShiftLeft<3>(packedA), hi5);
-    const VU16 raw8 = OrAnd(down8, ShiftLeft<3>(packed9), hi5);
-    const VU16 raw9 = OrAnd(down9, ShiftLeft<3>(packedA), hi5);
+    const VU16 raw8 = OrAnd(down8, ShiftLeft<3>(packedB), hi5);
+    const VU16 raw9 = OrAnd(down9, ShiftLeft<3>(packedC), hi5);
 
     const VU16 rawA = OrAnd(downA, ShiftRight<2>(packed8), hi5);
     const VU16 rawB = OrAnd(downB, ShiftRight<2>(packed9), hi5);
     const VU16 rawC = OrAnd(downC, ShiftRight<2>(packedA), hi5);
-    const VU16 rawD = OrAnd(downD, ShiftRight<2>(packed9), hi5);
-    const VU16 rawE = OrAnd(downE, ShiftRight<2>(packedA), hi5);
+    const VU16 rawD = OrAnd(downD, ShiftRight<2>(packedB), hi5);
+    const VU16 rawE = OrAnd(downE, ShiftRight<2>(packedC), hi5);
 
-    // Shift MSB into the top 5-of-11 and mask.
-    const VU16 p0 = Xor3(And(ShiftRight<7>(packed8), hi5),  //
-                         And(ShiftRight<6>(packed9), hi5),
-                         And(ShiftRight<5>(packedA), hi5));
-    const VU16 p1 = Xor3(And(ShiftRight<4>(packedB), hi5),
-                         And(ShiftRight<3>(packedC), hi5), downF);
+    // Shift each MSB (bit 15 of packed8..C holds one of rawF's five top bits)
+    // into its own target position and mask to that single bit, so the adjacent
+    // rawB..E top bits the shifts also bring into the 0x1F00 window do not leak.
+    const VU16 p0 = Xor3(And(ShiftRight<7>(packed8), Set(d, 0x100u)),  //
+                         And(ShiftRight<6>(packed9), Set(d, 0x200u)),
+                         And(ShiftRight<5>(packedA), Set(d, 0x400u)));
+    const VU16 p1 = Xor3(And(ShiftRight<4>(packedB), Set(d, 0x800u)),
+                         And(ShiftRight<3>(packedC), Set(d, 0x1000u)), downF);
     const VU16 rawF = Or(p0, p1);
 
     StoreU(raw0, d, raw + 0 * N);

--- a/hwy/contrib/bit_pack/bit_pack_test.cc
+++ b/hwy/contrib/bit_pack/bit_pack_test.cc
@@ -52,7 +52,15 @@ namespace {
 
 template <size_t kBits, typename T>
 T Random(RandomState& rng) {
-  return ConvertScalarTo<T>(Random32(&rng) & kBits);
+  // Draw enough random bits for T, then mask to the low kBits (the width the
+  // pack/unpack under test operates on). Note kBits is a bit count, so the
+  // mask is (1 << kBits) - 1, not kBits itself; compute it in 64-bit to avoid
+  // shifting by the full width (kBits == 64 for Pack64).
+  const uint64_t bits =
+      (sizeof(T) <= 4) ? uint64_t{Random32(&rng)} : Random64(&rng);
+  const uint64_t mask =
+      (kBits >= 64) ? ~uint64_t{0} : ((uint64_t{1} << kBits) - 1);
+  return ConvertScalarTo<T>(bits & mask);
 }
 
 template <typename T>


### PR DESCRIPTION
## Summary

While tightening the bit_pack test I found that its input generator masks values with the bit **count** instead of a bit **mask**, which was hiding two real round-trip bugs in the 16-bit packers.

`hwy/contrib/bit_pack/bit_pack_test.cc`:

```cpp
template <size_t kBits, typename T>
T Random(RandomState& rng) {
  return ConvertScalarTo<T>(Random32(&rng) & kBits);   // & kBits, not & ((1<<kBits)-1)
}
```

`kBits` is a bit count (1..64), so `x & kBits` only yields values that share bits with `kBits`'s binary representation — e.g. for `kBits == 11` (`0b1011`) it never sets bit positions 2 and beyond within the 11-bit field. The packers were therefore only ever tested on a tiny, non-representative subset of inputs.

Fixing the mask to `(1 << kBits) - 1` (and using a 64-bit RNG for 64-bit `T`, with a guard for `kBits == 64`) exposes two genuine round-trip failures — `Unpack(Pack(x)) != x` — on **every SIMD target** (AVX3_ZEN4, AVX3_DL, AVX3, AVX2, SSE4, SSSE3, SSE2), while `SCALAR` happens to pass (its input seed is `N * 129`, so it draws different data):

### `Pack16<11>::Unpack` — rawF MSB leak

The three top bits of `rawF` live in bit 15 of `packed8/9/A`, but all three shifted terms were masked with the same `hi3 = 0x700`:

```cpp
const VU16 rawF = Or(downF, Xor3(And(ShiftRight<7>(packed8), hi3),
                                 And(ShiftRight<6>(packed9), hi3),
                                 And(ShiftRight<5>(packedA), hi3)));
```

`ShiftRight<6>(packed9)` also brings `packed9` bit 14 (the top of the `rawD` group) into position 8, and `ShiftRight<5>(packedA)` brings `packedA` bits 13-14 (top of `rawE`) into positions 8-9. Masking each term to its own single target bit (`0x100/0x200/0x400`) fixes it.

### `Pack16<13>` — three issues

1. **Pack** scatters `rawF`'s five top bits into the MSB of `packed8..C` with `next = ShiftLeft<3>(next)`, but `next` is `0x7C00` at that point, so the mask is `0xE000`, not the intended `0x8000` (the comment even says `= 0x8000u`). The extra bits 13-14 overwrite the top of the `rawA..E` groups with `rawF`'s lower bits.
2. **Unpack** reads `raw8`/`raw9` and `rawD`/`rawE` from `packed9`/`packedA`, but `Pack` stores those groups in `packedB`/`packedC`.
3. **Unpack** `rawF` has the same shared-`hi5` leak as the 11-bit case.

## Fix

- `Random()`: mask with `(1 << kBits) - 1`, computed in 64-bit, drawing 64 random bits for 64-bit `T`.
- `Pack16<11>::Unpack`: per-position masks for the `rawF` terms.
- `Pack16<13>::Pack`: set the `rawF`-scatter mask to `0x8000` explicitly.
- `Pack16<13>::Unpack`: read `raw8/9` and `rawD/E` from `packedB/C`; per-position masks for `rawF`.

## Testing

`bit_pack_test` passes with the hardened generator on every compiled target and every bit width:

```
[==========] 32 tests from 1 test suite ran.
[  PASSED  ] 32 tests.
```

Before the packer fixes, the hardened test aborts on Pack16 at 11 and 13 bits on all seven SIMD targets; after, all of Pack8/16/32/64 round-trip. `SCALAR` was green throughout (different input seed), so this was latent.
