### PR TITLE
Gate workaround for compiler bug in hn::Min on arm_sve to clang19 and earlier.

### DIFF
--- a/hwy/ops/arm_sve-inl.h
+++ b/hwy/ops/arm_sve-inl.h
@@ -2062,7 +2062,7 @@ HWY_SVE_FOREACH_UI(HWY_SVE_RETV_ARGPVV, Max, max)
 HWY_SVE_FOREACH_F(HWY_SVE_RETV_ARGPVV, Max, maxnm)
 
 // Workaround for incorrect results with `svmin`.
-#if HWY_COMPILER_CLANG
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 2000
 template <class V, HWY_IF_SIGNED_V(V)>
 HWY_API V Min(V a, V b) {
   return IfThenElse(Lt(a, b), a, b);


### PR DESCRIPTION
Per #3336. Same change #3307 made for `hn::Abs`.

Both of these came in together in #2537 ("workaround for Abs and Min") for the same clang19 SVE bug, so gating them the same way seemed like the obvious follow up.

Full ctest suite on aarch64 SVE2-128, clang 24.0.0git, `HWY_COMPILER_CLANG=2400`, built with `--no-default-config`. 3388 tests, 100% passed, 0 failed, both with the workaround and with it gated. 1375 SVE-target cases pass either way.

The two builds do differ (`sort_test` md5 fa7266d6 vs ecc67d1d) so the gate is reaching codegen and this isnt a no-op. In a standalone vqsort binary the census goes from `fminnm=0 fcmne=1262 sel=3390` to `fminnm=1214 fcmne=48 sel=215`, and the gated `fminnm` count matches `fmaxnm` exactly at 1214, which is what youd expect once Min and Max are symmetric again.

For the timing, VQSort on 2M keys, one Cortex-X925 core (NVIDIA GB10, SVE2-128), 12 passes with the arm order rotated, 15 reps each, medians. I built gcc 13.3.0 from the same tree as a reference since it takes the `#else` branch either way.

```
type   clang today   clang gated      gcc     gate buys   vs gcc after
f64      33.17 ms      26.79 ms    25.21 ms     +23.8 %       +6.2 %
f32      18.81 ms      13.46 ms    13.41 ms     +39.7 %       +0.4 %
i64      26.74 ms      25.91 ms    24.25 ms      +3.2 %       +6.9 %
i32      13.69 ms      12.93 ms    12.94 ms      +5.9 %       -0.1 %
```

The gate wins 12/12 passes on every type, sign test p=0.0005. A/A floor on this rig (same binary under three labels in the same rotated schedule) is 0.32 to 1.35 %, so the f64 and i64 residuals are real and the i32 one isnt.

It closes most of llvm/llvm-project#214554 but not all of it. f32 and i32 end up level with gcc, f64 and i64 keep about 6 to 7 % at 12/12. That issue should stay open, just much smaller than it was filed as.

I havent reproduced whatever the original clang19 failure was, so the green suite here is consistent with it being fixed but isnt proof it was the same bug as the Abs one.
