### PR TITLE
ops/scalar: avoid signed-overflow UB in ReorderWidenMulAccumulate (i16->i32)

### DIFF
--- a/hwy/ops/scalar-inl.h
+++ b/hwy/ops/scalar-inl.h
@@ -2130,7 +2130,11 @@ HWY_API Vec1<int32_t> ReorderWidenMulAccumulate(D32 /* tag */, Vec1<int16_t> a,
                                                 Vec1<int16_t> b,
                                                 const Vec1<int32_t> sum0,
                                                 Vec1<int32_t>& /* sum1 */) {
-  return Vec1<int32_t>(a.raw * b.raw + sum0.raw);
+  // Accumulate via unsigned to avoid signed-overflow UB when sum0 is near
+  // the int32 limits (the product a*b always fits in int32). This matches the
+  // uint16 overload below and the defined wraparound of the SIMD targets.
+  return Vec1<int32_t>(static_cast<int32_t>(
+      static_cast<uint32_t>(a.raw * b.raw) + static_cast<uint32_t>(sum0.raw)));
 }
 
 template <class DU32, HWY_IF_U32_D(DU32)>


### PR DESCRIPTION
## Problem

The scalar (`HWY_SCALAR`) `int16 -> int32` overload of
`ReorderWidenMulAccumulate` computed:

```cpp
return Vec1<int32_t>(a.raw * b.raw + sum0.raw);
```

`a.raw * b.raw` always fits in `int32` (`32767 * 32767 = 1073676289`), but the
`+ sum0.raw` term is evaluated in `int` and overflows when the accumulator is
near the `int32` limits — signed-integer-overflow UB. `sum0` is a
documented-valid input (`quick_reference` places no no-overflow precondition on
it), and a large accumulator arises naturally in an `int16` dot product / L2
norm once it saturates.

Building the existing `widen_mul_test` (or a small scalar harness) with UBSan
reports:

```
hwy/ops/scalar-inl.h: runtime error: signed integer overflow:
1073676289 + 2147483647 cannot be represented in type 'int'
```

Every other target already avoids this: the `uint16` overload immediately below
casts to `uint32_t`, and EMU128 accumulates via a `uint64`-based `Add`. The
scalar `int16` path is the lone UB outlier.

## Fix

Accumulate through the unsigned counterpart, matching the sibling `uint16`
overload and the defined wraparound of the SIMD targets:

```cpp
return Vec1<int32_t>(static_cast<int32_t>(
    static_cast<uint32_t>(a.raw * b.raw) + static_cast<uint32_t>(sum0.raw)));
```

No functional change: the result is the same two's-complement wrap the other
targets already produce (verified: `a = b = 32767, sum0 = INT32_MAX` yields
`-1073807360` on SCALAR, matching the wrap). This is the same UB class as the
previously-fixed `count-inl` int16 overflow.

## Testing

- The scalar harness that reproduced the UBSan error above now runs clean and
  returns the correct wrapped value.
- `widen_mul_test` and `dot_test` pass under `-fsanitize=address,undefined`
  across all targets (SCALAR, EMU128, and native x86).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
