### PR TITLE
fix cache control dispatch on non-x86

### DIFF
--- a/hwy/cache_control.h
+++ b/hwy/cache_control.h
@@ -21,7 +21,10 @@
 
 // Requires SSE2; fails to compile on 32-bit Clang 7 (see
 // https://github.com/gperftools/gperftools/issues/946).
-#if !defined(__SSE2__) || (HWY_COMPILER_CLANG && HWY_ARCH_X86_32)
+#if HWY_ARCH_X86 &&                                                      \
+    (!(defined(__SSE2__) || HWY_ARCH_X86_64 ||                           \
+       (HWY_COMPILER_MSVC && defined(_M_IX86_FP) && _M_IX86_FP >= 2)) || \
+     (HWY_COMPILER_CLANG && HWY_ARCH_X86_32))
 #undef HWY_DISABLE_CACHE_CONTROL
 #define HWY_DISABLE_CACHE_CONTROL
 #endif
@@ -31,7 +34,7 @@
 #if HWY_ARCH_X86 && !HWY_COMPILER_MSVC
 #include <emmintrin.h>  // SSE2
 #include <xmmintrin.h>  // _mm_prefetch
-#elif HWY_ARCH_ARM_A64
+#elif HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG
 #include <arm_acle.h>
 #endif
 #endif  // HWY_DISABLE_CACHE_CONTROL


### PR DESCRIPTION
Before the gate on `defined(__SSE2__)` was on all arches and in MSVC, so prefetch and other functions compiled to no-ops.
I fix this so:

1) HWY_ARCH_X86 check added to this #if
2) MSVC doesnt have `__SSE2__`, so instead(for x86_32) I added this: `(HWY_COMPILER_MSVC && defined(_M_IX86_FP) && _M_IX86_FP >= 2))`
3) #include <arm_acle.h> is used only for __yield(); which is gated on `HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG`, so include now also gated on this.