### PR TITLE
2x unroll IndexOfMin/IndexOfMax, plus MaskedEq and ReduceMax suggestions

### DIFF
--- a/hwy/contrib/algo/minmax-inl.h
+++ b/hwy/contrib/algo/minmax-inl.h
@@ -113,6 +113,13 @@ size_t IndexOfMin(D d, const T* HWY_RESTRICT in, size_t count) {
   const size_t max_blocks = static_cast<size_t>(
       block_limit < (uint64_t{1} << 20) ? block_limit : (uint64_t{1} << 20));
 
+  // Blocks are counted down rather than up, so the earliest block is the
+  // largest counter. That lets the resolution below zero out non-candidate
+  // lanes, because zero is the identity for ReduceMax and is never a valid
+  // counter: block b in [0, max_blocks) is stored as max_blocks - b, which is
+  // at least 1. A lane the loop never touched keeps max_blocks, i.e. block 0.
+  const TU inv_base = static_cast<TU>(max_blocks);
+
   const T identity = hwy::PositiveInfOrHighestValue<T>();
   const Vec<D> identity_vec = Set(d, identity);
 
@@ -122,29 +129,60 @@ size_t IndexOfMin(D d, const T* HWY_RESTRICT in, size_t count) {
   for (size_t seg = 0; seg < count; seg += max_blocks * N) {
     const size_t seg_len = HWY_MIN(count - seg, max_blocks * N);
 
-    Vec<D> acc = identity_vec;
-    VFromD<decltype(du)> blocks = Zero(du);
+    Vec<D> acc0 = identity_vec;
+    Vec<D> acc1 = identity_vec;
+    VFromD<decltype(du)> blocks0 = Set(du, inv_base);
+    VFromD<decltype(du)> blocks1 = Set(du, inv_base);
 
-    TU block = 0;
-    for (size_t i = 0; i < seg_len; i += N, ++block) {
+    size_t i = 0;
+    TU inv_block = inv_base;
+
+    // Two accumulators, because each select otherwise waits on the previous
+    // iteration's acc and the loop becomes a latency chain.
+    if (seg_len >= 2 * N) {
+      for (; i + 2 * N <= seg_len;
+           i += 2 * N, inv_block = static_cast<TU>(inv_block - 2)) {
+        const Vec<D> v0 = LoadU(d, in + seg + i);
+        const Vec<D> v1 = LoadU(d, in + seg + i + N);
+        // Strictly less, so an equal value later never displaces an earlier
+        // one.
+        const Mask<D> lt0 = Lt(v0, acc0);
+        const Mask<D> lt1 = Lt(v1, acc1);
+        acc0 = IfThenElse(lt0, v0, acc0);
+        acc1 = IfThenElse(lt1, v1, acc1);
+        blocks0 = IfThenElse(RebindMask(du, lt0), Set(du, inv_block), blocks0);
+        blocks1 = IfThenElse(RebindMask(du, lt1),
+                             Set(du, static_cast<TU>(inv_block - 1)), blocks1);
+      }
+
+      // Fold the odd blocks into the even ones: the smaller value wins, and on
+      // a tie the earlier block does, which is the larger counter. Merging
+      // before the tail is what keeps the tail's blocks correctly later.
+      const Mask<D> take1 =
+          Or(Lt(acc1, acc0),
+             And(Eq(acc0, acc1), RebindMask(d, Gt(blocks1, blocks0))));
+      acc0 = IfThenElse(take1, acc1, acc0);
+      blocks0 = IfThenElse(RebindMask(du, take1), blocks1, blocks0);
+    }
+
+    for (; i < seg_len; i += N, --inv_block) {
       const size_t n = HWY_MIN(seg_len - i, N);
       const Vec<D> v = LoadNOr(identity_vec, d, in + seg + i, n);
-      // Strictly less, so an equal value later never displaces an earlier one.
-      const Mask<D> lt = Lt(v, acc);
-      acc = IfThenElse(lt, v, acc);
-      blocks = IfThenElse(RebindMask(du, lt), Set(du, block), blocks);
+      const Mask<D> lt = Lt(v, acc0);
+      acc0 = IfThenElse(lt, v, acc0);
+      blocks0 = IfThenElse(RebindMask(du, lt), Set(du, inv_block), blocks0);
     }
 
     // Resolve lanes: smallest value, then earliest block, then lowest lane.
-    const T seg_min = ReduceMin(d, acc);
-    const Mask<D> is_min = Eq(acc, Set(d, seg_min));
-    const VFromD<decltype(du)> cand =
-        IfThenElse(RebindMask(du, is_min), blocks, Set(du, LimitsMax<TU>()));
-    const TU min_block = ReduceMin(du, cand);
-    const Mask<D> winners =
-        And(is_min, RebindMask(d, Eq(blocks, Set(du, min_block))));
-    const size_t idx =
-        seg + static_cast<size_t>(min_block) * N + FindKnownFirstTrue(d, winners);
+    const T seg_min = ReduceMin(d, acc0);
+    const Mask<D> is_min = Eq(acc0, Set(d, seg_min));
+    const TU best_inv =
+        ReduceMax(du, IfThenElseZero(RebindMask(du, is_min), blocks0));
+    const Mask<D> winners = RebindMask(
+        d, MaskedEq(RebindMask(du, is_min), blocks0, Set(du, best_inv)));
+    const size_t min_block =
+        static_cast<size_t>(max_blocks) - static_cast<size_t>(best_inv);
+    const size_t idx = seg + min_block * N + FindKnownFirstTrue(d, winners);
 
     if (seg_min < best) {
       best = seg_min;
@@ -174,6 +212,9 @@ size_t IndexOfMax(D d, const T* HWY_RESTRICT in, size_t count) {
   const size_t max_blocks = static_cast<size_t>(
       block_limit < (uint64_t{1} << 20) ? block_limit : (uint64_t{1} << 20));
 
+  // Counted down so the earliest block is the largest counter; see IndexOfMin.
+  const TU inv_base = static_cast<TU>(max_blocks);
+
   const T identity = hwy::NegativeInfOrLowestValue<T>();
   const Vec<D> identity_vec = Set(d, identity);
 
@@ -183,27 +224,52 @@ size_t IndexOfMax(D d, const T* HWY_RESTRICT in, size_t count) {
   for (size_t seg = 0; seg < count; seg += max_blocks * N) {
     const size_t seg_len = HWY_MIN(count - seg, max_blocks * N);
 
-    Vec<D> acc = identity_vec;
-    VFromD<decltype(du)> blocks = Zero(du);
+    Vec<D> acc0 = identity_vec;
+    Vec<D> acc1 = identity_vec;
+    VFromD<decltype(du)> blocks0 = Set(du, inv_base);
+    VFromD<decltype(du)> blocks1 = Set(du, inv_base);
 
-    TU block = 0;
-    for (size_t i = 0; i < seg_len; i += N, ++block) {
-      const size_t n = HWY_MIN(seg_len - i, N);
-      const Vec<D> v = LoadNOr(identity_vec, d, in + seg + i, n);
-      const Mask<D> gt = Gt(v, acc);
-      acc = IfThenElse(gt, v, acc);
-      blocks = IfThenElse(RebindMask(du, gt), Set(du, block), blocks);
+    size_t i = 0;
+    TU inv_block = inv_base;
+
+    if (seg_len >= 2 * N) {
+      for (; i + 2 * N <= seg_len;
+           i += 2 * N, inv_block = static_cast<TU>(inv_block - 2)) {
+        const Vec<D> v0 = LoadU(d, in + seg + i);
+        const Vec<D> v1 = LoadU(d, in + seg + i + N);
+        const Mask<D> gt0 = Gt(v0, acc0);
+        const Mask<D> gt1 = Gt(v1, acc1);
+        acc0 = IfThenElse(gt0, v0, acc0);
+        acc1 = IfThenElse(gt1, v1, acc1);
+        blocks0 = IfThenElse(RebindMask(du, gt0), Set(du, inv_block), blocks0);
+        blocks1 = IfThenElse(RebindMask(du, gt1),
+                             Set(du, static_cast<TU>(inv_block - 1)), blocks1);
+      }
+
+      const Mask<D> take1 =
+          Or(Gt(acc1, acc0),
+             And(Eq(acc0, acc1), RebindMask(d, Gt(blocks1, blocks0))));
+      acc0 = IfThenElse(take1, acc1, acc0);
+      blocks0 = IfThenElse(RebindMask(du, take1), blocks1, blocks0);
     }
 
-    const T seg_max = ReduceMax(d, acc);
-    const Mask<D> is_max = Eq(acc, Set(d, seg_max));
-    const VFromD<decltype(du)> cand =
-        IfThenElse(RebindMask(du, is_max), blocks, Set(du, LimitsMax<TU>()));
-    const TU min_block = ReduceMin(du, cand);
-    const Mask<D> winners =
-        And(is_max, RebindMask(d, Eq(blocks, Set(du, min_block))));
-    const size_t idx =
-        seg + static_cast<size_t>(min_block) * N + FindKnownFirstTrue(d, winners);
+    for (; i < seg_len; i += N, --inv_block) {
+      const size_t n = HWY_MIN(seg_len - i, N);
+      const Vec<D> v = LoadNOr(identity_vec, d, in + seg + i, n);
+      const Mask<D> gt = Gt(v, acc0);
+      acc0 = IfThenElse(gt, v, acc0);
+      blocks0 = IfThenElse(RebindMask(du, gt), Set(du, inv_block), blocks0);
+    }
+
+    const T seg_max = ReduceMax(d, acc0);
+    const Mask<D> is_max = Eq(acc0, Set(d, seg_max));
+    const TU best_inv =
+        ReduceMax(du, IfThenElseZero(RebindMask(du, is_max), blocks0));
+    const Mask<D> winners = RebindMask(
+        d, MaskedEq(RebindMask(du, is_max), blocks0, Set(du, best_inv)));
+    const size_t min_block =
+        static_cast<size_t>(max_blocks) - static_cast<size_t>(best_inv);
+    const size_t idx = seg + min_block * N + FindKnownFirstTrue(d, winners);
 
     if (seg_max > best) {
       best = seg_max;

--- a/hwy/contrib/algo/minmax_value_test.cc
+++ b/hwy/contrib/algo/minmax_value_test.cc
@@ -243,6 +243,20 @@ struct TestIndexOfExtremeInLongSpan {
       HWY_ASSERT_EQ(pos, IndexOfMax(d, in, count));
       in[pos] = ConvertScalarTo<T>(1);
     }
+
+    // A span made entirely of the identity value never compares strictly
+    // better than the accumulator, so no lane's block counter is ever written
+    // and no segment ever beats the running best. Index 0 is the only correct
+    // answer, since every position ties.
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = hwy::PositiveInfOrHighestValue<T>();
+    }
+    HWY_ASSERT_EQ(size_t{0}, IndexOfMin(d, in, count));
+
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = hwy::NegativeInfOrLowestValue<T>();
+    }
+    HWY_ASSERT_EQ(size_t{0}, IndexOfMax(d, in, count));
   }
 };
 


### PR DESCRIPTION
Follow-up to #3253, covering all three review comments.

**`MaskedEq`** replaces `And(is_min, Eq(...))` in the winner resolution.

**`IfThenElseZero` + `ReduceMax`** replaces `IfThenElse(..., Set(du, LimitsMax<TU>()))` + `ReduceMin`. As you noted, this needs the block counter stored inverted: block `b` is now held as `max_blocks - b`, so real counters occupy `[1, max_blocks]`, `0` is free to mean "not a candidate", and "earliest block" becomes "largest counter", which is what `ReduceMax` gives. A lane that never improved keeps `max_blocks`, i.e. block 0, correct for an all-ties span. There was no test for that case, so I added one.

**2x unroll.** Two accumulators, even blocks in one and odd in the other. The merge has to carry the block along with the value and keep resolving ties to the earlier block, so it is `Lt(acc1, acc0) || (Eq(acc0, acc1) && Gt(blocks1, blocks0))` rather than a plain `Min`. The bulk loop also stops calling `LoadNOr', it has a full-vector fast path, but the length computation and its branch still run every iteration; only the tail needs it now.

Benchmarks, AVX2 on a Zen 3 (Ryzen 5 5600H), both implementations in one binary alternating order, best of 9, everything at `-O3`. The middle column is the load change alone with a single accumulator, to separate it from the unroll:

| | merged | 1 acc, unmasked bulk | 2 acc, unmasked bulk |
| --- | --- | --- | --- |
| f32, 64 MB | 2.679 ms | 2.651 ms (1.01x) | 2.621 ms (1.02x) |
| f32, 16 MB | 0.591 ms | 0.537 ms (1.10x) | 0.539 ms (1.10x) |
| f32, 4 MB | 0.078 ms | 0.088 ms (0.89x) | 0.075 ms (1.04x) |
| f32, 256 KB | 0.005 ms | 0.006 ms (0.86x) | 0.004 ms (1.10x) |
| i8, 16 MB | 0.618 ms | 0.514 ms (1.20x) | 0.494 ms (1.25x) |
| i8, 1 MB | 0.030 ms | 0.020 ms (1.46x) | 0.018 ms (1.63x) |
| i32, 16 MB | 0.692 ms | 0.626 ms (1.10x) | 0.601 ms (1.15x) |

Most of the gain is the load change; the second accumulator adds 1.02–1.12x on top. It earns its place mainly at the small sizes, where the load split alone regresses (0.86x at 256 KB) because the extra loop isn't amortised. At genuinely DRAM-bound sizes none of it moves (1.02x at 64 MB). Happy to take this to 4x like `MinValue` if you want it, though each accumulator costs another two-level tie-break merge rather than a free `Min`, so I'd expect it to flatten out.

One correction to #3253 while I'm here: the "roughly 10x std::min_element" in that PR body was measuring the compiler, not the kernel. The scalar baseline was built at a lower optimisation level — at `-O2` gcc keeps the running minimum in memory and reloads it through the result pointer each iteration, so it pays load-use latency (13.5 ms), while at `-O3` it keeps the value in a register via `minss` (1.9 ms). Neither is vectorised. With both sides at `-O3` the real figure is ~3x for `f32` and ~16x for `i8`. Same paragraph also called 16 MB "past L3" on a machine whose L3 is exactly 16 MiB. Apologies for the noise in the record.

Tests: existing `minmax_value_test.cc` passes 25/25 on AVX2, SSE4, SSSE3, SSE2 and EMU128, plus the new all-identity case. I also injected three deliberate bugs into the new merge, dropping the tie-break clause, inverting it, and storing the wrong block number in the odd stream, and confirmed each is caught (all three surface on `i8`, which has the most ties per vector).
