### PR TITLE
contrib/math: correct Atan2/FastAtan2 for negative-zero x

### DIFF
--- a/hwy/contrib/math/fast_math-inl.h
+++ b/hwy/contrib/math/fast_math-inl.h
@@ -625,7 +625,9 @@ HWY_INLINE V FastAtan2(const D d, V y, V x) {
   const M ay_gt_ax = Gt(ay, ax);
   V angle = MaskedSubOr(poly, ay_gt_ax, kPiOverTwo, poly);
 
-  const M x_neg = Lt(x, k0);
+  // Test the sign bit (not Lt) so a negative-zero x reflects into the
+  // negative-x half-plane, giving atan2(+/-0, -0) = +/-pi.
+  const M x_neg = IsNegative(x);
   angle = MaskedSubOr(angle, x_neg, kPi, angle);
 
   const M is_nan = IsEitherNaN(y, x);

--- a/hwy/contrib/math/math-inl.h
+++ b/hwy/contrib/math/math-inl.h
@@ -2382,7 +2382,9 @@ HWY_INLINE V Atan2(const D d, V y, V x) {
   const M ay_gt_ax = Gt(ay, ax);
   V angle = MaskedSubOr(poly, ay_gt_ax, kPiOverTwo, poly);
 
-  const M x_neg = Lt(x, k0);
+  // Test the sign bit (not Lt) so a negative-zero x reflects into the
+  // negative-x half-plane, giving atan2(+/-0, -0) = +/-pi.
+  const M x_neg = IsNegative(x);
   angle = MaskedSubOr(angle, x_neg, kPi, angle);
 
   const M is_nan = IsEitherNaN(y, x);

--- a/hwy/contrib/math/math_tan_test.cc
+++ b/hwy/contrib/math/math_tan_test.cc
@@ -89,6 +89,8 @@ void Atan2TestCases(T /*unused*/, D d, size_t& padded,
                            // y = ±0, x < 0 or -0
                            {p0, n1, pi},
                            {n0, n2, -pi},
+                           {p0, n0, pi},
+                           {n0, n0, -pi},
                            // y = ±0, x > 0 or +0
                            {p0, p2, p0},
                            {n0, p2, n0},


### PR DESCRIPTION
### Summary

`Atan2` (and `FastAtan2`) return the wrong value when `x` is negative zero: `atan2(±0, −0)` gives `±0` instead of the IEEE-754 / C result `±π`. The function's own doc comment states it "correctly handles negative zero", so this is a documented-supported input.

### Cause

The reflection into the negative-x half-plane is gated by `Lt(x, 0)`:

```cpp
const M x_neg = Lt(x, k0);
angle = MaskedSubOr(angle, x_neg, kPi, angle);
```

For `x == -0.0`, `Lt(-0.0, 0.0)` is `false` because `-0.0 == +0.0` in IEEE comparison, so the `π − angle` correction is skipped. For `y = ±0` the result is then `CopySign(0, y)` = `±0` rather than `±π`. (For `x = -0` with non-zero `y` the reflection is a symmetric no-op, so only `y = ±0, x = -0` is observably wrong.)

### Fix

Gate the reflection on the sign bit with `IsNegative(x)` instead of `Lt`:

```cpp
const M x_neg = IsNegative(x);
```

`IsNegative` classifies `-0.0` as negative (it tests the sign bit), so the reflection now fires and `atan2(±0, −0)` yields `±π`. Only `x == -0.0` changes behavior — `+0.0`, normal negative `x`, and `−∞` keep the sign-bit classification `Lt` already gave them, and `NaN` is still overridden by the `is_nan` mask — so no other input changes on any target.

### Testing

- Added `atan2(±0, −0) = ±π` to `Atan2TestCases`, which exercises both `Atan2` and `FastAtan2`. Before the fix the new cases fail (`expected 3.14159, actual 0`); after, they pass.
- `math_tan_test`, `math_test`, `math_trig_test`, and `fast_math_test` all pass across every enabled SIMD target.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.