### PR TITLE
Fix LASX Tgamma failure and enable runtime dispatch for GCC >= 15.3

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -357,12 +357,14 @@
 #ifndef HWY_BROKEN_LOONGARCH  // allow override
 // Using __loongarch_sx and __loongarch_asx macros to
 // check whether LSX/LASX targets are available.
-// GCC does not work yet, see https://gcc.gnu.org/PR121875.
+// GCC < 15.3 does not work, see https://gcc.gnu.org/PR121875.
 #if !defined(__loongarch_sx) && \
-    !(HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800)
+    !(HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800) && \
+    !(HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL >= 1503)
 #define HWY_BROKEN_LOONGARCH (HWY_LSX | HWY_LASX)
 #elif !defined(__loongarch_asx) && \
-      !(HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800)
+      !(HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800) && \
+      !(HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL >= 1503)
 #define HWY_BROKEN_LOONGARCH (HWY_LASX)
 #else
 #define HWY_BROKEN_LOONGARCH 0
@@ -811,7 +813,8 @@
 
 #ifndef HWY_HAVE_RUNTIME_DISPATCH_LOONGARCH  // allow override
 #if HWY_ARCH_LOONGARCH && HWY_HAVE_AUXV && !defined(__loongarch_asx) && \
-    HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800
+    (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG >= 1800) || \
+    (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL >= 1503)
 #define HWY_HAVE_RUNTIME_DISPATCH_LOONGARCH 1
 #else
 #define HWY_HAVE_RUNTIME_DISPATCH_LOONGARCH 0

--- a/hwy/ops/loongarch_lasx-inl.h
+++ b/hwy/ops/loongarch_lasx-inl.h
@@ -1829,11 +1829,11 @@ HWY_API Vec256<double> MulAdd(Vec256<double> mul, Vec256<double> x,
 
 HWY_API Vec256<float> NegMulAdd(Vec256<float> mul, Vec256<float> x,
                                 Vec256<float> add) {
-  return add - mul * x;
+  return Vec256<float>{__lasx_xvfnmsub_s(mul.raw, x.raw, add.raw)};
 }
 HWY_API Vec256<double> NegMulAdd(Vec256<double> mul, Vec256<double> x,
                                  Vec256<double> add) {
-  return add - mul * x;
+  return Vec256<double>{__lasx_xvfnmsub_d(mul.raw, x.raw, add.raw)};
 }
 
 HWY_API Vec256<float> MulSub(Vec256<float> mul, Vec256<float> x,

--- a/hwy/ops/loongarch_lasx-inl.h
+++ b/hwy/ops/loongarch_lasx-inl.h
@@ -27,7 +27,9 @@
 // loongarch_lsx-inl.h is used (instead of moving lasxintrin.h after
 // HWY_BEFORE_NAMESPACE).
 HWY_PUSH_ATTRIBUTES("lsx,lasx")
+#ifndef __loongarch_asx
 #define __loongarch_asx
+#endif
 #include <lasxintrin.h>
 #undef __loongarch_asx
 // Prevent "unused push_attribute" warning from Clang.

--- a/hwy/ops/loongarch_lsx-inl.h
+++ b/hwy/ops/loongarch_lsx-inl.h
@@ -27,7 +27,9 @@
 // we'll get an "always_inline function requires lasx but would be inlined
 // into a function that is compiled without suport for lasx" error.
 HWY_PUSH_ATTRIBUTES("lsx")
+#ifndef __loongarch_sx
 #define __loongarch_sx
+#endif
 #include <lsxintrin.h>
 #undef __loongarch_sx
 // Prevent "unused push_attribute" warning from Clang.


### PR DESCRIPTION
Fix LASX NegMulAdd implementation:
    
    The tgamma implmentation (added in #3141) expects it to be fused
    (i.e. only the final result is rounded and the intermediate result
    from multiplication should be treated as infinite precesion), but
    the LoongArch implementation was unfused.
    
    Use the LASX instruction with fused semantics instead, similar to
    the LSX implementation added in #3141.


Dispatch LSX/LASX at runtime with GCC >= 15.3:
    
    Commit 10d7ab41fda3 ("Dispatch LSX/LASX at runtime") implemented the
    dispatch of LSX/LASX optimized routines with Clang.  Unfortunately GCC
    had a bug so the dispatch was not implemented for GCC at the time.
    Now the bug is fixed with GCC 15.3 and newer, so enable the runtime
    dispatch with GCC >= 15.3 too.
    
    As the GCC target pragma automatically updates the status of
    __loongarch_sx and __loongarch_asx, guard the definition of them to
    prevent a macro redefinition warning.
