### PR TITLE
Use SumsOf8 for AVX2 u8 lane sums

### DIFF
--- a/hwy/ops/x86_128-inl.h
+++ b/hwy/ops/x86_128-inl.h
@@ -15507,13 +15507,14 @@ HWY_API Mask128<T, N> SetAtOrBeforeFirst(Mask128<T, N> mask) {
 
 // Nothing fully native, generic_ops-inl defines SumOfLanes and ReduceSum.
 
-// We provide specializations of u8x8 and u8x16, so exclude those.
+// We provide specializations of u8x8 and u8x16 below, and u8x32 in
+// x86_256-inl.h, so exclude those.
 #undef HWY_IF_SUM_OF_LANES_D
-#define HWY_IF_SUM_OF_LANES_D(D)                                        \
-  HWY_IF_LANES_GT_D(D, 1),                                              \
-      hwy::EnableIf<!hwy::IsSame<TFromD<D>, uint8_t>() ||               \
-                    (HWY_V_SIZE_D(D) != 8 && HWY_V_SIZE_D(D) != 16)>* = \
-          nullptr
+#define HWY_IF_SUM_OF_LANES_D(D)                                      \
+  HWY_IF_LANES_GT_D(D, 1),                                            \
+      hwy::EnableIf<!hwy::IsSame<TFromD<D>, uint8_t>() ||             \
+                    (HWY_V_SIZE_D(D) != 8 && HWY_V_SIZE_D(D) != 16 && \
+                     HWY_V_SIZE_D(D) != 32)>* = nullptr
 
 template <class D, HWY_IF_U8_D(D), HWY_IF_LANES_D(D, 8)>
 HWY_API VFromD<D> SumOfLanes(D d, VFromD<D> v) {

--- a/hwy/ops/x86_256-inl.h
+++ b/hwy/ops/x86_256-inl.h
@@ -2129,6 +2129,14 @@ HWY_API Vec256<uint64_t> SumsOf8(Vec256<uint8_t> v) {
   return Vec256<uint64_t>{_mm256_sad_epu8(v.raw, _mm256_setzero_si256())};
 }
 
+template <class D, HWY_IF_U8_D(D), HWY_IF_V_SIZE_D(D, 32)>
+HWY_API VFromD<D> SumOfLanes(D d, VFromD<D> v) {
+  const Repartition<uint64_t, decltype(d)> d64;
+  VFromD<decltype(d64)> sums = SumsOf8(v);
+  sums = SumOfLanes(d64, sums);
+  return Broadcast<0>(BitCast(d, sums));
+}
+
 HWY_API Vec256<uint64_t> SumsOf8AbsDiff(Vec256<uint8_t> a, Vec256<uint8_t> b) {
   return Vec256<uint64_t>{_mm256_sad_epu8(a.raw, b.raw)};
 }


### PR DESCRIPTION
## Problem

Full-width AVX2 `uint8_t` `SumOfLanes` and `ReduceSum` use the generic shuffle-and-widen reduction despite AVX2 already having a native `SumsOf8` implementation.

## Root cause

The generic reduction eligibility condition excludes the existing u8x8 and u8x16 specialisations, but not u8x32. There is therefore no overload that routes a 256-bit byte reduction through `SumsOf8`.

## Change

Exclude u8x32 from the generic reduction and add a 256-bit overload that:

1. uses `SumsOf8` to form four exact uint64 partial sums;
2. reduces those partial sums using the existing uint64 implementation; and
3. broadcasts the low byte.

The low byte preserves the existing modulo-256 uint8 reduction semantics.

## Correctness

The existing parameterised reduction tests cover `SumOfLanes`, `ReduceSum`, full and partial vectors, and unsigned wraparound.

- GCC 14.2: 40/40 focused cases passed
- Clang 19.1 with warnings-as-errors: 40/40 focused cases passed
- Clang ASan+UBSan: 40/40 focused cases passed
- MSVC 19.41 core Release test: passed
- Full GCC suite: 2,360 executed tests passed, 18 expected skips, zero failures

## Performance

Intel Core i9-13905H, WSL2 Debian, static AVX2, `-O3 -march=haswell`, pinned to logical CPU 4. Results are medians of 31 interleaved samples with 16,777,216 reductions per sample. Brackets show IQR.

| Case | Compiler | Baseline | Patched | Change |
| ---- | -------- | -------: | ------: | -----: |
| 1 vector/call | GCC 14.2 | 1.104 [1.079, 1.124] ns | 0.652 [0.644, 0.671] ns | -40.9% |
| 8 vectors/call | GCC 14.2 | 1.095 [1.075, 1.124] ns | 0.609 [0.599, 0.638] ns | -44.4% |
| 1 vector/call | Clang 19.1 | 1.050 [1.016, 1.068] ns | 0.561 [0.558, 0.570] ns | -46.6% |
| 8 vectors/call | Clang 19.1 | 0.983 [0.977, 1.003] ns | 0.568 [0.559, 0.578] ns | -42.2% |

The GCC SIMD reduction sequence decreases from 14 vector operations to 7.
Clang shows a comparable reduction.

## Regressions

The u8x16 control code generation is unchanged with both GCC and Clang.
The isolated micro-object text size also decreases. No tested target regressed.

## Scope

Performance was measured only on AVX2 x86-64. No AVX-512, Arm, RISC-V or Power performance is claimed.