### PR TITLE
hash/phast: do not abort BuildPhast for exactly 64 keys

### DIFF
--- a/hwy/contrib/hash/phast.cc
+++ b/hwy/contrib/hash/phast.cc
@@ -88,7 +88,10 @@ static AlignedVector<PhastConfig> EnumerateConfigs(size_t num_keys,
                                                    size_t num_workers,
                                                    size_t& reps_per_config) {
   const size_t min_slice_length = MinSliceLength(num_keys);
-  HWY_ASSERT(num_keys == 1 || min_slice_length < num_keys);
+  // MinSliceLength may equal num_keys (num_keys == 1, and num_keys == 64 where
+  // it returns 64); MakeConfig clamps num_slots to at least slice_length, so
+  // equality is fine. Only min_slice_length > num_keys would be a bug.
+  HWY_ASSERT(min_slice_length <= num_keys);
 
   const std::vector<int> kHeadroomPercents = {1, 2, 3, 4, 10, 15, 20};
   const std::vector<size_t> kSliceShifts = {0, 1};

--- a/hwy/contrib/hash/phast_test.cc
+++ b/hwy/contrib/hash/phast_test.cc
@@ -149,7 +149,8 @@ void TestDistinctAndRange(const size_t num_keys) {
 HWY_NOINLINE void TestMultipleSizes() {
   const size_t kMul = 1;  // increase for larger tests.
   fprintf(stderr, "=== TestSmall ===\n");
-  for (size_t num_keys = 1; num_keys < 64; ++num_keys) {
+  // Includes num_keys == 64, where MinSliceLength(num_keys) == num_keys.
+  for (size_t num_keys = 1; num_keys < 100; ++num_keys) {
     TestDistinctAndRange(num_keys);
   }
   TestDistinctAndRange(/*num_keys=*/AdjustedReps(AdjustedReps(100 * kMul)));


### PR DESCRIPTION
## Summary

`BuildPhast` aborts the program for exactly 64 distinct keys.

`EnumerateConfigs` (`hwy/contrib/hash/phast.cc:91`) asserts:

```cpp
const size_t min_slice_length = MinSliceLength(num_keys);
HWY_ASSERT(num_keys == 1 || min_slice_length < num_keys);
```

`MinSliceLength` returns `RoundDownToPow2(num_keys / 2)` for `num_keys < 64` and a flat `64` for `64 <= num_keys < 1300`. At exactly `num_keys == 64` that is `64`, i.e. `min_slice_length == num_keys`, so the assert `num_keys == 1 || 64 < 64` is false and fires. `HWY_ASSERT` is unconditional (unlike `HWY_DASSERT`), so `BuildPhast` — a public `HWY_CONTRIB_DLLEXPORT` entry point — aborts the process for any set of 64 distinct keys. 63 and 65 keys both build fine; 64 is the only value besides the already-special-cased `num_keys == 1` where `MinSliceLength` equals `num_keys`.

## Fix

Equality is a valid configuration: `MakeConfig` clamps `num_slots` to at least `slice_length`, so `num_slice_offsets = num_slots - slice_length + 1 >= 1` and the table builds exactly as it does for 65 keys. Relax the guard to `min_slice_length <= num_keys` (only `min_slice_length > num_keys` would actually break slicing), which also subsumes the `num_keys == 1` case.

`TestMultipleSizes` swept `num_keys` in `[1, 64)` then jumped to 100/500/2048, so the boundary was never exercised; extend the small-count loop to `[1, 100)`.

## Testing

Built + run locally (AVX3/Zen4). With the extended test against the current **unfixed** `phast.cc`, `phast_test` aborts at the 64-key build:

```
Build(     63 keys):    0.49 ms,      66 slots, 4.06 b/key ...
Abort at phast.cc:91: Assert num_keys == 1 || min_slice_length < num_keys
```

After the fix, 64 keys builds a valid table and the full suite passes:

```
Build(     64 keys):    0.46 ms,      65 slots, 4.00 b/key config  0, attempt  0
[  PASSED  ] 2 tests.
```
