### PR TITLE
contrib/math: preserve negative zero in Sin

### DIFF
--- a/hwy/contrib/math/math-inl.h
+++ b/hwy/contrib/math/math-inl.h
@@ -2860,8 +2860,11 @@ HWY_INLINE V Sin(const D d, V x) {
   const VI32 q = impl.ToInt32(d, MulAdd(abs_x, kOneOverPi, kHalf));
 
   // Reduce range, apply sign, and approximate.
-  return impl.Poly(d, Xor(impl.SinReduce(d, abs_x, q),
-                          Xor(impl.SinSignFromQuadrant(d, q), sign_x)));
+  const V s = impl.Poly(d, Xor(impl.SinReduce(d, abs_x, q),
+                               Xor(impl.SinSignFromQuadrant(d, q), sign_x)));
+  // sin is odd, so sin(-0) must be -0; the polynomial yields +0 for a zero
+  // reduced argument, so reapply x's sign when the result is zero.
+  return IfThenElse(Eq(s, Zero(d)), CopySign(s, x), s);
 }
 
 template <class D, class V>

--- a/hwy/contrib/math/math_test.cc
+++ b/hwy/contrib/math/math_test.cc
@@ -210,6 +210,39 @@ HWY_NOINLINE void TestAllExpm1SignedZero() {
   ForFloat3264Types(ForPartialVectors<TestExpm1SignedZero>());
 }
 
+// Odd functions (and log1p) must preserve the sign of zero: fn(+/-0) = +/-0
+// (C11 Annex F). The ULP comparator used by the other tests treats +0 == -0,
+// so this is checked bit-exactly.
+struct TestSignedZero {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T, D d) {
+    using TU = MakeUnsigned<T>;
+    const T p0 = ConvertScalarTo<T>(0.0);
+    const T n0 = ConvertScalarTo<T>(-0.0);
+    const TU p0b = BitCastScalar<TU>(p0);
+    const TU n0b = BitCastScalar<TU>(n0);
+#define HWY_ASSERT_SIGNED_ZERO(fn)                                   \
+  HWY_ASSERT_EQ(p0b, BitCastScalar<TU>(GetLane(fn(d, Set(d, p0))))); \
+  HWY_ASSERT_EQ(n0b, BitCastScalar<TU>(GetLane(fn(d, Set(d, n0)))))
+    HWY_ASSERT_SIGNED_ZERO(CallSin);
+    HWY_ASSERT_SIGNED_ZERO(CallTan);
+    HWY_ASSERT_SIGNED_ZERO(CallAsin);
+    HWY_ASSERT_SIGNED_ZERO(CallAtan);
+    HWY_ASSERT_SIGNED_ZERO(CallAsinh);
+    HWY_ASSERT_SIGNED_ZERO(CallAtanh);
+    HWY_ASSERT_SIGNED_ZERO(CallCbrt);
+    HWY_ASSERT_SIGNED_ZERO(CallErf);
+    HWY_ASSERT_SIGNED_ZERO(CallLog1p);
+    HWY_ASSERT_SIGNED_ZERO(CallSinh);
+    HWY_ASSERT_SIGNED_ZERO(CallTanh);
+#undef HWY_ASSERT_SIGNED_ZERO
+  }
+};
+
+HWY_NOINLINE void TestAllSignedZero() {
+  ForFloat3264Types(ForPartialVectors<TestSignedZero>());
+}
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -233,6 +266,7 @@ HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllTgamma);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllLogGamma);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllPow);
 HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllExpm1SignedZero);
+HWY_EXPORT_AND_TEST_P(HwyMathTest, TestAllSignedZero);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy


### PR DESCRIPTION
### Summary

`Sin(-0.0)` returns `+0.0` instead of `-0.0` on all targets. C11 Annex F (F.10.1.6) requires `sin(±0) = ±0`, and `std::sin` complies, so this is a signed-zero correctness bug.

### Cause

`Sin` folds the sign of `x` into the polynomial argument:

```cpp
return impl.Poly(d, Xor(impl.SinReduce(d, abs_x, q),
                        Xor(impl.SinSignFromQuadrant(d, q), sign_x)));
```

For `x = -0.0` the reduced argument is zero and the polynomial produces `+0.0`, so the negative-zero sign is lost.

### Fix

`sin` is odd, so its result must carry the sign of `x` when the magnitude is zero. Reapply `x`'s sign when the result is exactly zero:

```cpp
const V s = impl.Poly(...);
return IfThenElse(Eq(s, Zero(d)), CopySign(s, x), s);
```

For the supported range the result is exactly zero only at `x = ±0`, so the guard fires only there; every other input is unchanged on every target.

### Testing

- Added `TestSignedZero`, a **bit-exact** check that the sign-preserving math functions return `±0` for `±0`: `Sin`, `Tan`, `Asin`, `Atan`, `Asinh`, `Atanh`, `Cbrt`, `Erf`, `Log1p`, `Sinh`, `Tanh`. The existing ULP comparators treat `+0 == -0` and could not catch this. Before the fix the `Sin` case fails on all targets; after, all pass (the others were already correct).
- Full `math_test` passes (104 tests) across every enabled SIMD target.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.