### PR TITLE
faster vqsort when <4 keys per vector: add new Sort16Rows cases to BaseCase

### DIFF
--- a/hwy/contrib/sort/bench_sort.cc
+++ b/hwy/contrib/sort/bench_sort.cc
@@ -17,6 +17,7 @@
 #include <stdio.h>
 
 #include <vector>
+#include <array>
 
 // clang-format off
 #undef HWY_TARGET_INCLUDE
@@ -151,7 +152,7 @@ HWY_NOINLINE void BenchPartition() {
 
   constexpr size_t kLPK = st.LanesPerKey();
   HWY_ALIGN LaneType
-      buf[SortConstants::BufBytes<LaneType, kLPK>(HWY_MAX_BYTES) /
+      buf[SortConstants::BufBytes<LaneType>(HWY_MAX_BYTES) /
           sizeof(LaneType)];
   uint64_t* HWY_RESTRICT state = GetGeneratorState();
 
@@ -217,7 +218,7 @@ HWY_NOINLINE void BenchBase(std::vector<SortResult>& results) {
 
   const size_t N = Lanes(d);
   constexpr size_t kLPK = st.LanesPerKey();
-  const size_t num_lanes = SortConstants::BaseCaseNumLanes<kLPK>(N);
+  const size_t num_lanes = SortConstants::BaseCaseNumLanes(N);
   const size_t num_keys = num_lanes / kLPK;
   auto keys = hwy::AllocateAligned<LaneType>(num_lanes);
   auto buf = hwy::AllocateAligned<LaneType>(num_lanes + N);
@@ -314,9 +315,14 @@ HWY_NOINLINE void BenchSort(size_t num_keys) {
   using LaneType = typename Traits::LaneType;
   using KeyType = typename Traits::KeyType;
   const size_t num_lanes = num_keys * st.LanesPerKey();
-  auto aligned = hwy::AllocateAligned<LaneType>(num_lanes);
 
+  constexpr size_t inner_reps_max = 30;
   const size_t reps = num_keys > 1000 * 1000 ? 10 : 30;
+  const size_t inner_reps = num_keys <= 128 ? inner_reps_max : 1;
+
+  std::array<decltype(hwy::AllocateAligned<LaneType>(num_lanes)), inner_reps_max> aligned;
+  for (size_t i = 0; i < inner_reps; ++i) aligned[i] = hwy::AllocateAligned<LaneType>(num_lanes);
+
 
   for (Algo algo : AlgoForBench()) {
     // Other algorithms don't depend on the vector instructions, so only run
@@ -330,17 +336,22 @@ HWY_NOINLINE void BenchSort(size_t num_keys) {
     for (Dist dist : AllDist()) {
       std::vector<double> seconds;
       for (size_t rep = 0; rep < reps; ++rep) {
-        InputStats<LaneType> input_stats =
-            GenerateInput(dist, aligned.get(), num_lanes);
-
+        std::array<InputStats<LaneType>, inner_reps_max> input_stats;
+        for (size_t i = 0; i < inner_reps; ++i) {
+          input_stats[i] = GenerateInput(dist, aligned[i].get(), num_lanes);
+        }
         const Timestamp t0;
-        Run(algo, HWY_RCAST_ALIGNED(KeyType*, aligned.get()), num_keys, shared,
-            /*thread=*/0, /*k_keys=*/0, Order());
-        seconds.push_back(SecondsSince(t0));
+        for (size_t inner_rep = 0; inner_rep < inner_reps; ++inner_rep) {
+          Run(algo, HWY_RCAST_ALIGNED(KeyType*, aligned[inner_rep].get()), num_keys, shared,
+              /*thread=*/0, /*k_keys=*/0, Order());
+        }
+        seconds.push_back(SecondsSince(t0) / static_cast<double>(inner_reps));
         // printf("%f\n", seconds.back());
 
-        SortOrderVerifier<Traits>()(algo, input_stats, aligned.get(), num_keys,
-                                    num_keys);
+        for (size_t i = 0; i < inner_reps; ++i) {
+          SortOrderVerifier<Traits>()(algo, input_stats[i], aligned[i].get(), num_keys,
+                                      num_keys);
+        }
       }
       SortResult(algo, dist, num_keys, 1, SummarizeMeasurements(seconds),
                  sizeof(KeyType), st.KeyString())

--- a/hwy/contrib/sort/shared-inl.h
+++ b/hwy/contrib/sort/shared-inl.h
@@ -57,12 +57,10 @@ struct SortConstants {
   // networks (for which only loose upper bounds on size are known).
   static constexpr size_t kMaxRows = 16;
 
-  // Template argument ensures there is no actual division instruction.
-  template <size_t kLPK>
   static constexpr HWY_INLINE size_t BaseCaseNumLanes(size_t N) {
-    // We use 8, 8x2, 8x4, and 16x{4..} networks, in units of keys. For N/kLPK
-    // < 4, we cannot use the 16-row networks.
-    return (((N / kLPK) >= 4) ? kMaxRows : 8) * HWY_MIN(N, kMaxCols);
+    // We use 8, 8x2, 8x4, and 16 networks, in units of keys.
+    // For any N/kLPK the largest network is 16 rows.
+    return kMaxRows * HWY_MIN(N, kMaxCols);
   }
 
   // Unrolling is important (pipelining and amortizing branch mispredictions);
@@ -94,28 +92,28 @@ struct SortConstants {
   }
 
   // Max across the three buffer usages.
-  template <typename T, size_t kLPK>
+  template <typename T>
   static constexpr HWY_INLINE size_t BufNum(size_t N) {
     // BaseCase may write one padding vector, and SortSamples uses the space
     // after samples as the buffer.
-    return HWY_MAX(SampleLanes<T>() + BaseCaseNumLanes<kLPK>(N) + N,
+    return HWY_MAX(SampleLanes<T>() + BaseCaseNumLanes(N) + N,
                    PartitionBufNum(N));
   }
 
   // Translates vector_size to lanes and returns size in bytes.
-  template <typename T, size_t kLPK>
+  template <typename T>
   static constexpr HWY_INLINE size_t BufBytes(size_t vector_size) {
-    return BufNum<T, kLPK>(vector_size / sizeof(T)) * sizeof(T);
+    return BufNum<T>(vector_size / sizeof(T)) * sizeof(T);
   }
 
   // Returns max for any type.
   template <size_t kLPK>
   static constexpr HWY_INLINE size_t MaxBufBytes(size_t vector_size) {
     // If 2 lanes per key, it's a 128-bit key with u64 lanes.
-    return kLPK == 2 ? BufBytes<uint64_t, 2>(vector_size)
-                     : HWY_MAX((BufBytes<uint16_t, 1>(vector_size)),
-                               HWY_MAX((BufBytes<uint32_t, 1>(vector_size)),
-                                       (BufBytes<uint64_t, 1>(vector_size))));
+    return kLPK == 2 ? BufBytes<uint64_t>(vector_size)
+                     : HWY_MAX((BufBytes<uint16_t>(vector_size)),
+                               HWY_MAX((BufBytes<uint32_t>(vector_size)),
+                                       (BufBytes<uint64_t>(vector_size))));
   }
 };
 

--- a/hwy/contrib/sort/sort_unit_test.cc
+++ b/hwy/contrib/sort/sort_unit_test.cc
@@ -160,7 +160,7 @@ static HWY_NOINLINE void TestBaseCaseAscDesc() {
   const SortTag<LaneType> d;
   const size_t N = Lanes(d);
   constexpr size_t N1 = st.LanesPerKey();
-  const size_t base_case_num = SortConstants::BaseCaseNumLanes<N1>(N);
+  const size_t base_case_num = SortConstants::BaseCaseNumLanes(N);
 
   constexpr int kDebug = 0;
   auto aligned_lanes = hwy::AllocateAligned<LaneType>(N + base_case_num + N);
@@ -240,7 +240,7 @@ static HWY_NOINLINE void TestBaseCase01() {
   const SortTag<LaneType> d;
   const size_t N = Lanes(d);
   constexpr size_t N1 = st.LanesPerKey();
-  const size_t base_case_num = SortConstants::BaseCaseNumLanes<N1>(N);
+  const size_t base_case_num = SortConstants::BaseCaseNumLanes(N);
 
   constexpr int kDebug = 0;
   auto lanes = hwy::AllocateAligned<LaneType>(base_case_num + N);
@@ -361,14 +361,14 @@ static HWY_NOINLINE void TestPartition() {
   const size_t N = Lanes(d);
   constexpr int kDebug = 0;
   constexpr size_t N1 = st.LanesPerKey();
-  const size_t base_case_num = SortConstants::BaseCaseNumLanes<N1>(N);
+  const size_t base_case_num = SortConstants::BaseCaseNumLanes(N);
   HWY_ASSERT(2 * N <= base_case_num);  // See HandleSpecialCases
 
   // left + len + align
   const size_t total = 32 + (base_case_num + 4 * HWY_MAX(N, 4)) + 2 * N;
   auto aligned_lanes = hwy::AllocateAligned<LaneType>(total);
   HWY_ASSERT(aligned_lanes);
-  HWY_ALIGN LaneType buf[SortConstants::BufBytes<LaneType, N1>(HWY_MAX_BYTES) /
+  HWY_ALIGN LaneType buf[SortConstants::BufBytes<LaneType>(HWY_MAX_BYTES) /
                          sizeof(LaneType)];
 
   for (bool in_asc : {false, true}) {

--- a/hwy/contrib/sort/vqsort-inl.h
+++ b/hwy/contrib/sort/vqsort-inl.h
@@ -584,7 +584,7 @@ HWY_NOINLINE void BaseCase(D d, TraitsKV, T* HWY_RESTRICT keys,
   using Traits = typename TraitsKV::SharedTraitsForSortingNetwork;
   Traits st;
   constexpr size_t kLPK = st.LanesPerKey();
-  HWY_DASSERT(num_lanes <= Constants::BaseCaseNumLanes<kLPK>(Lanes(d)));
+  HWY_DASSERT(num_lanes <= Constants::BaseCaseNumLanes(Lanes(d)));
   const size_t num_keys = num_lanes / kLPK;
 
   // Can be zero when called through HandleSpecialCases, but also 1 (in which
@@ -603,8 +603,9 @@ HWY_NOINLINE void BaseCase(D d, TraitsKV, T* HWY_RESTRICT keys,
       /* <= 2 */ &Sort2To2<Traits, T>,
       /* <= 4 */ &Sort3To4<Traits, T>,
       /* <= 8 */ &Sort8Rows<1, Traits, T>,  // 1 key per row
-      /* <= 16 */ kMaxKeysPerVector >= 2 ? &Sort8Rows<2, Traits, T> : nullptr,
-      /* <= 32 */ kMaxKeysPerVector >= 4 ? &Sort8Rows<4, Traits, T> : nullptr,
+      /* <= 16 */ kMaxKeysPerVector >= 2 ? &Sort8Rows<2, Traits, T> : &Sort16Rows<1, Traits, T>,
+      /* <= 32 */ kMaxKeysPerVector >= 4 ? &Sort8Rows<4, Traits, T> :
+                  kMaxKeysPerVector >= 2 ? &Sort16Rows<2, Traits, T> : nullptr,
       /* <= 64 */ kMaxKeysPerVector >= 4 ? &Sort16Rows<4, Traits, T> : nullptr,
       /* <= 128 */ kMaxKeysPerVector >= 8 ? &Sort16Rows<8, Traits, T> : nullptr,
 #if !HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD
@@ -1316,7 +1317,7 @@ HWY_INLINE void SortSamples(D d, Traits st, T* HWY_RESTRICT buf) {
   const size_t N = Lanes(d);
   constexpr size_t kSampleLanes = Constants::SampleLanes<T>();
   // Network must be large enough to sort two chunks.
-  HWY_DASSERT(Constants::BaseCaseNumLanes<st.LanesPerKey()>(N) >= kSampleLanes);
+  HWY_DASSERT(Constants::BaseCaseNumLanes(N) >= kSampleLanes);
 
   BaseCase(d, st, buf, kSampleLanes, buf + kSampleLanes);
 
@@ -1775,8 +1776,7 @@ HWY_NOINLINE void Recurse(D d, Traits st, T* HWY_RESTRICT keys,
   HWY_DASSERT(num != 0);
 
   const size_t N = Lanes(d);
-  constexpr size_t kLPK = st.LanesPerKey();
-  if (HWY_UNLIKELY(num <= Constants::BaseCaseNumLanes<kLPK>(N))) {
+  if (HWY_UNLIKELY(num <= Constants::BaseCaseNumLanes(N))) {
     BaseCase(d, st, keys, num, buf);
     return;
   }
@@ -1889,8 +1889,7 @@ template <class D, class Traits, typename T>
 HWY_INLINE bool HandleSpecialCases(D d, Traits st, T* HWY_RESTRICT keys,
                                    size_t num, T* HWY_RESTRICT buf) {
   const size_t N = Lanes(d);
-  constexpr size_t kLPK = st.LanesPerKey();
-  const size_t base_case_num = Constants::BaseCaseNumLanes<kLPK>(N);
+  const size_t base_case_num = Constants::BaseCaseNumLanes(N);
 
   // Recurse will also check this, but doing so here first avoids setting up
   // the random generator state.
@@ -2144,8 +2143,7 @@ void Select(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
 // `num` is in units of `T`, not keys!
 template <class D, class Traits, typename T>
 HWY_API void Sort(D d, Traits st, T* HWY_RESTRICT keys, const size_t num) {
-  constexpr size_t kLPK = st.LanesPerKey();
-  HWY_ALIGN T buf[SortConstants::BufBytes<T, kLPK>(HWY_MAX_BYTES) / sizeof(T)];
+  HWY_ALIGN T buf[SortConstants::BufBytes<T>(HWY_MAX_BYTES) / sizeof(T)];
   Sort(d, st, keys, num, buf);
 }
 
@@ -2155,8 +2153,7 @@ HWY_API void Sort(D d, Traits st, T* HWY_RESTRICT keys, const size_t num) {
 template <class D, class Traits, typename T>
 HWY_API void PartialSort(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
                          const size_t k) {
-  constexpr size_t kLPK = st.LanesPerKey();
-  HWY_ALIGN T buf[SortConstants::BufBytes<T, kLPK>(HWY_MAX_BYTES) / sizeof(T)];
+  HWY_ALIGN T buf[SortConstants::BufBytes<T>(HWY_MAX_BYTES) / sizeof(T)];
   PartialSort(d, st, keys, num, k, buf);
 }
 
@@ -2167,8 +2164,7 @@ HWY_API void PartialSort(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
 template <class D, class Traits, typename T>
 HWY_API void Select(D d, Traits st, T* HWY_RESTRICT keys, const size_t num,
                     const size_t k) {
-  constexpr size_t kLPK = st.LanesPerKey();
-  HWY_ALIGN T buf[SortConstants::BufBytes<T, kLPK>(HWY_MAX_BYTES) / sizeof(T)];
+  HWY_ALIGN T buf[SortConstants::BufBytes<T>(HWY_MAX_BYTES) / sizeof(T)];
   Select(d, st, keys, num, k, buf);
 }
 


### PR DESCRIPTION
I added sorting networks for cases, when <4 keys fits the register. BaseCase::funcs:

1) <= 16: if 1 key, use Sort16Rows<1>
2) <= 32: if 2 keys, use Sort16Rows<2>

Also, kLPK in BaseCaseNumLanes is no longer needed, because cases for <4 added. I removed it.

bench_sort: for n <= 128 a single bench is terrible noisy, so now 30 sorts of 30 different buffers are measured for them in one measurement.


Final speedup(I alternated many benches and took the median, apple m5)
| type | n | speedup |
|-|-|-:|
| U128 | 16 | +326.3% |
| k+v=128 | 16 | +270.9% |
| i64 | 32 | +355.8% |
| U128 |  32 | +58.6% |
| k+v=128 | 32 | +56.5% |
| i64 | 64 | +71.7% |
| U128 |  64 | +53.0% |
| k+v=128 | 64 | +47.1% |
| i64 | 128 | +59.2% |
| U128 |  128 | +43.8%  |
| k+v=128 | 128 |  +39.9% |
| i64 | 10000 | +26.8% |
| U128 |  10000 | +23.6%  |
| k+v=128 | 10000 |  +22.6% |

for n=1e4 i used uniform32.
Other types remain unchanged