### PR TITLE
Faster NEON CompressStore: use fused BitsFromMask and PopCount

### DIFF
--- a/hwy/ops/arm_neon-inl.h
+++ b/hwy/ops/arm_neon-inl.h
@@ -10260,13 +10260,52 @@ HWY_INLINE Vec128<T, N> CompressBits(Vec128<T, N> v,
   return detail::Compress(v, mask_bits);
 }
 
+namespace detail {
+struct BitsAndCount {
+  uint64_t bits;
+  size_t count;
+};
+template <typename D, HWY_IF_LANES_D(D, 1)>
+HWY_INLINE auto BitsAndCountFromMask(D, MFromD<D> m) {
+  RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  alignas(16) static constexpr TU weights[1] = {1 + 2};
+  const TU s = ReduceSum(du, And(VecFromMask(du, RebindMask(du, m)), Load(du, weights)));
+  return BitsAndCount{static_cast<uint64_t>(s & 1), static_cast<size_t>(s >> 1)};
+}
+template <typename D, HWY_IF_LANES_D(D, 2)>
+HWY_INLINE auto BitsAndCountFromMask(D, MFromD<D> m) {
+  RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  alignas(16) static constexpr TU weights[2] = {1 + 4, 2 + 4};
+  const TU s = ReduceSum(du, And(VecFromMask(du, RebindMask(du, m)), Load(du, weights)));
+  return BitsAndCount{static_cast<uint64_t>(s & 3), static_cast<size_t>(s >> 2)};
+}
+template <typename D, HWY_IF_LANES_D(D, 4)>
+HWY_INLINE auto BitsAndCountFromMask(D, MFromD<D> m) {
+  RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  alignas(16) static constexpr TU weights[4] = {1 + 16, 2 + 16, 4 + 16, 8 + 16};
+  const TU s = ReduceSum(du, And(VecFromMask(du, RebindMask(du, m)), Load(du, weights)));
+  return BitsAndCount{static_cast<uint64_t>(s & 15), static_cast<size_t>(s >> 4)};
+}
+template <typename D, HWY_IF_NOT_T_SIZE_D(D, 1) /* because 256 > max value in u8 */, HWY_IF_LANES_D(D, 8)>
+HWY_INLINE auto BitsAndCountFromMask(D, MFromD<D> m) {
+  RebindToUnsigned<D> du;
+  using TU = TFromD<decltype(du)>;
+  alignas(16) static constexpr TU weights[8] = {1 + 256, 2 + 256, 4 + 256, 8 + 256, 16 + 256, 32 + 256, 64 + 256, 128 + 256};
+  const TU s = ReduceSum(du, And(VecFromMask(du, RebindMask(du, m)), Load(du, weights)));
+  return BitsAndCount{static_cast<uint64_t>(s & 255), static_cast<size_t>(s >> 8)};
+}
+}  // namespace detail
+
 // ------------------------------ CompressStore
 template <class D, HWY_IF_NOT_T_SIZE_D(D, 1)>
 HWY_API size_t CompressStore(VFromD<D> v, MFromD<D> mask, D d,
                              TFromD<D>* HWY_RESTRICT unaligned) {
-  const uint64_t mask_bits = BitsFromMask(d, mask);
-  StoreU(detail::Compress(v, mask_bits), d, unaligned);
-  return PopCount(mask_bits);
+  const detail::BitsAndCount bits_and_count = detail::BitsAndCountFromMask(d, mask);
+  StoreU(detail::Compress(v, bits_and_count.bits), d, unaligned);
+  return bits_and_count.count;
 }
 
 // ------------------------------ CompressBlendedStore
@@ -10274,8 +10313,9 @@ template <class D, HWY_IF_NOT_T_SIZE_D(D, 1)>
 HWY_API size_t CompressBlendedStore(VFromD<D> v, MFromD<D> m, D d,
                                     TFromD<D>* HWY_RESTRICT unaligned) {
   const RebindToUnsigned<decltype(d)> du;  // so we can support fp16/bf16
-  const uint64_t mask_bits = BitsFromMask(d, m);
-  const size_t count = PopCount(mask_bits);
+  const detail::BitsAndCount bits_and_count = detail::BitsAndCountFromMask(d, m);
+  const uint64_t mask_bits = bits_and_count.bits;
+  const size_t count = bits_and_count.count;
   const MFromD<D> store_mask = RebindMask(d, FirstN(du, count));
   const VFromD<decltype(du)> compressed =
       detail::Compress(BitCast(du, v), mask_bits);


### PR DESCRIPTION
I added `detail::BitsAndCountFromMask`. It returns bits = BitsFromMask and count of ones in the mask. This function calculates count inside the existing algorithm for bits, so it spends only one operation for count instead of a call to PopCount.

It gives a win of about 30% (apple m5) here:
```
size_t loop(const uint32_t* src, uint32_t* dst, const size_t n) {
  ScalableTag<uint32_t> d;
  const size_t W = Lanes(d);
  size_t j = 0;
  for (size_t i = 0; i + W <= n; i += W) {
    auto v = Load(d, src + i);
    auto m = Gt(v, Set(d, 0x80000000u));
    j += CompressStore(v, m, d, dst + j);
  }
  return j;
}
```
Density is 50%.