### PR TITLE
Add float16 trig math functions, promote per half by default

### DIFF
--- a/hwy/contrib/math/f16_math-inl.h
+++ b/hwy/contrib/math/f16_math-inl.h
@@ -38,13 +38,31 @@ namespace HWY_NAMESPACE {
 // namespace would also find math-inl.h's impl::Log and be ambiguous.
 namespace f16_impl {
 
-// Promotes lower/upper halves of the float16 vector `v` to float32,
-// evaluates `kernel` (a functor wrapping one float32 math function) twice,
-// then demotes and recombines. Never instantiated on HWY_SCALAR, so
-// PromoteUpperTo and Combine are safe to name here. There is no
-// OrderedDemote2To for f32->f16, hence DemoteTo + Combine.
-template <class D, class Kernel, class V = VFromD<D>>
-HWY_INLINE V F16ViaF32PerHalf(D d, V v, Kernel kernel) {
+// Promotes the lower and upper halves of the float16 vector `v` to float32,
+// evaluates `kernel` (a functor wrapping one float32 math function) on each,
+// then demotes and recombines. There is no OrderedDemote2To for f32->f16,
+// hence DemoteTo + Combine.
+//
+// This is used for every non-fractional vector with more than one lane. A
+// single promotion via Rebind<float, D> would be cheaper for small vectors,
+// but on scalable targets it is not always lane-exact: MaxLanes() is only an
+// upper bound, so a CappedTag whose cap does not bind is a full vector at run
+// time, and Rebind then runs into the cap (SVE additionally clamps kPow2 to
+// 0). For example, on SVE2 with 512-bit vectors, CappedTag<float16_t, 32> has
+// Lanes() == 32 but Rebind<float, decltype(d)> has Lanes() == 16, so a single
+// promotion would cover only the lower half. RepartitionToWide keeps kPow2
+// and therefore always has exactly Lanes(d) / 2 lanes.
+//
+// Fractional tags (kPow2 < 0) take the single-promotion overload below
+// instead. Their Rebind is lane-exact because the widening is absorbed by
+// kPow2, and per-half is not even instantiable at kPow2 == -3, where
+// RepartitionToWide<D> would need a float32 tag below the smallest supported
+// fraction. This is the same split as IotaForSpecial in test_util-inl.h.
+// Neither condition compares MaxLanes against a vector size, so both hold at
+// every vector length.
+template <class D, class Kernel, class V = VFromD<D>, HWY_IF_F16_D(D),
+          HWY_IF_LANES_GT_D(D, 1), HWY_IF_POW2_GT_D(D, -1)>
+HWY_INLINE V F16ViaF32(D d, V v, Kernel kernel) {
   const Half<D> dh;
   const RepartitionToWide<D> df32;
   HWY_DASSERT(Lanes(df32) == Lanes(d) / 2);
@@ -53,48 +71,52 @@ HWY_INLINE V F16ViaF32PerHalf(D d, V v, Kernel kernel) {
   return Combine(d, DemoteTo(dh, hi), DemoteTo(dh, lo));
 }
 
-// Whether `Rebind<float, D>` is guaranteed to have exactly `Lanes(d)` lanes,
-// i.e. one promotion covers every lane of `v`.
-//
-// Rebind raises kPow2 by one because float lanes are twice as large. On
-// fixed-size targets Lanes() == MaxLanes(), so comparing sizes is enough. On
-// scalable targets it is not: MaxLanes() is only an upper bound, so a
-// CappedTag whose cap does not bind is a full vector at run time. Rebind then
-// runs into the cap, and SVE additionally clamps kPow2 to 0, leaving the
-// float32 tag with half as many lanes as `d`. For example, on SVE2 with
-// 512-bit vectors, CappedTag<float16_t, 32> has Lanes() == 32, but
-// Rebind<float, decltype(d)> has Lanes() == 16: the kernel would see only
-// lanes 0..15, and DemoteTo, which duplicates its result into both halves of
-// the register, would store those same results again for lanes 16..31.
-//
-// Fractional tags absorb the widening in kPow2 and are safe, as is any tag
-// whose cap binds even for the smallest possible vector. Everything else uses
-// the per-half path, whose RepartitionToWide keeps kPow2 and therefore always
-// has exactly Lanes(d) / 2 lanes.
-template <class D>
-constexpr bool F16OnePromotionCoversAllLanes() {
-  return (HWY_POW2_D(D) + 1 <= HWY_MAX_POW2) &&
-         (HWY_HAVE_SCALABLE
-              ? (HWY_POW2_D(D) < 0 || HWY_V_SIZE_D(D) * 2 <= HWY_MIN_BYTES)
-              : (HWY_V_SIZE_D(D) <= HWY_MAX_BYTES / 2));
-}
-
-// Evaluates `kernel` on all lanes of `v` with a single promotion and one
-// kernel evaluation.
+// Single-lane vectors (including all of HWY_SCALAR, where PromoteUpperTo and
+// Combine do not exist) and fractional tags: one Rebind promotion is
+// lane-exact for both.
 template <class D, class Kernel, class V = VFromD<D>, HWY_IF_F16_D(D),
-          hwy::EnableIf<F16OnePromotionCoversAllLanes<D>()>* = nullptr>
+          hwy::EnableIf<(HWY_MAX_LANES_D(D) == 1) ||
+                        (HWY_POW2_D(D) < 0)>* = nullptr>
 HWY_INLINE V F16ViaF32(D d, V v, Kernel kernel) {
   const Rebind<float, D> df32;
   HWY_DASSERT(Lanes(df32) == Lanes(d));
   return DemoteTo(d, kernel(df32, PromoteTo(df32, v)));
 }
 
-// Everything else needs two promotions, one per half.
+// Two-output counterparts of F16ViaF32: `kernel` writes two float32 results,
+// each of which is demoted (and, per half, recombined) separately.
 template <class D, class Kernel, class V = VFromD<D>, HWY_IF_F16_D(D),
-          hwy::EnableIf<!F16OnePromotionCoversAllLanes<D>()>* = nullptr>
-HWY_INLINE V F16ViaF32(D d, V v, Kernel kernel) {
-  return F16ViaF32PerHalf(d, v, kernel);
+          HWY_IF_LANES_GT_D(D, 1), HWY_IF_POW2_GT_D(D, -1)>
+HWY_INLINE void F16ViaF32TwoOut(D d, V v, Kernel kernel, V& out0, V& out1) {
+  const Half<D> dh;
+  const RepartitionToWide<D> df32;
+  HWY_DASSERT(Lanes(df32) == Lanes(d) / 2);
+  using VF32 = VFromD<decltype(df32)>;
+  VF32 lo0, lo1, hi0, hi1;
+  kernel(df32, PromoteLowerTo(df32, v), lo0, lo1);
+  kernel(df32, PromoteUpperTo(df32, v), hi0, hi1);
+  out0 = Combine(d, DemoteTo(dh, hi0), DemoteTo(dh, lo0));
+  out1 = Combine(d, DemoteTo(dh, hi1), DemoteTo(dh, lo1));
 }
+
+template <class D, class Kernel, class V = VFromD<D>, HWY_IF_F16_D(D),
+          hwy::EnableIf<(HWY_MAX_LANES_D(D) == 1) ||
+                        (HWY_POW2_D(D) < 0)>* = nullptr>
+HWY_INLINE void F16ViaF32TwoOut(D d, V v, Kernel kernel, V& out0, V& out1) {
+  const Rebind<float, D> df32;
+  HWY_DASSERT(Lanes(df32) == Lanes(d));
+  VFromD<decltype(df32)> f0, f1;
+  kernel(df32, PromoteTo(df32, v), f0, f1);
+  out0 = DemoteTo(d, f0);
+  out1 = DemoteTo(d, f1);
+}
+
+struct CosKernel {
+  template <class DF, class VF>
+  HWY_INLINE VF operator()(DF df, VF x) const {
+    return Cos(df, x);
+  }
+};
 
 struct ExpKernel {
   template <class DF, class VF>
@@ -145,11 +167,47 @@ struct Log2Kernel {
   }
 };
 
+struct SinKernel {
+  template <class DF, class VF>
+  HWY_INLINE VF operator()(DF df, VF x) const {
+    return Sin(df, x);
+  }
+};
+
+struct SinCosKernel {
+  template <class DF, class VF>
+  HWY_INLINE void operator()(DF df, VF x, VF& s, VF& c) const {
+    SinCos(df, x, s, c);
+  }
+};
+
+// Calls the float32 Tan, which divides in float32; dividing the demoted
+// float16 sine and cosine would instead lose accuracy near the poles.
+struct TanKernel {
+  template <class DF, class VF>
+  HWY_INLINE VF operator()(DF df, VF x) const {
+    return Tan(df, x);
+  }
+};
+
 }  // namespace f16_impl
 
 // The generic templates in math-inl.h are constrained with
 // HWY_IF_NOT_SPECIAL_FLOAT_D, so these HWY_IF_F16_D overloads partition the
 // overload set rather than being ambiguous.
+
+/**
+ * Highway SIMD version of std::cos(x) for float16 lanes.
+ *
+ * Valid Lane Types: float16
+ *        Max Error: ULP = 1
+ *      Valid Range: float16[-39000, +39000]
+ * @return cosine of 'x'
+ */
+template <class D, class V, HWY_IF_F16_D(D)>
+HWY_INLINE V Cos(D d, V x) {
+  return f16_impl::F16ViaF32(d, x, f16_impl::CosKernel());
+}
 
 /**
  * Highway SIMD version of std::exp(x) for float16 lanes.
@@ -240,6 +298,46 @@ HWY_INLINE V Log1p(D d, V x) {
 template <class D, class V, HWY_IF_F16_D(D)>
 HWY_INLINE V Log2(D d, V x) {
   return f16_impl::F16ViaF32(d, x, f16_impl::Log2Kernel());
+}
+
+/**
+ * Highway SIMD version of std::sin(x) for float16 lanes.
+ *
+ * Valid Lane Types: float16
+ *        Max Error: ULP = 1
+ *      Valid Range: float16[-39000, +39000]
+ * @return sine of 'x'
+ */
+template <class D, class V, HWY_IF_F16_D(D)>
+HWY_INLINE V Sin(D d, V x) {
+  return f16_impl::F16ViaF32(d, x, f16_impl::SinKernel());
+}
+
+/**
+ * Highway SIMD version of SinCos for float16 lanes.
+ * Compute the sine and cosine at the same time
+ * The performance should be around the same as calling Sin.
+ *
+ * Valid Lane Types: float16
+ *        Max Error: ULP = 1
+ *      Valid Range: float16[-39000, +39000]
+ */
+template <class D, class V, HWY_IF_F16_D(D)>
+HWY_INLINE void SinCos(D d, V x, V& s, V& c) {
+  f16_impl::F16ViaF32TwoOut(d, x, f16_impl::SinCosKernel(), s, c);
+}
+
+/**
+ * Highway SIMD version of std::tan(x) for float16 lanes.
+ *
+ * Valid Lane Types: float16
+ *        Max Error: ULP = 1
+ *      Valid Range: float16[-39000, +39000]
+ * @return tangent of 'x'
+ */
+template <class D, class V, HWY_IF_F16_D(D)>
+HWY_INLINE V Tan(D d, V x) {
+  return f16_impl::F16ViaF32(d, x, f16_impl::TanKernel());
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)

--- a/hwy/contrib/math/f16_math_test.cc
+++ b/hwy/contrib/math/f16_math_test.cc
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <cmath>  // std::exp
+#include <cmath>  // std::exp, std::sin
 
 // For faster tests. Not using AES, hence NEON_WITHOUT_AES is sufficient.
 // SVE is mostly superseded by SVE2.
@@ -61,6 +61,38 @@ DEFINE_F16_MATH_TEST(Log2,
   std::log2,  CallLog2,  +5.960464478E-8f, +65504.0f, 1)
 // clang-format on
 
+// SinCos has two outputs, so test each separately, as math_trig_test.cc does.
+template <class D>
+static Vec<D> F16SinCosSin(const D d, VecArg<Vec<D>> x) {
+  Vec<D> s, c;
+  CallSinCos(d, x, s, c);
+  return s;
+}
+
+template <class D>
+static Vec<D> F16SinCosCos(const D d, VecArg<Vec<D>> x) {
+  Vec<D> s, c;
+  CallSinCos(d, x, s, c);
+  return c;
+}
+
+// Unlike the bounds above, these come from math_trig_test.cc rather than from
+// the float16 finite range: the trig kernels are only accurate on
+// [-39000, +39000], which is narrower than float16 can represent. Beyond it
+// the Cody-Waite range reduction loses exactness on targets without FMA.
+// clang-format off
+DEFINE_F16_MATH_TEST(Sin,
+  std::sin,   CallSin,      -39000.0f,        +39000.0f, 1)
+DEFINE_F16_MATH_TEST(Cos,
+  std::cos,   CallCos,      -39000.0f,        +39000.0f, 1)
+DEFINE_F16_MATH_TEST(Tan,
+  std::tan,   CallTan,      -39000.0f,        +39000.0f, 1)
+DEFINE_F16_MATH_TEST(SinCosSin,
+  std::sin,   F16SinCosSin, -39000.0f,        +39000.0f, 1)
+DEFINE_F16_MATH_TEST(SinCosCos,
+  std::cos,   F16SinCosCos, -39000.0f,        +39000.0f, 1)
+// clang-format on
+
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
@@ -78,6 +110,11 @@ HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Log);
 HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Log10);
 HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Log1p);
 HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Log2);
+HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Sin);
+HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Cos);
+HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16Tan);
+HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16SinCosSin);
+HWY_EXPORT_AND_TEST_P(HwyF16MathTest, TestAllF16SinCosCos);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/contrib/math/math-inl.h
+++ b/hwy/contrib/math/math-inl.h
@@ -165,7 +165,7 @@ HWY_NOINLINE V CallCbrt(const D d, VecArg<V> x) {
  *      Valid Range: [-39000, +39000]
  * @return cosine of 'x'
  */
-template <class D, class V>
+template <class D, class V, HWY_IF_NOT_SPECIAL_FLOAT_D(D)>
 HWY_INLINE V Cos(D d, V x);
 template <class D, class V>
 HWY_NOINLINE V CallCos(const D d, VecArg<V> x) {
@@ -182,7 +182,7 @@ HWY_NOINLINE V CallCos(const D d, VecArg<V> x) {
  * ~300 ULP. Valid Range: [-39000, +39000]
  * @return tangent of 'x'
  */
-template <class D, class V>
+template <class D, class V, HWY_IF_NOT_SPECIAL_FLOAT_D(D)>
 HWY_INLINE V Tan(D d, V x);
 template <class D, class V>
 HWY_NOINLINE V CallTan(const D d, VecArg<V> x) {
@@ -317,7 +317,7 @@ HWY_NOINLINE V CallLog2(const D d, VecArg<V> x) {
  *      Valid Range: [-39000, +39000]
  * @return sine of 'x'
  */
-template <class D, class V>
+template <class D, class V, HWY_IF_NOT_SPECIAL_FLOAT_D(D)>
 HWY_INLINE V Sin(D d, V x);
 template <class D, class V>
 HWY_NOINLINE V CallSin(const D d, VecArg<V> x) {
@@ -408,7 +408,7 @@ HWY_NOINLINE V CallLogGamma(const D d, VecArg<V> x) {
  *        Max Error: ULP = 1
  *      Valid Range: [-39000, +39000]
  */
-template <class D, class V>
+template <class D, class V, HWY_IF_NOT_SPECIAL_FLOAT_D(D)>
 HWY_INLINE void SinCos(D d, V x, V& s, V& c);
 template <class D, class V>
 HWY_NOINLINE void CallSinCos(const D d, VecArg<V> x, V& s, V& c) {
@@ -2549,7 +2549,9 @@ HWY_INLINE V Cbrt(const D d, V x) {
   return y;
 }
 
-template <class D, class V>
+template <class D, class V,
+          hwy::EnableIf<
+              !hwy::IsSpecialFloat<hwy::HWY_NAMESPACE::TFromD<D>>()>*>
 HWY_INLINE V Cos(const D d, V x) {
   using T = TFromD<D>;
   impl::CosSinImpl<T> impl;
@@ -2837,7 +2839,9 @@ HWY_INLINE V Pow(D d, V a, V b) {
   return result;
 }
 
-template <class D, class V>
+template <class D, class V,
+          hwy::EnableIf<
+              !hwy::IsSpecialFloat<hwy::HWY_NAMESPACE::TFromD<D>>()>*>
 HWY_INLINE V Sin(const D d, V x) {
   using T = TFromD<D>;
   impl::CosSinImpl<T> impl;
@@ -2903,14 +2907,18 @@ HWY_INLINE V Tanh(const D d, V x) {
   return Xor(z, sign);  // Reapply the sign bit
 }
 
-template <class D, class V>
+template <class D, class V,
+          hwy::EnableIf<
+              !hwy::IsSpecialFloat<hwy::HWY_NAMESPACE::TFromD<D>>()>*>
 HWY_INLINE void SinCos(const D d, V x, V& s, V& c) {
   using T = TFromD<D>;
   impl::SinCosImpl<T> impl;
   impl.SinCos(d, x, s, c);
 }
 
-template <class D, class V>
+template <class D, class V,
+          hwy::EnableIf<
+              !hwy::IsSpecialFloat<hwy::HWY_NAMESPACE::TFromD<D>>()>*>
 HWY_INLINE V Tan(const D d, V x) {
   V s, c;
   SinCos(d, x, s, c);


### PR DESCRIPTION
Towards #2682, second PR of the series: adds `float16_t` overloads of `Sin`, `Cos`, `Tan` and `SinCos`. `SinCos` gets a two-output adapter; `Tan` calls the float32 `Tan` so the division happens in float32 rather than on demoted float16 sine/cosine.

As discussed in #3228, the adapter now promotes per half by default via `RepartitionToWide`, which keeps kPow2 and so always has exactly `Lanes(d) / 2` lanes; the MaxLanes-based predicate is gone. A single `Rebind` promotion remains only where per-half is impossible: single-lane tags, and fractional tags, whose `Rebind` is lane-exact and which cannot `Repartition` at kPow2 == -3 (same split as `IotaForSpecial`). Neither condition compares MaxLanes against a vector size, so both hold at every vector length; `HWY_DASSERT`s check the lane invariants.

The trig range is [-39000, +39000], mirroring the float32 kernels: beyond that the Cody-Waite reduction loses exactness without FMA (Cos reaches 8 ULP at x=54304). Over that range the exhaustive test measures 1 ULP for all four.