### PR TITLE
hash/phast: return empty sentinel instead of aborting on an empty key set

### DIFF
--- a/hwy/contrib/hash/phast.cc
+++ b/hwy/contrib/hash/phast.cc
@@ -586,6 +586,10 @@ class PerWorkerBuilder {
 static PhastData BuildPhastImpl(Span<const uint32_t> keys,
                                 const size_t payload_bytes, ThreadPool& pool) {
   const size_t num_keys = keys.size();
+  // An empty key set has no perfect hash to build. Return the same empty/failed
+  // sentinel (NumSlots() == 0) as the build-failure path and the HWY_SCALAR
+  // overload, rather than aborting in MinSliceLength's num_keys >= 1 assert.
+  if (num_keys == 0) return PhastData();
   const size_t num_workers = pool.NumWorkers();
 
   // Allocate per-worker builders once; reused across all configs.

--- a/hwy/contrib/hash/phast_test.cc
+++ b/hwy/contrib/hash/phast_test.cc
@@ -175,6 +175,15 @@ HWY_BEFORE_TEST(PhastTest);
 HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestQueryConsistency);
 HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestMultipleSizes);
 HWY_AFTER_TEST();
+
+// An empty key set has no perfect hash; BuildPhast must return the empty
+// sentinel (NumSlots() == 0) rather than aborting.
+TEST(PhastEmptyTest, EmptyKeysReturnEmpty) {
+  ThreadPool pool(0);
+  const uint32_t* no_keys = nullptr;
+  const PhastData data = BuildPhast(Span<const uint32_t>(no_keys, 0), 0, pool);
+  EXPECT_EQ(size_t{0}, data.NumSlots());
+}
 }  // namespace hwy
 HWY_TEST_MAIN();
 #endif  // HWY_ONCE


### PR DESCRIPTION
## Summary

`BuildPhast` aborts the whole program when called with an empty key set.

`BuildPhastImpl` → `EnumerateConfigs` → `MinSliceLength(0)` hits `HWY_ASSERT(num_keys >= 1)` (`phast.cc:75`). There is no empty-input guard on the path and `HWY_ASSERT` is unconditional, so any `BuildPhast(Span<const uint32_t>{}, ...)` aborts:

```
Abort at phast.cc:75: Assert num_keys >= 1
```

`num_keys == 1` builds fine, so `0` is a lone aborting boundary (same shape as the `num_keys == 64` abort fixed in #3182). It is also target-dependent: the `HWY_SCALAR` `BuildPhastImpl` overload already does `return PhastData();` for any input, so on a scalar build the same call returns an empty table while on a SIMD build it aborts.

## Fix

Return the existing empty/failed sentinel (`PhastData()`, `NumSlots() == 0`) for an empty key set — the same value the build-failure path (the `return PhastData();` at the end of `BuildPhastImpl`) and the scalar overload already return — so callers can detect the empty case instead of the process aborting.

## Testing

Reproduced through the public API against the unfixed library:

```
calling BuildPhast(empty span)...
Abort at phast.cc:75: Assert num_keys >= 1
```

After the fix:

```
  empty -> NumSlots=0
  3 keys -> NumSlots=4
```

Added a regression test (`PhastEmptyTest.EmptyKeysReturnEmpty`) that calls `BuildPhast` with an empty span and checks `NumSlots() == 0`; `phast_test` passes (`[ PASSED ] 3 tests`).
