### PR TITLE
LoongArch native CeilInt/FloorInt

### DIFF
--- a/hwy/ops/loongarch_lasx-inl.h
+++ b/hwy/ops/loongarch_lasx-inl.h
@@ -3832,6 +3832,24 @@ HWY_API VFromD<DU> ConvertTo(DU /*du*/, VFromD<RebindToFloat<DU>> v) {
   return VFromD<DU>{__lasx_xvftintrz_lu_d(v.raw)};
 }
 
+// ------------------------------ CeilInt/FloorInt
+
+HWY_API Vec256<int32_t> CeilInt(const Vec256<float> v) {
+  return Vec256<int32_t>{__lasx_xvftintrp_w_s(v.raw)};
+}
+
+HWY_API Vec256<int64_t> CeilInt(const Vec256<double> v) {
+  return Vec256<int64_t>{__lasx_xvftintrp_l_d(v.raw)};
+}
+
+HWY_API Vec256<int32_t> FloorInt(const Vec256<float> v) {
+  return Vec256<int32_t>{__lasx_xvftintrm_w_s(v.raw)};
+}
+
+HWY_API Vec256<int64_t> FloorInt(const Vec256<double> v) {
+  return Vec256<int64_t>{__lasx_xvftintrm_l_d(v.raw)};
+}
+
 template <typename T, HWY_IF_FLOAT3264(T)>
 HWY_API Vec256<MakeSigned<T>> NearestInt(const Vec256<T> v) {
   return ConvertTo(Full256<MakeSigned<T>>(), Round(v));

--- a/hwy/ops/loongarch_lsx-inl.h
+++ b/hwy/ops/loongarch_lsx-inl.h
@@ -5016,6 +5016,37 @@ HWY_API VFromD<D> ConvertTo(D /* tag */, VFromD<Rebind<double, D>> v) {
   return VFromD<D>{__lsx_vftintrz_lu_d(v.raw)};
 }
 
+// ------------------------------ CeilInt/FloorInt
+
+// loongarch_lasx-inl.h includes this header and defines its own 256-bit
+// overloads, so leave the HWY_NATIVE_CEIL_FLOOR_INT toggle unguarded for LASX
+// to inherit.
+#ifdef HWY_NATIVE_CEIL_FLOOR_INT
+#undef HWY_NATIVE_CEIL_FLOOR_INT
+#else
+#define HWY_NATIVE_CEIL_FLOOR_INT
+#endif
+
+template <size_t N>
+HWY_API Vec128<int32_t, N> CeilInt(const Vec128<float, N> v) {
+  return Vec128<int32_t, N>{__lsx_vftintrp_w_s(v.raw)};
+}
+
+template <size_t N>
+HWY_API Vec128<int64_t, N> CeilInt(const Vec128<double, N> v) {
+  return Vec128<int64_t, N>{__lsx_vftintrp_l_d(v.raw)};
+}
+
+template <size_t N>
+HWY_API Vec128<int32_t, N> FloorInt(const Vec128<float, N> v) {
+  return Vec128<int32_t, N>{__lsx_vftintrm_w_s(v.raw)};
+}
+
+template <size_t N>
+HWY_API Vec128<int64_t, N> FloorInt(const Vec128<double, N> v) {
+  return Vec128<int64_t, N>{__lsx_vftintrm_l_d(v.raw)};
+}
+
 // ------------------------------ NearestInt (Round)
 
 template <size_t N>


### PR DESCRIPTION
Adding the LSX and LASX overrides for `CeilInt`/`FloorInt`