### PR TITLE
Do not extend the EMU128 opt-out to GCC 14/15 on RISC-V

### DIFF
--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -409,8 +409,17 @@
 // remains with 13.2, see #1683. This is separate from HWY_BROKEN_TARGETS
 // because it affects the fallback target, which must always be enabled. If 1,
 // we instead choose HWY_SCALAR even without HWY_COMPILE_ONLY_SCALAR being set.
+// The extension of this opt-out to GCC 14 and 15 was prompted by Armv7
+// failures (#1683, #2622), both of which trace to
+// https://gcc.gnu.org/PR111231. RISC-V has no native SIMD baseline unless the
+// V extension is enabled, so there EMU128 is the only fallback able to provide
+// fixed-width tags: substituting HWY_SCALAR does not merely lose speed, it
+// makes FixedTag<T, N> with N > 1 fail to compile, which breaks downstream
+// users such as V8's JSON stringifier. Keep the older blanket GCC < 14 opt-out,
+// but do not extend it to RISC-V, where the bug has not been observed.
 #if !defined(HWY_BROKEN_EMU128)  // allow overriding
-#if (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1600) || \
+#if (HWY_COMPILER_GCC_ACTUAL &&                                   \
+     HWY_COMPILER_GCC_ACTUAL < (HWY_ARCH_RISCV ? 1400 : 1600)) || \
     defined(HWY_NO_LIBCXX)
 #define HWY_BROKEN_EMU128 1
 #else


### PR DESCRIPTION
## Problem

On RISC-V without the V extension there is no native SIMD target, so the fallback target is also the static target. HWY_BROKEN_EMU128 therefore selects HWY_SCALAR (HWY_LANES(T) == 1), and code using fixed-width tags fails to compile rather than running slower.

V8's JSON stringifier builds a FixedTag<uint8_t, 16> unconditionally, so Node.js cannot currently be built for riscv64 with GCC 15 — see [conda-forge/nodejs-feedstock#498](https://github.com/conda-forge/nodejs-feedstock/pull/498) for the downstream build failure.

The threshold was raised to GCC < 14 in 952590cc (#1683) and to GCC < 16 in f38ee257 (#2622). Both reports are Armv7, and both trace to https://gcc.gnu.org/PR111231.

## Change

Keep the blanket GCC < 14 opt-out; don't extend it to GCC 14/15 on RISC-V:

#if (HWY_COMPILER_GCC_ACTUAL &&                                   \
     HWY_COMPILER_GCC_ACTUAL < (HWY_ARCH_RISCV ? 1400 : 1600)) || \
    defined(HWY_NO_LIBCXX)

Only GCC 14/15 on RISC-V change; Armv7, x86, clang and HWY_NO_LIBCXX are unaffected.

## Testing

Native RISC-V hardware (SpacemiT, Bianbu 4.0), g++ 15.2.0, -march=rv64imafdc -mabi=lp64d:

before:  static target = HWY_SCALAR  HWY_LANES(uint8_t)=1
after:   static target = HWY_EMU128  HWY_LANES(uint8_t)=16

All 62 test TUs pass with EMU128 (pass=62 fail=0 buildfail=0), including the tests that fail on Armv7 in #2622 — TestAllPromoteOddEvenTo, TestAllSatWidenMulPairwiseAdd, TestAllSumsOf2, TestAllSumsOf4. The bug does not reproduce on RISC-V.
