### PR TITLE
perf(phast): prune builder collision and scan tests by slice structure

### DIFF
--- a/hwy/contrib/hash/phast.cc
+++ b/hwy/contrib/hash/phast.cc
@@ -289,6 +289,14 @@ class PerWorkerBuilder {
     const size_t fail_b_size = ComputeBucketPos(rank);
     const size_t num_pos_to_find = fail_b_size * 256;
 
+    // all_pos_ is covered by the fail_b_size slices of this bucket, which
+    // together span at most fail_b_size * slice_length of num_slots - about
+    // 0.4% for 1M keys. Positions outside them cannot be in all_pos_, so the
+    // Find below is skipped for the vast majority of scanned positions.
+    uint32_t slice_begin[kMaxHashesPerBucket];
+    ComputeSliceBegins(rank, fail_b_size, slice_begin);
+    const uint32_t slice_length = config_.placement.slice_mask + 1;
+
     // Scan recent buckets for those whose committed positions match any
     // target position (i.e., they block a candidate seed).
     const ScalableTag<uint32_t> du32;
@@ -307,6 +315,12 @@ class PerWorkerBuilder {
       bool matches = false;
       for (size_t idx = 0; idx < scan_size && !matches; ++idx) {
         const uint32_t pos = ComputeOnePos(scan_begin + idx, scan_seed);
+        // Unsigned wraparound also rejects pos < slice_begin[i].
+        bool in_slice = false;
+        for (size_t i = 0; i < fail_b_size && !in_slice; ++i) {
+          in_slice = (pos - slice_begin[i]) < slice_length;
+        }
+        if (!in_slice) continue;
         matches = Find(du32, pos, all_pos_.data(), num_pos_to_find) !=
                   num_pos_to_find;
       }
@@ -352,6 +366,23 @@ class PerWorkerBuilder {
     return false;
   }
 
+  // Writes, for each key of the bucket at `rank`, the first slot it can occupy.
+  // PosFromHashAndSeed is LemireMod(hash, num_slice_offsets) + (Placement(hash,
+  // seed) & slice_mask): the first term does not depend on the seed and the
+  // second is less than slice_length, so every seed places that key somewhere
+  // in [slice_begin, slice_begin + slice_length). Two keys whose slices are
+  // disjoint therefore cannot share a slot at any seed.
+  void ComputeSliceBegins(uint32_t rank, size_t b_size,
+                          uint32_t* HWY_RESTRICT slice_begin) const {
+    const uint32_t bucket_idx = bucket_idx_largest_first_[rank];
+    const size_t b_begin = total_hashes_before_bucket_[bucket_idx];
+    for (size_t idx = 0; idx < b_size; ++idx) {
+      const uint32_t key_idx = key_idx_for_pos_[b_begin + idx];
+      slice_begin[idx] = LemireMod(hash_for_key_idx_[key_idx],
+                                   config_.placement.num_slice_offsets);
+    }
+  }
+
   // Computes the position for a single hash+seed pair (scalar).
   // Much cheaper than ComputeBucketPos, which computes all 256 seeds.
   uint32_t ComputeOnePos(size_t b_pos, uint32_t seed) const {
@@ -394,6 +425,29 @@ class PerWorkerBuilder {
     const size_t b_size = ComputeBucketPos(rank);
     const size_t num_candidates = WriteSeedCandidates(b_size, seed_candidates);
 
+    // Two keys of this bucket can only share a slot if their slices overlap
+    // (see ComputeSliceBegins). Collecting those pairs once replaces the
+    // b_size*(b_size-1)/2 pairwise test that would otherwise repeat for each of
+    // the num_candidates seeds. Measured over a 1M-key build, 48,796 of
+    // 8,571,328 pairs overlap - 0.57% - so the inner check below is usually
+    // empty and the quadratic term disappears entirely for that bucket.
+    uint16_t overlap[kMaxHashesPerBucket * (kMaxHashesPerBucket - 1) / 2];
+    size_t num_overlap = 0;
+    if (b_size >= 2 && num_candidates != 0) {
+      uint32_t slice_begin[kMaxHashesPerBucket];
+      ComputeSliceBegins(rank, b_size, slice_begin);
+      const uint32_t slice_length = config_.placement.slice_mask + 1;
+      for (size_t i = 0; i < b_size; ++i) {
+        for (size_t j = i + 1; j < b_size; ++j) {
+          const uint32_t bi = slice_begin[i], bj = slice_begin[j];
+          const uint32_t d = bi > bj ? bi - bj : bj - bi;
+          if (d < slice_length) {
+            overlap[num_overlap++] = static_cast<uint16_t>((i << 8) | j);
+          }
+        }
+      }
+    }
+
     uint32_t best_seed = 0;
     uint32_t best_cost = ~0u;
 
@@ -402,12 +456,13 @@ class PerWorkerBuilder {
       if (seed == excluded_seed) continue;
 
       if (b_size >= 2) {
-        // Pairwise collision check.
+        // Pairwise collision check, restricted to pairs with overlapping
+        // slices; the rest cannot collide at this or any other seed.
         bool has_dup = false;
-        for (size_t i = 0; i < b_size && !has_dup; ++i) {
-          for (size_t j = i + 1; j < b_size && !has_dup; ++j) {
-            has_dup = (all_pos_[i * 256 + seed] == all_pos_[j * 256 + seed]);
-          }
+        for (size_t p = 0; p < num_overlap && !has_dup; ++p) {
+          const size_t i = overlap[p] >> 8;
+          const size_t j = overlap[p] & 0xFF;
+          has_dup = (all_pos_[i * 256 + seed] == all_pos_[j * 256 + seed]);
         }
         if (has_dup) continue;
 

--- a/hwy/contrib/hash/phast_test.cc
+++ b/hwy/contrib/hash/phast_test.cc
@@ -47,12 +47,122 @@ namespace {
 
 // Phast is not supported on HWY_SCALAR and too slow on HWY_EMU128.
 #if (HWY_TARGET == HWY_SCALAR || HWY_TARGET == HWY_EMU128) && !HWY_IDE
+HWY_NOINLINE void TestSliceInvariant() {}
+HWY_NOINLINE void TestDisjointSlicesNeverCollide() {}
+HWY_NOINLINE void TestSliceBoundIsTight() {}
 HWY_NOINLINE void TestQueryConsistency() {}
 HWY_NOINLINE void TestMultipleSizes() {}
 #else
 
 static ThreadPool MakePool() {
   return ThreadPool(ThreadPool::NumThreadsFromCores());
+}
+
+// --------------------------------------------------------------------------
+// Placement structure. The builder's collision and overlap checks rely on
+// PosFromHashAndSeed decomposing into a seed-independent slice base plus an
+// offset smaller than slice_length. These tests pin that decomposition so a
+// change to Placement/Hash16 that broke it would fail here rather than silently
+// invalidate the builder's pruning.
+
+// Every seed places a key inside its own slice.
+HWY_NOINLINE void TestSliceInvariant() {
+  fprintf(stderr, "=== TestSliceInvariant ===\n");
+  const size_t kNumSlots[] = {203, 1021, 12289, 206001};
+  const uint32_t kSliceLengths[] = {64, 128, 512, 2048};
+  size_t checked = 0;
+  for (size_t num_slots : kNumSlots) {
+    for (uint32_t slice_length : kSliceLengths) {
+      if (num_slots < slice_length) continue;
+      const PhastPlacement pp(num_slots, slice_length);
+      uint32_t hash = 0x9E3779B9u;
+      for (size_t t = 0; t < 500; ++t) {
+        hash = hash * 1664525u + 1013904223u;
+        const uint32_t base = LemireMod(hash, pp.num_slice_offsets);
+        for (uint32_t seed = 0; seed < 256; ++seed) {
+          const uint32_t pos = Phast::PosFromHashAndSeed(pp, hash, seed);
+          HWY_ASSERT_M(pos >= base, "position below its slice");
+          HWY_ASSERT_M(pos - base < slice_length, "position beyond its slice");
+          HWY_ASSERT_M(pos < num_slots, "position outside the table");
+          ++checked;
+        }
+      }
+    }
+  }
+  fprintf(stderr, "  OK: %zu (hash, seed) pairs inside their slice\n", checked);
+}
+
+// Keys whose slices are disjoint cannot share a slot at any seed. This is what
+// lets the builder skip those pairs instead of retesting them per seed.
+HWY_NOINLINE void TestDisjointSlicesNeverCollide() {
+  fprintf(stderr, "=== TestDisjointSlicesNeverCollide ===\n");
+  const PhastPlacement pp(/*num_slots=*/1020001, /*slice_length=*/2048);
+  const uint32_t slice_length = pp.slice_mask + 1;
+  uint32_t hash = 12345u;
+  size_t disjoint = 0;
+  for (size_t t = 0; t < 20000; ++t) {
+    hash = hash * 1664525u + 1013904223u;
+    const uint32_t hi = hash;
+    hash = hash * 1664525u + 1013904223u;
+    const uint32_t hj = hash;
+    const uint32_t bi = LemireMod(hi, pp.num_slice_offsets);
+    const uint32_t bj = LemireMod(hj, pp.num_slice_offsets);
+    const uint32_t d = bi > bj ? bi - bj : bj - bi;
+    if (d < slice_length) continue;  // slices overlap; collision permitted
+    ++disjoint;
+    for (uint32_t seed = 0; seed < 256; ++seed) {
+      HWY_ASSERT_M(Phast::PosFromHashAndSeed(pp, hi, seed) !=
+                       Phast::PosFromHashAndSeed(pp, hj, seed),
+                   "disjoint slices produced a collision");
+    }
+  }
+  HWY_ASSERT_M(disjoint > 1000, "too few disjoint pairs to be meaningful");
+  fprintf(stderr, "  OK: %zu random disjoint pairs, no collision\n", disjoint);
+
+  // Random pairs land far apart and so exercise the claim weakly. The case that
+  // discriminates is the tightest one: slices exactly slice_length apart, where
+  // a single extra reachable offset would produce a collision. Construct those
+  // pairs rather than sampling for them.
+  const PhastPlacement tight(/*num_slots=*/203, /*slice_length=*/64);
+  const uint32_t width = tight.slice_mask + 1;
+  size_t constructed = 0;
+  for (uint64_t h = 0; h <= 0xFFFFFFFFull; h += 655357) {
+    const uint32_t hi2 = static_cast<uint32_t>(h);
+    const uint64_t target =
+        static_cast<uint64_t>(LemireMod(hi2, tight.num_slice_offsets)) + width;
+    if (target >= tight.num_slice_offsets) continue;
+    const uint64_t lo = ((target << 32) + tight.num_slice_offsets - 1) /
+                        tight.num_slice_offsets;
+    if (lo > 0xFFFFFFFFull) continue;
+    const uint32_t hj2 = static_cast<uint32_t>(lo);
+    if (LemireMod(hj2, tight.num_slice_offsets) != target) continue;
+    ++constructed;
+    for (uint32_t seed = 0; seed < 256; ++seed) {
+      HWY_ASSERT_M(Phast::PosFromHashAndSeed(tight, hi2, seed) !=
+                       Phast::PosFromHashAndSeed(tight, hj2, seed),
+                   "slices exactly slice_length apart must not collide");
+    }
+  }
+  HWY_ASSERT_M(constructed > 500, "too few tight pairs constructed");
+  fprintf(stderr, "  OK: %zu pairs exactly slice_length apart, no collision\n",
+          constructed);
+}
+
+// The bound above is `< slice_length`, not `< slice_length - 1`: slices exactly
+// slice_length - 1 apart share one slot and that slot is reachable. Regression
+// case for a config the builder enumerates (num_keys 200, headroom 1%).
+HWY_NOINLINE void TestSliceBoundIsTight() {
+  fprintf(stderr, "=== TestSliceBoundIsTight ===\n");
+  const PhastPlacement pp(/*num_slots=*/203, /*slice_length=*/64);
+  const uint32_t hi = 0x000c0000u, hj = 0x73570000u, seed = 0;
+  const uint32_t bi = LemireMod(hi, pp.num_slice_offsets);
+  const uint32_t bj = LemireMod(hj, pp.num_slice_offsets);
+  HWY_ASSERT_M(bj - bi == pp.slice_mask, "witness slices not slice_length-1 apart");
+  const uint32_t pi = Phast::PosFromHashAndSeed(pp, hi, seed);
+  const uint32_t pj = Phast::PosFromHashAndSeed(pp, hj, seed);
+  HWY_ASSERT_M(pi == pj, "witness pair must collide; the bound cannot be tightened");
+  fprintf(stderr, "  OK: slices %u apart (slice_length-1) collide at slot %u\n",
+          bj - bi, pi);
 }
 
 HWY_NOINLINE void TestQueryConsistency() {
@@ -172,6 +282,9 @@ HWY_AFTER_NAMESPACE();
 #if HWY_ONCE
 namespace hwy {
 HWY_BEFORE_TEST(PhastTest);
+HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestSliceInvariant);
+HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestDisjointSlicesNeverCollide);
+HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestSliceBoundIsTight);
 HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestQueryConsistency);
 HWY_EXPORT_AND_TEST_BEST_P(PhastTest, TestMultipleSizes);
 HWY_AFTER_TEST();


### PR DESCRIPTION
## Summary

`Phast::PosFromHashAndSeed` is `LemireMod(hash, num_slice_offsets)` plus
`Placement(hash, seed) & slice_mask`. The first term does not depend on the seed
and the second is masked to `slice_length`, so every position reachable from one
hash lies in a range of width `slice_length` fixed by the hash alone.

`TryPlaceBucket` tests all `b_size*(b_size-1)/2` key pairs of a bucket for a
shared slot, once per candidate seed. Two keys can only collide if their ranges
overlap, so this change collects the overlapping pairs once per bucket and tests
only those. `TryCuckooSwap` calls `Find`, a linear scan of `fail_b_size * 256`
elements, on every scanned position; `all_pos_` lies inside `fail_b_size` ranges,
so this change bounds-checks first.

Both are exact rejections, not heuristics. Seed selection, placement order,
config selection and the returned `PhastData` are unchanged. No public API,
header, storage-format or query-path change.

Fixes #3243.

## Comparison counts

Atomic counters in the pairwise check, whole builds, 9 workers.

| num_keys | `d043aee` | PR head (collect + per-seed) | reduction | duplicates found |
|---|---|---|---|---|
| 200,000 | 480,728,084 | 4,119,273 + 14,145,884 = 18,265,157 | 26.3x | 2,939 on both |
| 1,000,000 | 894,081,141 | 8,571,056 + 5,072,681 = 13,643,737 | 65.5x | 937 on both |

Overlapping pairs: 121,497 of 4,119,273 at 200,000 keys, 48,796 of 8,571,328 at
1,000,000. Equal duplicate counts on both builds is the restriction confirmed on
real inputs rather than only on constructed pairs.

## Build time

`d043aee` vs PR head, clang 22.1.7 `x86_64-pc-windows-msvc`, `-O2`, AVX2,
Windows 11, 9 workers, `payload_bytes` = 4. Both binaries link the same
`hwy.lib`; only `hwy_contrib.lib` differs. Six paired interleaved runs at
1,000,000 keys, 7 repetitions each, alternating arms so both see the same
machine state:

| pair | `d043aee` min / median | PR head min / median | ratio min / median |
|---|---|---|---|
| 1 | 1047.2 / 1510.9 ms | 527.9 / 587.9 ms | 1.98x / 2.57x |
| 2 | 903.9 / 1062.2 ms | 501.1 / 514.5 ms | 1.80x / 2.06x |
| 3 | 880.5 / 986.4 ms | 528.8 / 551.3 ms | 1.66x / 1.79x |
| 4 | 964.0 / 1073.9 ms | 538.7 / 549.7 ms | 1.79x / 1.95x |
| 5 | 835.8 / 884.3 ms | 507.5 / 532.2 ms | 1.65x / 1.66x |
| 6 | 883.7 / 929.3 ms | 508.6 / 526.2 ms | 1.74x / 1.77x |

Worst pair 1.65x on the minimum. At 200,000 keys, 324.5 -> 204.6 ms minimum. At
10,000 keys, 4.9 -> 3.3 ms; greedy placement almost always succeeds there so
`TryCuckooSwap` rarely runs and the gain comes from `TryPlaceBucket` alone.
Isolating the two changes at 1,000,000 keys, medians over three rounds: the scan
bound alone takes 833 -> 490, 805 -> 483, 837 -> 523 ms, and the pair collection
takes those to 462, 453, 444 ms.

## Tests

`phast_test.cc` gains three tests calling `Phast::PosFromHashAndSeed` and
`PhastPlacement` directly rather than reimplementing them. Suite goes 3 -> 6.

| test | asserts | scale |
|---|---|---|
| `TestSliceInvariant` | `base <= Pos < base + slice_length`, `Pos < num_slots` | 1,664,000 (hash, seed) pairs, 4 `num_slots` x 4 `slice_length` |
| `TestDisjointSlicesNeverCollide` | disjoint ranges never collide at any of 256 seeds | 19,929 random pairs plus 3,558 constructed pairs exactly `slice_length` apart |
| `TestSliceBoundIsTight` | the bound is `< slice_length`, not `< slice_length - 1` | one recorded witness |

Each was verified to fail before being relied on. Mutating
`Placement(hash, seed) & pp.slice_mask` to `% (pp.slice_mask + 2)` in
`phast-inl.h` aborts all three:

```
TestSliceInvariant               pos - base < slice_length: position beyond its slice
TestDisjointSlicesNeverCollide   slices exactly slice_length apart must not collide
TestSliceBoundIsTight            witness pair must collide; the bound cannot be tightened
```

Mutating the `TryPlaceBucket` predicate to `< slice_length - 1` makes the
existing `TestMultipleSizes` fail with `Collision detected` at 2,048 keys or
fewer, so the off-by-one is a correctness bug and the pre-existing suite already
catches it. The same mutation on the `TryCuckooSwap` bound leaves all 6 tests
passing — it changes which swaps run and so which seeds are chosen, while still
producing a valid perfect hash — and is caught only by the digest below. The two
bounds fail differently and are covered accordingly.

Random sampling is blind to that boundary: the set of hash-block gaps at exactly
`slice_length - 1` has width `65536 / num_slice_offsets`, which is 0.064 at 1M
keys, so the case is unreachable there and reachable only at the small configs
`MinSliceLength` selects below 1,300 keys. `TestSliceBoundIsTight` uses a
constructed witness for that reason.

Buildable targets on this setup, PR head: `phast_test` 6/6, `cuckoo2x2_test` 3/3,
`shardmul_test` 3/3. Skips are the EMU128 variants, skipped on `d043aee` too.

## Output identity

An FNV-1a 64 digest over `num_slots`, `hash_key`, `bucket_mask`,
`num_slice_offsets`, `slice_mask`, `config_idx`, `attempt_idx` and every packed
seed word `GatherSeeds` reads. 14 key-set sizes (1, 2, 17, 63, 64, 100, 511,
1000, 4096, 9500, 12000, 50000, 140000, 200000) x 3 key-set seeds = 42 cases, 3
repeated builds each, against both libraries: 252 builds. 42/42 digests match
`d043aee`; 0/126 repeated builds per binary differed from their own first build.

## Rejected alternatives

A bitset over `[0, num_slots)` for the `TryCuckooSwap` test, following the
existing `Occupancy` pattern, makes membership exact and drops the `Find`
fallback, but the 256-seed orbit visits 242 distinct positions in a 2048-wide
range, so the range check already rejects 99.60% of probes and the bitset would
filter the residual 0.40% at the cost of a `num_slots`-sized allocation and a
per-call reset. Sorting the range bases before collecting pairs would give
`O(b_size log b_size + pairs)` instead of `O(b_size^2)`, but `b_size` is 2 to 12
on every build measured and `kMaxHashesPerBucket` is 32, so `b_size^2/2 <= 496`
beats a sort at every reachable size.

## Limits

Timings are one machine, one compiler, one OS and the AVX2 target only, and the
machine was not quiesced, hence paired interleaved runs rather than a single
median. Comparison, overlap and duplicate counts are exact instrumented counts
and carry no such caveat. `b_size` was 2 to 12 on every build measured;
collection cost grows as `b_size^2` and `kMaxHashesPerBucket` is 32, a regime not
exercised here. Determinism is conditional on worker count on `d043aee` and on
this change alike, since `reps_per_config` derives from `pool.NumWorkers()`.
Two failures visible around this PR are pre-existing and unrelated to it.
`hwy/contrib/hash/hash_test.cc` does not build under clang-cl on the machine used
above (19 `always_inline ... requires target feature 'ssse3'` errors); verified
by stashing this change and rebuilding on `d043aee`, which produces the same 19
errors. In CI, `Build and test GCC-16 on AArch64` (`multiarch.yml`, job `aarch64_cmake`,
`runs-on: ubuntu-26.04-arm`) is red here, and reproduces identically on the base
commit:

| | `d043aee` master, job 91194654723 | this PR, job 91441853717 |
|---|---|---|
| Build step conclusion | `cancelled` | `cancelled` |
| duration | 33m30s | 36m01s |
| last line | `[ 57%] ... masked_arithmetic_test.cc.o` | `[ 57%] ... masked_arithmetic_test.cc.o` |
| compile errors | 0 | 0 |
| tests executed | 0 | 0 |

Both stop at the same percentage on the same translation unit after ~35 minutes,
so this is the runner being reclaimed at a fixed point in the build rather than
an intermittent fault. In this PR's run nothing else failed — the sibling
`Clang-22 on AArch64` succeeded at 02:25:54, after the GCC-16 build was already
cancelled at 02:18:35, and the other 18 jobs in run 30727519527 all passed — so
neither `fail-fast` nor `cancel-in-progress` explains it. `hwy/contrib/hash/phast.cc`
itself compiled cleanly on that toolchain, at 23%, under `-ftrapv` and
`-DHWY_WARNINGS_ARE_ERRORS=ON`, roughly 34 minutes before the job died.
