### PR TITLE
contrib/math: preserve negative zero in FastTan

### DIFF
--- a/hwy/contrib/math/fast_math-inl.h
+++ b/hwy/contrib/math/fast_math-inl.h
@@ -46,8 +46,11 @@ HWY_INLINE void ReduceAngleTan(D d, V ang, V& x_red, V& sign) {
   quotient = Round(quotient);
   auto ang_mod = NegMulAdd(quotient, pi, ang);
 
-  // Determine sign
-  sign = ang_mod;
+  // Determine sign. Preserve the input's signed zero: when the reduced angle
+  // is exactly zero, the cancellation above can turn a -0 input into +0 on
+  // some targets, but tan(-0) must be -0. For any nonzero reduced angle the
+  // sign correctly follows ang_mod (e.g. tan(2) < 0 for a positive input).
+  sign = IfThenElse(Eq(ang_mod, Zero(d)), ang, ang_mod);
 
   // Absolute value
   x_red = Abs(ang_mod);

--- a/hwy/contrib/math/math_tan_test.cc
+++ b/hwy/contrib/math/math_tan_test.cc
@@ -437,6 +437,23 @@ HWY_NOINLINE void TestAllFastTan() {
   ForFloat3264Types(ForPartialVectors<TestFastTanRelative>());
 }
 
+struct TestFastTanSignedZero {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T, D d) {
+    using TU = MakeUnsigned<T>;
+    const T pos0 = ConvertScalarTo<T>(0.0);
+    const T neg0 = ConvertScalarTo<T>(-0.0);
+    const T gp = GetLane(CallFastTan(d, Set(d, pos0)));
+    const T gn = GetLane(CallFastTan(d, Set(d, neg0)));
+    HWY_ASSERT_EQ(BitCastScalar<TU>(pos0), BitCastScalar<TU>(gp));
+    HWY_ASSERT_EQ(BitCastScalar<TU>(neg0), BitCastScalar<TU>(gn));
+  }
+};
+
+HWY_NOINLINE void TestAllFastTanSignedZero() {
+  ForFloat3264Types(ForPartialVectors<TestFastTanSignedZero>());
+}
+
 struct TestFastAtanRelative {
   template <class T, class D>
   HWY_NOINLINE void operator()(T, D d) {
@@ -546,6 +563,7 @@ HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllAtan);
 HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllAtan2);
 HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllHypot);
 HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllFastTan);
+HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllFastTanSignedZero);
 HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllFastAtan);
 HWY_EXPORT_AND_TEST_P(HwyMathTanTest, TestAllFastAtan2);
 


### PR DESCRIPTION
### Summary

`FastTan(-0.0)` returns `+0.0` instead of `-0.0` on some targets (reproduced on AVX3_ZEN4). C11 Annex F (F.10.7.8) requires `tan(±0) = ±0`, and `std::tan` complies, so this is a signed-zero correctness bug.

### Cause

`ReduceAngleTan` computes the reduced angle `ang_mod = ang - round(ang/π)·π` and sets `sign = ang_mod`; the final result is `CopySign(result, sign)`. For `ang = -0.0`, the cancellation `-0 - (-0·π)` can round to `+0.0` (target-dependent), so the negative-zero sign is lost and `FastTan(-0)` becomes `+0`. (`FastAtan2`, fixed in #3272, was the same class of bug.)

### Fix

When the reduced angle is exactly zero, take the sign from the original input; otherwise keep `ang_mod`:

```cpp
sign = IfThenElse(Eq(ang_mod, Zero(d)), ang, ang_mod);
```

The sign of `tan` must follow the *reduced* angle for nonzero inputs (e.g. `tan(2) < 0` even though the input is positive), so a blanket `CopySign(result, x)` would be wrong — the guard fires only when `ang_mod == 0`, which within the supported range only happens for `x = ±0`. Only that case changes; every other input is unchanged on every target.

### Testing

- Added `TestFastTanSignedZero`, a **bit-exact** check that `FastTan(±0)` returns `±0`. The existing relative-error test skips `|expected| ≈ 0` and never checks the sign, so it could not catch this. The new test fails on baseline (AVX3_ZEN4: expected `-0`, got `+0`) and passes with the fix.
- Full `math_tan_test` passes (64 tests) across every enabled SIMD target.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.