### PR TITLE
Add IndexOfMin and IndexOfMax to hwy/contrib/algo

### DIFF
--- a/hwy/contrib/algo/minmax-inl.h
+++ b/hwy/contrib/algo/minmax-inl.h
@@ -94,6 +94,126 @@ T MaxValue(D d, const T* HWY_RESTRICT in, size_t count) {
   return ReduceMax(d, acc0);
 }
 
+// Returns the index of the first occurrence of the minimum value in
+// `in[0, count)`, or `count` if `count == 0`. Ties resolve to the lowest index,
+// matching `std::min_element`.
+template <class D, typename T = TFromD<D>>
+size_t IndexOfMin(D d, const T* HWY_RESTRICT in, size_t count) {
+  if (HWY_UNLIKELY(count == 0)) return count;
+
+  const RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  const size_t N = Lanes(d);
+
+  // Lanes record which block held their best value, so a segment can span at
+  // most this many blocks before that counter would wrap. Capped so neither the
+  // count nor the multiply below can overflow; for 32-bit and wider lanes this
+  // is a single segment in practice.
+  const uint64_t block_limit = static_cast<uint64_t>(LimitsMax<TU>());
+  const size_t max_blocks = static_cast<size_t>(
+      block_limit < (uint64_t{1} << 20) ? block_limit : (uint64_t{1} << 20));
+
+  const T identity = hwy::PositiveInfOrHighestValue<T>();
+  const Vec<D> identity_vec = Set(d, identity);
+
+  T best = identity;
+  size_t best_idx = 0;
+
+  for (size_t seg = 0; seg < count; seg += max_blocks * N) {
+    const size_t seg_len = HWY_MIN(count - seg, max_blocks * N);
+
+    Vec<D> acc = identity_vec;
+    VFromD<decltype(du)> blocks = Zero(du);
+
+    TU block = 0;
+    for (size_t i = 0; i < seg_len; i += N, ++block) {
+      const size_t n = HWY_MIN(seg_len - i, N);
+      const Vec<D> v = LoadNOr(identity_vec, d, in + seg + i, n);
+      // Strictly less, so an equal value later never displaces an earlier one.
+      const Mask<D> lt = Lt(v, acc);
+      acc = IfThenElse(lt, v, acc);
+      blocks = IfThenElse(RebindMask(du, lt), Set(du, block), blocks);
+    }
+
+    // Resolve lanes: smallest value, then earliest block, then lowest lane.
+    const T seg_min = ReduceMin(d, acc);
+    const Mask<D> is_min = Eq(acc, Set(d, seg_min));
+    const VFromD<decltype(du)> cand =
+        IfThenElse(RebindMask(du, is_min), blocks, Set(du, LimitsMax<TU>()));
+    const TU min_block = ReduceMin(du, cand);
+    const Mask<D> winners =
+        And(is_min, RebindMask(d, Eq(blocks, Set(du, min_block))));
+    const size_t idx =
+        seg + static_cast<size_t>(min_block) * N + FindKnownFirstTrue(d, winners);
+
+    if (seg_min < best) {
+      best = seg_min;
+      best_idx = idx;
+    }
+  }
+
+  return best_idx;
+}
+
+// Returns the index of the first occurrence of the maximum value in
+// `in[0, count)`, or `count` if `count == 0`. Ties resolve to the lowest index,
+// matching `std::max_element`.
+template <class D, typename T = TFromD<D>>
+size_t IndexOfMax(D d, const T* HWY_RESTRICT in, size_t count) {
+  if (HWY_UNLIKELY(count == 0)) return count;
+
+  const RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  const size_t N = Lanes(d);
+
+  // Lanes record which block held their best value, so a segment can span at
+  // most this many blocks before that counter would wrap. Capped so neither the
+  // count nor the multiply below can overflow; for 32-bit and wider lanes this
+  // is a single segment in practice.
+  const uint64_t block_limit = static_cast<uint64_t>(LimitsMax<TU>());
+  const size_t max_blocks = static_cast<size_t>(
+      block_limit < (uint64_t{1} << 20) ? block_limit : (uint64_t{1} << 20));
+
+  const T identity = hwy::NegativeInfOrLowestValue<T>();
+  const Vec<D> identity_vec = Set(d, identity);
+
+  T best = identity;
+  size_t best_idx = 0;
+
+  for (size_t seg = 0; seg < count; seg += max_blocks * N) {
+    const size_t seg_len = HWY_MIN(count - seg, max_blocks * N);
+
+    Vec<D> acc = identity_vec;
+    VFromD<decltype(du)> blocks = Zero(du);
+
+    TU block = 0;
+    for (size_t i = 0; i < seg_len; i += N, ++block) {
+      const size_t n = HWY_MIN(seg_len - i, N);
+      const Vec<D> v = LoadNOr(identity_vec, d, in + seg + i, n);
+      const Mask<D> gt = Gt(v, acc);
+      acc = IfThenElse(gt, v, acc);
+      blocks = IfThenElse(RebindMask(du, gt), Set(du, block), blocks);
+    }
+
+    const T seg_max = ReduceMax(d, acc);
+    const Mask<D> is_max = Eq(acc, Set(d, seg_max));
+    const VFromD<decltype(du)> cand =
+        IfThenElse(RebindMask(du, is_max), blocks, Set(du, LimitsMax<TU>()));
+    const TU min_block = ReduceMin(du, cand);
+    const Mask<D> winners =
+        And(is_max, RebindMask(d, Eq(blocks, Set(du, min_block))));
+    const size_t idx =
+        seg + static_cast<size_t>(min_block) * N + FindKnownFirstTrue(d, winners);
+
+    if (seg_max > best) {
+      best = seg_max;
+      best_idx = idx;
+    }
+  }
+
+  return best_idx;
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy

--- a/hwy/contrib/algo/minmax_value_test.cc
+++ b/hwy/contrib/algo/minmax_value_test.cc
@@ -66,6 +66,26 @@ T ScalarMax(const T* in, size_t count) {
   return result;
 }
 
+template <typename T>
+size_t ScalarIndexOfMin(const T* in, size_t count) {
+  if (count == 0) return count;
+  size_t best = 0;
+  for (size_t i = 1; i < count; ++i) {
+    if (in[i] < in[best]) best = i;
+  }
+  return best;
+}
+
+template <typename T>
+size_t ScalarIndexOfMax(const T* in, size_t count) {
+  if (count == 0) return count;
+  size_t best = 0;
+  for (size_t i = 1; i < count; ++i) {
+    if (in[i] > in[best]) best = i;
+  }
+  return best;
+}
+
 template <class Test>
 struct ForeachCountAndMisalign {
   template <typename T, class D>
@@ -138,6 +158,106 @@ struct TestMaxValue {
   }
 };
 
+struct TestIndexOfMin {
+  template <class D>
+  void operator()(D d, size_t count, size_t misalign, RandomState& rng) {
+    using T = TFromD<D>;
+    AlignedFreeUniquePtr<T[]> storage =
+        AllocateAligned<T>(HWY_MAX(1, misalign + count));
+    HWY_ASSERT(storage);
+    T* in = storage.get() + misalign;
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = Random<T>(rng);
+    }
+
+    const size_t expected = ScalarIndexOfMin(in, count);
+    const size_t actual = IndexOfMin(d, in, count);
+
+    if (expected != actual) {
+      fprintf(stderr,
+              "%s count %d misalign %d: IndexOfMin expected %d got %d\n",
+              hwy::TypeName(T(), Lanes(d)).c_str(), static_cast<int>(count),
+              static_cast<int>(misalign), static_cast<int>(expected),
+              static_cast<int>(actual));
+      HWY_ASSERT(false);
+    }
+  }
+};
+
+struct TestIndexOfMax {
+  template <class D>
+  void operator()(D d, size_t count, size_t misalign, RandomState& rng) {
+    using T = TFromD<D>;
+    AlignedFreeUniquePtr<T[]> storage =
+        AllocateAligned<T>(HWY_MAX(1, misalign + count));
+    HWY_ASSERT(storage);
+    T* in = storage.get() + misalign;
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = Random<T>(rng);
+    }
+
+    const size_t expected = ScalarIndexOfMax(in, count);
+    const size_t actual = IndexOfMax(d, in, count);
+
+    if (expected != actual) {
+      fprintf(stderr,
+              "%s count %d misalign %d: IndexOfMax expected %d got %d\n",
+              hwy::TypeName(T(), Lanes(d)).c_str(), static_cast<int>(count),
+              static_cast<int>(misalign), static_cast<int>(expected),
+              static_cast<int>(actual));
+      HWY_ASSERT(false);
+    }
+  }
+};
+
+// The random test above never reaches the block counter's limit, so this walks
+// a single extreme value through a span long enough to need several segments.
+struct TestIndexOfExtremeInLongSpan {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) const {
+    const size_t N = Lanes(d);
+    // 8-bit lanes can only count 255 blocks, so this spans more than one
+    // segment for them. Wider lanes run it as a single segment.
+    const size_t count = 300 * N;
+    AlignedFreeUniquePtr<T[]> storage = AllocateAligned<T>(count);
+    HWY_ASSERT(storage);
+    T* in = storage.get();
+
+    // A flat span means every position ties; the lowest index must win.
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = ConvertScalarTo<T>(1);
+    }
+    HWY_ASSERT_EQ(size_t{0}, IndexOfMin(d, in, count));
+    HWY_ASSERT_EQ(size_t{0}, IndexOfMax(d, in, count));
+
+    // A unique extreme either side of the 8-bit segment boundary, and at both
+    // ends, so a mishandled segment base shows up as a wrong index.
+    const size_t positions[] = {N - 1, 254 * N, 255 * N, 256 * N, count - 1};
+    for (size_t pos : positions) {
+      if (pos >= count) continue;
+      in[pos] = ConvertScalarTo<T>(0);
+      HWY_ASSERT_EQ(pos, IndexOfMin(d, in, count));
+      in[pos] = ConvertScalarTo<T>(1);
+
+      in[pos] = ConvertScalarTo<T>(2);
+      HWY_ASSERT_EQ(pos, IndexOfMax(d, in, count));
+      in[pos] = ConvertScalarTo<T>(1);
+    }
+  }
+};
+
+void TestAllIndexOfMin() {
+  ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestIndexOfMin>>());
+}
+
+void TestAllIndexOfMax() {
+  ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestIndexOfMax>>());
+}
+
+void TestAllIndexOfExtremeInLongSpan() {
+  ForAllTypes(ForPartialVectors<TestIndexOfExtremeInLongSpan>());
+}
+
 void TestAllMinValue() {
   ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestMinValue>>());
 }
