### PR TITLE
Fix TestShardMul on bi-endian

### DIFF
--- a/hwy/contrib/hash/shardmul-inl.h
+++ b/hwy/contrib/hash/shardmul-inl.h
@@ -94,8 +94,13 @@ class HWY_ALIGN_MAX ShardMul {
     // Split u64 keys into two u32 halves.
     const VU32 lo = BitCast(du32, key0);
     const VU32 hi = BitCast(du32, key1);
+#if HWY_IS_BIG_ENDIAN
+    LL = ConcatOdd(du32, hi, lo);
+    RR = ConcatEven(du32, hi, lo);
+#else
     LL = ConcatEven(du32, hi, lo);
     RR = ConcatOdd(du32, hi, lo);
+#endif
 
     // 4-round Feistel to ensure the two halves are independent (Luby-Rackoff).
     // Even with a stronger round function, three rounds are insufficient


### PR DESCRIPTION
Commit 4ecb74a has caused the following test failures on s390x:
```
ShardMulTestGroup/ShardMulTest.TestShardMulTwoVec
ShardMulTestGroup/ShardMulTest.TestShardMulCollisionFree
```
On big-endian, BitCast places the upper 32 bits in even lanes, so swap Even/Odd to match scalar.