### PR TITLE
sort: fix hang in the heapsort PartialSort fallback for k == 0

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -286,6 +286,41 @@ void TestPartialSortKEqualsN() {
   }
 }
 
+template <typename T>
+void TestPartialSortKEqualsZeroForType() {
+  const size_t num = 10;
+  std::vector<T> keys(num);
+  std::iota(keys.begin(), keys.end(), T{0});
+  std::reverse(keys.begin(), keys.end());
+  std::vector<T> expected(keys);
+
+  // k == 0 places no elements; this must return (not hang or overrun) and
+  // preserve the multiset. Exercises the heapsort fallback on !VQSORT_ENABLED
+  // builds, where HeapSelect/HeapSort formerly underflowed (k - N1) for k == 0.
+  hwy::VQPartialSort(keys.data(), num, /*k=*/0, hwy::SortAscending());
+
+  std::sort(keys.begin(), keys.end());
+  std::sort(expected.begin(), expected.end());
+  for (size_t i = 0; i < num; ++i) {
+    if (keys[i] != expected[i]) {
+      HWY_ABORT("KEqualsZero mismatch at %zu\n", i);
+    }
+  }
+}
+
+void TestPartialSortKEqualsZero() {
+  TestPartialSortKEqualsZeroForType<uint32_t>();
+  TestPartialSortKEqualsZeroForType<int32_t>();
+  if (hwy::HaveInteger64()) {
+    TestPartialSortKEqualsZeroForType<int64_t>();
+    TestPartialSortKEqualsZeroForType<uint64_t>();
+  }
+  TestPartialSortKEqualsZeroForType<float>();
+  if (hwy::HaveFloat64()) {
+    TestPartialSortKEqualsZeroForType<double>();
+  }
+}
+
 // Shuffled finite values (within float16_t's exact range to avoid overflow to
 // inf), with a few NaN and a few real +inf at spread-out positions. The +inf
 // is the case a by-value sentinel scan confuses with NaN. Returns the NaN count.
@@ -459,6 +494,7 @@ HWY_EXPORT_AND_TEST_P(SortTest, TestAllSort);
 HWY_EXPORT_AND_TEST_P(SortTest, TestAllSelect);
 HWY_EXPORT_AND_TEST_P(SortTest, TestAllPartialSort);
 HWY_EXPORT_AND_TEST_P(SortTest, TestPartialSortKEqualsN);
+HWY_EXPORT_AND_TEST_P(SortTest, TestPartialSortKEqualsZero);
 HWY_EXPORT_AND_TEST_P(SortTest, TestSelectWithNaN);
 HWY_AFTER_TEST();
 }  // namespace

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -161,7 +161,9 @@ template <class Traits, typename T>
 void HeapSort(Traits st, T* HWY_RESTRICT lanes, const size_t num_lanes) {
   constexpr size_t N1 = st.LanesPerKey();
   HWY_DASSERT(num_lanes % N1 == 0);
-  if (num_lanes == N1) return;
+  // 0 or 1 key is already sorted. Also avoids the (num_lanes - N1) underflow in
+  // the build-heap loop below when num_lanes == 0.
+  if (num_lanes <= N1) return;
 
   // Build heap.
   for (size_t i = ((num_lanes - N1) / N1 / 2) * N1; i != (~N1 + 1); i -= N1) {
@@ -232,6 +234,9 @@ void HeapSelect(Traits st, T* HWY_RESTRICT lanes, const size_t num_lanes,
 template <class Traits, typename T>
 void HeapPartialSort(Traits st, T* HWY_RESTRICT lanes, const size_t num_lanes,
                      const size_t k_lanes) {
+  // Selecting/sorting 0 keys is a no-op; return before HeapSelect/HeapSort,
+  // whose build-heap loops underflow (k_lanes - N1) when k_lanes == 0.
+  if (k_lanes == 0) return;
   // When k_lanes == num_lanes, selecting all elements is a no-op; skip to
   // avoid out-of-bounds access in HeapSelect.
   if (k_lanes < num_lanes) {


### PR DESCRIPTION
## Summary

`VQPartialSort(keys, n, /*k=*/0, ...)` hangs on `!VQSORT_ENABLED` builds.

`VQSORT_ENABLED` is 0 on `HWY_SCALAR`, MSVC optimized builds, ARMv7 debug, and when `HWY_DISABLE_VQSORT` is defined (`shared-inl.h`). On those, `PartialSort` uses the heapsort fallback: `HeapPartialSort` → `HeapSelect` / `HeapSort`. Both build their heap with:

```cpp
for (size_t i = ((k - N1) / N1 / 2) * N1; i != (~N1 + 1); i -= N1) { ... }
```

For `k == 0` (a partial-sort of zero keys), `k - N1` underflows to `~SIZE_MAX`, so `i` starts near `SIZE_MAX/2` and decrements by `N1` until it reaches the `~N1 + 1` (== `SIZE_MAX`) sentinel — roughly 2^63 iterations, i.e. an effectively infinite hang. `HeapPartialSort` reaches this because `PartialSort` guarantees `num_valid >= 1` but passes `k_valid == 0` straight through when the caller asks for `k == 0`.

`k == 0` (place the smallest zero elements) is a valid degenerate request, and on `VQSORT_ENABLED` builds it already returns immediately (the recursion's base case handles `num == 0`), so the hang is fallback-specific.

## Fix

- Return early from `HeapPartialSort` when `k_lanes == 0` — selecting/sorting zero keys is a no-op, so both `HeapSelect` and `HeapSort` are skipped.
- Harden `HeapSort`'s already-sorted guard from `num_lanes == N1` to `num_lanes <= N1`, so a direct `HeapSort(0)` also cannot underflow.

## Testing

`TestAllPartialSort` draws `k` from `k_dist(1, num_keys - 1)` (never 0) and skips VQ algos when `!VQSORT_ENABLED`, so the fallback `k == 0` path was untested. Added `TestPartialSortKEqualsZero` (mirrors `TestPartialSortKEqualsN`), which calls `VQPartialSort` with `k == 0`.

Reproduced via the public API (lib built with `-DHWY_DISABLE_VQSORT`): unfixed, `VQPartialSort(n=100, k=0)` never returns (hang); fixed, it returns immediately, leaving the array unchanged.

Both builds pass:
- `-DHWY_DISABLE_VQSORT` (heap fallback): `TestPartialSortKEqualsZero` passes on SCALAR/SSE2 (0 ms; hangs without the fix).
- default (VQSORT enabled): the `KEquals*` tests pass across targets (no regression).
