### PR TITLE
hash/shardmul_test: fix uint64->size_t narrowing on 32-bit targets

### DIFF
--- a/hwy/contrib/hash/shardmul_test.cc
+++ b/hwy/contrib/hash/shardmul_test.cc
@@ -76,7 +76,7 @@ static AlignedVector<uint64_t> GenerateClusteredKeys(size_t count) {
     uint8_t* bytes = reinterpret_cast<uint8_t*>(&key);
 
     // Randomly choose 1-5 byte positions to mutate.
-    const size_t num_mutations = 1 + (rng() % 5);
+    const size_t num_mutations = 1 + static_cast<size_t>(rng() % 5);
     for (size_t m = 0; m < num_mutations; ++m) {
       const size_t pos = rng() % 8;
       // UTF-8 byte range: mix of ASCII (0x20-0x7E), continuation (0x80-0xBF),


### PR DESCRIPTION
## Summary

`shardmul_test.cc` fails to build on 32-bit targets under `-Werror=conversion`.

`GenerateClusteredKeys` (line 79) has:

```cpp
const size_t num_mutations = 1 + (rng() % 5);
```

`rng()` returns `RngStream::result_type` (`uint64_t`), so `1 + (rng() % 5)` is `uint64_t`. On 32-bit targets where `size_t` is 32-bit, assigning it to `size_t` is a narrowing conversion, which `-Werror=conversion` rejects:

```
shardmul_test.cc:79:36: error: conversion from 'RngStream::result_type' {aka 'long long unsigned int'} to 'size_t' {aka 'unsigned int'} may change value [-Werror=conversion]
```

This breaks the `armv7` and `riscv64` multiarch CI jobs (GCC). The sibling `rng() % 8` on the next line is accepted because GCC's range analysis proves `[0, 7]` fits `size_t`; the `1 + (int)` on this line defeats that.

## Fix

Cast the modulo result to `size_t` explicitly (the value is in `[0, 4]`, so the cast is exact):

```cpp
const size_t num_mutations = 1 + static_cast<size_t>(rng() % 5);
```

## Testing

- Reproduced the exact conversion natively (`unsigned long long -> unsigned int`, which is `size_t` on a 32-bit target): the original pattern errors under `-Wconversion -Werror`, the cast compiles clean.
- `shardmul_test` builds and passes on x86_64 with the change (the cast is a no-op on 64-bit, so no behavior change).
