### PR TITLE
Made fixes to float_distribution example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -847,6 +847,15 @@ target_link_libraries(matrix_transpose_scatter_gather PRIVATE ${ATOMICS_LIBRARIE
 set_target_properties(matrix_transpose_scatter_gather
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
 
+# Float magnitude based compaction
+add_executable(float_distribution hwy/examples/float_distribution.cc)
+target_compile_options(float_distribution PRIVATE ${HWY_FLAGS})
+target_compile_features(float_distribution PRIVATE ${HWY_CXX_STD_TGT_COMPILE_FEATURE})
+target_link_libraries(float_distribution PRIVATE hwy)
+target_link_libraries(float_distribution PRIVATE ${ATOMICS_LIBRARIES})
+set_target_properties(float_distribution
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
+
 endif()  # HWY_ENABLE_EXAMPLES
 
 # -------------------------------------------------------- Tests

--- a/hwy/examples/float_distribution.cc
+++ b/hwy/examples/float_distribution.cc
@@ -68,15 +68,19 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
                                                size_t count,
                                                uint8_t threshold_val,
                                                uint8_t* HWY_RESTRICT out) {
+#if HWY_TARGET == HWY_SCALAR
+  // FloatDistributionSIMD is not supported on the HWY_SCALAR target
+
+  (void)in;
+  (void)count;
+  (void)threshold_val;
+  (void)out;
+  return 0;
+#else
   using DF32 = hn::ScalableTag<float>;
   using DU32 = hn::ScalableTag<uint32_t>;
-#if HWY_TARGET == HWY_SCALAR
-  using DU16 = hn::Rebind<uint16_t, DU32>;
-  using DU8 = hn::Rebind<uint8_t, DU32>;
-#else
   using DU16 = hn::Repartition<uint16_t, DU32>;
   using DU8 = hn::Repartition<uint8_t, DU32>;
-#endif
 
   const DF32 df32;
   const DU32 du32;
@@ -85,9 +89,7 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
 
   using VF32 = hn::Vec<DF32>;
   using VU32 = hn::Vec<DU32>;
-#if HWY_TARGET != HWY_SCALAR
   using VU16 = hn::Vec<DU16>;
-#endif
   using VU8 = hn::Vec<DU8>;
   using MU8 = hn::Mask<DU8>;
 
@@ -112,22 +114,6 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
   // It performs also clamping of values.
   // Reorder version dosen't assume any order of output elements.
   // If you want to preserve order you should use OrderedDemote2To.
-#if HWY_TARGET == HWY_SCALAR
-    const VU8 exp8_0 = hn::DemoteTo(du8, exp0);
-    const VU8 exp8_1 = hn::DemoteTo(du8, exp1);
-    const VU8 exp8_2 = hn::DemoteTo(du8, exp2);
-    const VU8 exp8_3 = hn::DemoteTo(du8, exp3);
-
-    const MU8 final_mask0 = hn::Gt(exp8_0, min_exp);
-    const MU8 final_mask1 = hn::Gt(exp8_1, min_exp);
-    const MU8 final_mask2 = hn::Gt(exp8_2, min_exp);
-    const MU8 final_mask3 = hn::Gt(exp8_3, min_exp);
-
-    out_idx += hn::CompressBlendedStore(exp8_0, final_mask0, du8, out + out_idx);
-    out_idx += hn::CompressBlendedStore(exp8_1, final_mask1, du8, out + out_idx);
-    out_idx += hn::CompressBlendedStore(exp8_2, final_mask2, du8, out + out_idx);
-    out_idx += hn::CompressBlendedStore(exp8_3, final_mask3, du8, out + out_idx);
-#else
     const VU16 exp16_01 = hn::ReorderDemote2To(du16, exp0, exp1);
     const VU16 exp16_23 = hn::ReorderDemote2To(du16, exp2, exp3);
     const VU8 exp8 = hn::ReorderDemote2To(du8, exp16_01, exp16_23);
@@ -140,7 +126,6 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
     // There is also CompressStore, which does the same job but faster but can
     // write more than indicated by the mask.
     out_idx += hn::CompressBlendedStore(exp8, final_mask, du8, out + out_idx);
-#endif
   };
 
   for (; i + block_size <= count; i += block_size) {
@@ -169,6 +154,7 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
   }
 
   return out_idx;
+#endif
 }
 
 }  // namespace HWY_NAMESPACE

--- a/hwy/examples/float_distribution.cc
+++ b/hwy/examples/float_distribution.cc
@@ -17,7 +17,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <bit>
 #include <cmath>
 #include <cstring>
 #include <random>
@@ -34,6 +33,7 @@
 #include "hwy/foreach_target.h"  // IWYU pragma: keep
 #include "hwy/highway.h"
 #include "hwy/nanobenchmark.h"
+#include "hwy/per_target.h"
 #include "hwy/timer.h"
 
 /*
@@ -70,8 +70,13 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
                                                uint8_t* HWY_RESTRICT out) {
   using DF32 = hn::ScalableTag<float>;
   using DU32 = hn::ScalableTag<uint32_t>;
+#if HWY_TARGET == HWY_SCALAR
+  using DU16 = hn::Rebind<uint16_t, DU32>;
+  using DU8 = hn::Rebind<uint8_t, DU32>;
+#else
   using DU16 = hn::Repartition<uint16_t, DU32>;
   using DU8 = hn::Repartition<uint8_t, DU32>;
+#endif
 
   const DF32 df32;
   const DU32 du32;
@@ -80,9 +85,13 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
 
   using VF32 = hn::Vec<DF32>;
   using VU32 = hn::Vec<DU32>;
+#if HWY_TARGET != HWY_SCALAR
   using VU16 = hn::Vec<DU16>;
+#endif
   using VU8 = hn::Vec<DU8>;
   using MU8 = hn::Mask<DU8>;
+
+  (void)du16;
 
   HWY_LANES_CONSTEXPR size_t lanes = hn::Lanes(df32);
   size_t out_idx = 0;
@@ -99,10 +108,26 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
 
   auto demote_and_store = [&](VU32 exp0, VU32 exp1, VU32 exp2,
                               VU32 exp3) HWY_ATTR {
-    // Demote compresses i32 -> i16 -> i8
-    // It performs also clamping of values.
-    // Reorder version dosen't assume any order of output elements.
-    // If you want to preserve order you should use OrderedDemote2To.
+  // Demote compresses i32 -> i16 -> i8
+  // It performs also clamping of values.
+  // Reorder version dosen't assume any order of output elements.
+  // If you want to preserve order you should use OrderedDemote2To.
+#if HWY_TARGET == HWY_SCALAR
+    const VU8 exp8_0 = hn::DemoteTo(du8, exp0);
+    const VU8 exp8_1 = hn::DemoteTo(du8, exp1);
+    const VU8 exp8_2 = hn::DemoteTo(du8, exp2);
+    const VU8 exp8_3 = hn::DemoteTo(du8, exp3);
+
+    const MU8 final_mask0 = hn::Gt(exp8_0, min_exp);
+    const MU8 final_mask1 = hn::Gt(exp8_1, min_exp);
+    const MU8 final_mask2 = hn::Gt(exp8_2, min_exp);
+    const MU8 final_mask3 = hn::Gt(exp8_3, min_exp);
+
+    out_idx += hn::CompressBlendedStore(exp8_0, final_mask0, du8, out + out_idx);
+    out_idx += hn::CompressBlendedStore(exp8_1, final_mask1, du8, out + out_idx);
+    out_idx += hn::CompressBlendedStore(exp8_2, final_mask2, du8, out + out_idx);
+    out_idx += hn::CompressBlendedStore(exp8_3, final_mask3, du8, out + out_idx);
+#else
     const VU16 exp16_01 = hn::ReorderDemote2To(du16, exp0, exp1);
     const VU16 exp16_23 = hn::ReorderDemote2To(du16, exp2, exp3);
     const VU8 exp8 = hn::ReorderDemote2To(du8, exp16_01, exp16_23);
@@ -115,6 +140,7 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
     // There is also CompressStore, which does the same job but faster but can
     // write more than indicated by the mask.
     out_idx += hn::CompressBlendedStore(exp8, final_mask, du8, out + out_idx);
+#endif
   };
 
   for (; i + block_size <= count; i += block_size) {
@@ -139,6 +165,7 @@ static HWY_INLINE size_t FloatDistributionSIMD(const float* HWY_RESTRICT in,
         to_exponent(load_chunk(0 * lanes)), to_exponent(load_chunk(1 * lanes)),
         to_exponent(load_chunk(2 * lanes)), to_exponent(load_chunk(3 * lanes)));
     i += remainder;
+    (void)i;
   }
 
   return out_idx;
@@ -158,7 +185,7 @@ HWY_EXPORT(FloatDistributionSIMD);
 // Helper to extract the exponent (approximate log2) of a float.
 HWY_INLINE uint32_t GetExponent(float v) {
   float abs_v = std::abs(v);
-  uint32_t int_v = std::bit_cast<uint32_t>(abs_v);
+  uint32_t int_v = hwy::BitCastScalar<uint32_t>(abs_v);
   return int_v >> 23;
 }
 
@@ -186,7 +213,7 @@ bool Verify(const float* HWY_RESTRICT in, size_t count, float threshold) {
   expected.resize(expected_size);
 
   const uint8_t threshold_val = static_cast<uint8_t>(GetExponent(threshold));
-  std::vector<uint8_t> actual(count + HWY_MAX_BYTES);
+  std::vector<uint8_t> actual(count + hwy::VectorBytes());
   size_t actual_size = HWY_DYNAMIC_DISPATCH(FloatDistributionSIMD)(
       in, count, threshold_val, actual.data());
   actual.resize(actual_size);
@@ -234,8 +261,11 @@ int RunTests() {
   std::mt19937 gen(42);
   std::uniform_real_distribution<float> dis(-1.5f, 1.5f);
   for (size_t size :
-       {1,  2,  3,   4,   7,   8,   15,  16,  17,  31,   32,   33,  63,
-        64, 65, 100, 127, 128, 129, 255, 256, 257, 1000, 1024, 1025}) {
+       {size_t{1},   size_t{2},   size_t{3},    size_t{4},    size_t{7},
+        size_t{8},   size_t{15},  size_t{16},   size_t{17},   size_t{31},
+        size_t{32},  size_t{33},  size_t{63},   size_t{64},   size_t{65},
+        size_t{100}, size_t{127}, size_t{128},  size_t{129},  size_t{255},
+        size_t{256}, size_t{257}, size_t{1000}, size_t{1024}, size_t{1025}}) {
     AlignedVector<float> in(size);
     for (size_t i = 0; i < size; ++i) {
       in[i] = dis(gen);


### PR DESCRIPTION
Replaced std::bit_cast with hwy::BitCastScalar in float_distribution.cc as std::bit_cast requires C++20.

Also updated FloatDistributionSIMD in float_distribution.cc to work with the HWY_SCALAR target.

Also replaced HWY_MAX_BYTES with `hwy::VectorBytes()` in Verify in float_distribution.cc, as it is possible for `hwy::VectorBytes() > HWY_MAX_BYTES` to be true if `HWY_TARGET != (HWY_TARGET & (-HWY_TARGET))` is true (or in other words, there is more than 1 target enabled).

Also fixed a compiler warning with the sizes list in RunTests() in float_distribution.cc.

Also updated CMakeLists.txt to build and compile float_distribution.