### PR TITLE
Fixed build errors with Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -170,6 +170,7 @@ hwy_contrib_sources = files(
     'hwy/contrib/hash/phast.cc',
     'hwy/contrib/hash/shardmul.cc',
     'hwy/contrib/sort/vqsort.cc',
+    'hwy/contrib/sort/vqsort_have.cc',
     'hwy/contrib/thread_pool/thread_pool.cc',
     'hwy/contrib/thread_pool/topology.cc',
     # plus all of the vqsort_*.cc....


### PR DESCRIPTION
Added hwy/contrib/sort/vqsort_have.cc to hwy_contrib_sources list in meson.build to fix build errors with Meson.