### PR TITLE
Use native LSX instructions

### DIFF
--- a/hwy/ops/loongarch_lsx-inl.h
+++ b/hwy/ops/loongarch_lsx-inl.h
@@ -2466,10 +2466,28 @@ HWY_API Vec128<double, N> MulAdd(Vec128<double, N> mul, Vec128<double, N> x,
 }
 
 // Unsigned
-template <typename T, size_t N, HWY_IF_UNSIGNED(T)>
-HWY_API Vec128<T, N> MulAdd(Vec128<T, N> mul, Vec128<T, N> x,
-                            Vec128<T, N> add) {
-  return mul * x + add;
+template <size_t N>
+HWY_API Vec128<uint8_t, N> MulAdd(Vec128<uint8_t, N> mul, Vec128<uint8_t, N> x,
+                                  Vec128<uint8_t, N> add) {
+  return Vec128<uint8_t, N>{__lsx_vmadd_b(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint16_t, N> MulAdd(Vec128<uint16_t, N> mul,
+                                   Vec128<uint16_t, N> x,
+                                   Vec128<uint16_t, N> add) {
+  return Vec128<uint16_t, N>{__lsx_vmadd_h(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint32_t, N> MulAdd(Vec128<uint32_t, N> mul,
+                                   Vec128<uint32_t, N> x,
+                                   Vec128<uint32_t, N> add) {
+  return Vec128<uint32_t, N>{__lsx_vmadd_w(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint64_t, N> MulAdd(Vec128<uint64_t, N> mul,
+                                   Vec128<uint64_t, N> x,
+                                   Vec128<uint64_t, N> add) {
+  return Vec128<uint64_t, N>{__lsx_vmadd_d(add.raw, mul.raw, x.raw)};
 }
 
 template <size_t N>
@@ -2509,10 +2527,29 @@ HWY_API Vec128<double, N> NegMulAdd(Vec128<double, N> mul, Vec128<double, N> x,
 }
 
 // unsigned
-template <typename T, size_t N, HWY_IF_NOT_SPECIAL_FLOAT(T)>
-HWY_API Vec128<T, N> NegMulAdd(Vec128<T, N> mul, Vec128<T, N> x,
-                               Vec128<T, N> add) {
-  return add - mul * x;
+template <size_t N>
+HWY_API Vec128<uint8_t, N> NegMulAdd(Vec128<uint8_t, N> mul,
+                                     Vec128<uint8_t, N> x,
+                                     Vec128<uint8_t, N> add) {
+  return Vec128<uint8_t, N>{__lsx_vmsub_b(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint16_t, N> NegMulAdd(Vec128<uint16_t, N> mul,
+                                      Vec128<uint16_t, N> x,
+                                      Vec128<uint16_t, N> add) {
+  return Vec128<uint16_t, N>{__lsx_vmsub_h(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint32_t, N> NegMulAdd(Vec128<uint32_t, N> mul,
+                                      Vec128<uint32_t, N> x,
+                                      Vec128<uint32_t, N> add) {
+  return Vec128<uint32_t, N>{__lsx_vmsub_w(add.raw, mul.raw, x.raw)};
+}
+template <size_t N>
+HWY_API Vec128<uint64_t, N> NegMulAdd(Vec128<uint64_t, N> mul,
+                                      Vec128<uint64_t, N> x,
+                                      Vec128<uint64_t, N> add) {
+  return Vec128<uint64_t, N>{__lsx_vmsub_d(add.raw, mul.raw, x.raw)};
 }
 
 // ------------------------------ Float MulSub
@@ -2538,7 +2575,19 @@ HWY_API Vec128<T, N> MulSub(Vec128<T, N> mul, Vec128<T, N> x,
 
 // ------------------------------ Float NegMulSub
 
-// float/unsigned
+// float
+template <size_t N>
+HWY_API Vec128<float, N> NegMulSub(Vec128<float, N> mul, Vec128<float, N> x,
+                                   Vec128<float, N> sub) {
+  return Vec128<float, N>{__lsx_vfnmadd_s(mul.raw, x.raw, sub.raw)};
+}
+template <size_t N>
+HWY_API Vec128<double, N> NegMulSub(Vec128<double, N> mul, Vec128<double, N> x,
+                                    Vec128<double, N> sub) {
+  return Vec128<double, N>{__lsx_vfnmadd_d(mul.raw, x.raw, sub.raw)};
+}
+
+// unsigned
 template <typename T, size_t N, HWY_IF_NOT_SPECIAL_FLOAT(T)>
 HWY_API Vec128<T, N> NegMulSub(Vec128<T, N> mul, Vec128<T, N> x,
                                Vec128<T, N> sub) {


### PR DESCRIPTION
Updating LSX to use native instructions instead of generic fallbacks, matching LASX.