### PR TITLE
contrib/image: guard the padding add and round-up in BytesPerRow

### DIFF
--- a/hwy/contrib/image/image.cc
+++ b/hwy/contrib/image/image.cc
@@ -46,11 +46,24 @@ size_t ImageBase::BytesPerRow(const size_t xsize, const size_t sizeof_t) {
   // Skip for the scalar case because no extra lanes will be loaded.
   if (vec_size != 1) {
     HWY_DASSERT(vec_size >= sizeof_t);
-    valid_bytes += vec_size - sizeof_t;
+    const size_t pad = vec_size - sizeof_t;
+    // The multiply guard above permits valid_bytes up to SIZE_MAX, so the
+    // padding add can wrap; guard it like the multiply.
+    if (valid_bytes > SIZE_MAX - pad) {
+      HWY_ABORT("ImageBase::BytesPerRow overflow: xsize=%zu, sizeof_t=%zu",
+                xsize, sizeof_t);
+    }
+    valid_bytes += pad;
   }
 
   // Round up to vector and cache line size.
   const size_t align = HWY_MAX(vec_size, HWY_ALIGNMENT);
+  // RoundUpTo rounds up by < align, and the Avoid2K adjustment below may add
+  // another `align`; reserve slack so neither multiply/add wraps size_t.
+  if (valid_bytes > SIZE_MAX - 2 * align) {
+    HWY_ABORT("ImageBase::BytesPerRow overflow: xsize=%zu, sizeof_t=%zu",
+              xsize, sizeof_t);
+  }
   size_t bytes_per_row = RoundUpTo(valid_bytes, align);
 
   // During the lengthy window before writes are committed to memory, CPUs


### PR DESCRIPTION
## Problem

`ImageBase::BytesPerRow` guards the `xsize * sizeof_t` multiply, but that guard permits a product up to `SIZE_MAX`:

```cpp
if (HWY_LIKELY(xsize != 0) && sizeof_t > SIZE_MAX / xsize) { HWY_ABORT(...); }
size_t valid_bytes = xsize * sizeof_t;             // may be as large as SIZE_MAX
if (vec_size != 1) { valid_bytes += vec_size - sizeof_t; }   // can wrap
const size_t align = HWY_MAX(vec_size, HWY_ALIGNMENT);
size_t bytes_per_row = RoundUpTo(valid_bytes, align);        // DivCeil * align, can wrap
```

The two later computations are unguarded, so an `xsize` within a few of `SIZE_MAX` silently wraps to a tiny row. `ImageBase::BytesPerRow(SIZE_MAX, 1)` returns **256** instead of aborting. Because `BytesPerRow` is public (documented for laying out externally-allocated memory) and drives the allocation size in the `Image` constructor — where on 32-bit/ILP32 targets the ctor's `xsize <= UINT32_MAX` assert is a tautology — a caller can end up with an under-sized allocation and `MutableRow` writes then overflow it.

## Fix

Guard the padding add, and reserve `2 * align` of slack before the round-up (covering both `RoundUpTo` and the subsequent Avoid2K `+= align`), aborting with the same message as the existing multiply guard. This is the same overflow-guard hardening as #3143 (DivCeil) and #3164, applied to the remaining unguarded size computations in this function. No behavior change for in-range sizes.

## Testing

Built against the contrib libs:
- Before: `BytesPerRow(100, 4) = 640`; `BytesPerRow(SIZE_MAX, 1) = 256` (no abort).
- After: `BytesPerRow(100, 4) = 640` (unchanged); `BytesPerRow(SIZE_MAX, 1)` aborts with `ImageBase::BytesPerRow overflow`.
- `image_test`: 16/16 pass.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
