### PR TITLE
Fixed errors in hash_test and phast_test if HWY_TEST_STANDALONE is 1

### DIFF
--- a/hwy/contrib/hash/hash_test.cc
+++ b/hwy/contrib/hash/hash_test.cc
@@ -304,7 +304,7 @@ template <class Hash>
 static HWY_NOINLINE void TestBijection(const Hash& hash) {
   // Verified for WeakTwoMul, Triple32, Murmur3, and Speck32. TestBuckets also
   // verifies bijection, but faster, hence disable.
-  if (Unpredictable1()) GTEST_SKIP();
+  if (Unpredictable1()) HWY_GTEST_SKIP();
 
   // Each worker hashes all inputs, but only stores outputs for its task's
   // range of outputs to reduce the working set size to L3. One global bitset

--- a/hwy/contrib/hash/phast_test.cc
+++ b/hwy/contrib/hash/phast_test.cc
@@ -182,7 +182,7 @@ TEST(PhastEmptyTest, EmptyKeysReturnEmpty) {
   ThreadPool pool(0);
   const uint32_t* no_keys = nullptr;
   const PhastData data = BuildPhast(Span<const uint32_t>(no_keys, 0), 0, pool);
-  EXPECT_EQ(size_t{0}, data.NumSlots());
+  HWY_ASSERT_EQ(size_t{0}, data.NumSlots());
 }
 }  // namespace hwy
 HWY_TEST_MAIN();

--- a/hwy/tests/hwy_gtest.h
+++ b/hwy/tests/hwy_gtest.h
@@ -217,6 +217,8 @@ std::string TestParamTargetNameAndT(
 
 #define HWY_TEST_MAIN() static_assert(true, "For requiring trailing semicolon")
 
+#define HWY_GTEST_SKIP() GTEST_SKIP()
+
 #else  // HWY_TEST_STANDALONE
 
 namespace {
@@ -717,6 +719,9 @@ struct RegisterTest {
     return 0;                                                              \
   }                                                                        \
   static_assert(true, "For requiring trailing semicolon")
+
+// HWY_GTEST_SKIP() does not support operator << if HWY_TEST_STANDALONE is 1
+#define HWY_GTEST_SKIP() return
 
 #endif  // HWY_TEST_STANDALONE
 


### PR DESCRIPTION
Added new `HWY_GTEST_SKIP()` macro, which is defined as `GTEST_SKIP()` if HWY_TEST_STANDALONE is 0 and `return` if HWY_TEST_STANDALONE is 1. The `HWY_GTEST_SKIP()` macro does not support `operator <<` if HWY_TEST_STANDALONE is 1.

Fixed compiler error in hash_test.cc if HWY_TEST_STANDALONE is 1 by replacing GTEST_SKIP() with HWY_GTEST_SKIP().

Also replaced EXPECT_EQ with HWY_ASSERT_EQ in phast_test.cc to fix compiler error if HWY_TEST_STANDALONE is 1.