@@ -158,6 +278,9 @@ namespace {
 HWY_BEFORE_TEST(MinMaxTest);
 HWY_EXPORT_AND_TEST_P(MinMaxTest, TestAllMinValue);
 HWY_EXPORT_AND_TEST_P(MinMaxTest, TestAllMaxValue);
+HWY_EXPORT_AND_TEST_P(MinMaxTest, TestAllIndexOfMin);
+HWY_EXPORT_AND_TEST_P(MinMaxTest, TestAllIndexOfMax);
+HWY_EXPORT_AND_TEST_P(MinMaxTest, TestAllIndexOfExtremeInLongSpan);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
From the op wishlist. minmax-inl.h already has MinValue/MaxValue which return the value, so these return where it is. Ties go to the lowest index, matching std::min_element.

Each lane keeps its best value plus the block it came from, then a final pass picks the smallest value, earliest block, lowest lane. Lanes hold the block number rather than the element index so it fits in the lane type — for 8-bit lanes that only reaches 255 blocks, so the loop works in segments and carries the base across. Wider lanes run as a single segment.

Roughly 10x std::min_element on 4M floats (1.46 ms vs 14.31 ms), and about 2x the cost of MinValue — the extra compare and two selects per vector, plus this isn't unrolled the way MinValue is. Happy to add the 4x unroll if you'd like it in the same PR.

Tests follow the existing minmax_value_test.cc pattern against a scalar reference, plus one that walks a single extreme across a span long enough to cross a segment boundary on 8-bit lanes.