### PR TITLE
Fix documented type constraints for complex ops

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1069,31 +1069,24 @@ ib)(c + id)`.
 
 Take `j` to be the even values of `i`.
 
-*   `V`: `{f}` \
+*   `V`: `{i,f}` \
     <code>V **ComplexConj**(V v)</code>: returns the complex conjugate of the
     vector, this negates the imaginary lanes. This is equivalent to
     `OddEven(Neg(a), a)`.
-*   `V`: `{f}` \
-    <code>V **MulComplex**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] +
+*   <code>V **MulComplex**(V a, V b)</code>: returns `(a[j] + i.a[j + 1])(b[j] +
     i.b[j + 1])`
-*   `V`: `{f}` \
-    <code>V **MulComplexConj**(V a, V b)</code>: returns `(a[j] + i.a[j +
+*   <code>V **MulComplexConj**(V a, V b)</code>: returns `(a[j] + i.a[j +
     1])(b[j] - i.b[j + 1])`
-*   `V`: `{f}` \
-    <code>V **MulComplexAdd**(V a, V b, V c)</code>: returns `(a[j] + i.a[j +
+*   <code>V **MulComplexAdd**(V a, V b, V c)</code>: returns `(a[j] + i.a[j +
     1])(b[j] + i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   `V`: `{f}` \
-    <code>V **MulComplexConjAdd**(V a, V b, V c)</code>: returns `(a[j] +
+*   <code>V **MulComplexConjAdd**(V a, V b, V c)</code>: returns `(a[j] +
     i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])`
-*   `V`: `{f}` \
-    <code>V **MaskedMulComplexConjAdd**(M mask, V a, V b, V c)</code>: returns
+*   <code>V **MaskedMulComplexConjAdd**(M mask, V a, V b, V c)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] - i.b[j + 1]) + (c[j] + i.c[j + 1])` or `0` if
     `mask[i]` is false.
-*   `V`: `{f}` \
-    <code>V **MaskedMulComplexConj**(M mask, V a, V b)</code>: returns `(a[j] +
+*   <code>V **MaskedMulComplexConj**(M mask, V a, V b)</code>: returns `(a[j] +
     i.a[j + 1])(b[j] - i.b[j + 1])` or `0` if `mask[i]` is false.
-*   `V`: `{f}` \
-    <code>V **MaskedMulComplexOr**(V no, M mask, V a, V b)</code>: returns
+*   <code>V **MaskedMulComplexOr**(V no, M mask, V a, V b)</code>: returns
     `(a[j] + i.a[j + 1])(b[j] + i.b[j + 1])` or `no[i]` if `mask[i]` is false.
 
 #### Shifts


### PR DESCRIPTION
Fixes #3291.

The complex number operations are all documented as `V`: `{f}`, but the
implementations are not restricted to floating-point types.

**What changed**

- `ComplexConj`: `{f}` -> `{i,f}`
- `MulComplex`, `MulComplexConj`, `MulComplexAdd`, `MulComplexConjAdd`,
  `MaskedMulComplexConjAdd`, `MaskedMulComplexConj`, `MaskedMulComplexOr`:
  constraint line removed

**Why**

- `ComplexConj` is declared with `HWY_IF_NOT_UNSIGNED(TFromV<V>)` in both
  `generic_ops-inl.h` and `arm_sve-inl.h`, so it supports `{i,f}`.
- The other ops have no type constraint in `generic_ops-inl.h`, and
  `arm_sve-inl.h` supplies both `HWY_IF_FLOAT_V` (native FCMLA) and
  `HWY_IF_NOT_FLOAT_V` overloads, so u, i and f are all supported.
- Per the notation section of `quick_reference.md`, only ops "limited to
  certain vector types" carry a constraint, so removing the line is the
  correct encoding for "all types supported" rather than widening it to
  `{u,i,f}`.

**How verified**

- Cross-checked the template constraints in `generic_ops-inl.h` and
  `arm_sve-inl.h`.
- Existing tests agree: `complex_arithmetic_test.cc` uses `ForSignedTypes`
  + `ForFloatTypes` for `ComplexConj` and `ForAllTypes` for the other
  seven operations.
- Documentation-only change; checked the rendered list, 80-column
  wrapping and trailing whitespace.
