### PR TITLE
Add portable interleaved range coder to hwy/contrib/coder

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -482,6 +482,24 @@ cc_library(
 )
 
 cc_library(
+    name = "range_coder",
+    srcs = [
+        "hwy/contrib/coder/range_coder.cc",
+    ],
+    hdrs = [
+        "hwy/contrib/coder/range_coder.h",
+    ],
+    compatible_with = [],
+    copts = COPTS,
+    textual_hdrs = [
+        "hwy/contrib/coder/range_coder-inl.h",
+    ],
+    deps = [
+        ":hwy",
+    ],
+)
+
+cc_library(
     name = "phast",
     srcs = [
         "hwy/contrib/hash/phast.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,9 @@ file(GLOB HWY_CONTRIB_SOURCES "hwy/contrib/sort/vqsort_*.cc")
 list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/base64/base64-inl.h
     hwy/contrib/bit_pack/bit_pack-inl.h
+    hwy/contrib/coder/range_coder.cc
+    hwy/contrib/coder/range_coder.h
+    hwy/contrib/coder/range_coder-inl.h
     hwy/contrib/dot/dot-inl.h
     hwy/contrib/hash/hash-inl.h
     hwy/contrib/hash/highwayhash-inl.h
@@ -1036,6 +1039,7 @@ list(APPEND HWY_TEST_FILES
   hwy/contrib/algo/minmax_value_test.cc
   hwy/contrib/algo/transform_test.cc
   hwy/contrib/bit_pack/bit_pack_test.cc
+  hwy/contrib/coder/range_coder_test.cc
   hwy/contrib/dot/dot_test.cc
   hwy/contrib/hash/cuckoo2x2_test.cc
   hwy/contrib/hash/hash_test.cc

--- a/g3doc/op_wishlist.md
+++ b/g3doc/op_wishlist.md
@@ -44,10 +44,6 @@ fmod, ilogb, logb, modf, nextafter, nexttoward, scalbn
 *   ShuffleSpan
 *   Reduce
 
-### Range coder
-
-Port https://github.com/richgel999/sserangecoding to Highway (~50 instructions).
-
 ### Iguana (fast LZ + ANS)
 
 Port https://github.com/SnellerInc/sneller/tree/master/ion/zion/iguana

--- a/hwy/contrib/coder/range_coder-inl.h
+++ b/hwy/contrib/coder/range_coder-inl.h
@@ -17,9 +17,14 @@
 // target, decoding the bitstream produced by hwy::EncodeInterleaved (see
 // range_coder.h). Ported from Richard Geldreich's public-domain
 // "sserangecoding" (https://github.com/richgel999/sserangecoding); the SSE4.1
-// kernel worked on four u32 lanes at a time, and this keeps that shape
-// (CappedTag<uint32_t, 4>), so the 16 interleaved streams are decoded as four
-// groups of four lanes.
+// kernel worked on four u32 lanes at a time, and this keeps that shape: the 16
+// interleaved streams are four groups of four lanes, held in four vector
+// locals and driven from an unrolled loop. The 4-lane vector is FixedTag, so
+// the same kernel runs on RVV and SVE (masked to four lanes) as well as the
+// fixed-size targets; only HWY_SCALAR, which cannot form a 4-lane vector, uses
+// the scalar reference decoder. Widening the group to Lanes(d) would need the
+// renormalization step (below) to be reworked away from its 4-lane pshufb
+// tables; that is a possible follow-up.
 //
 // The float divide for value/range is exact because `value` is always <= 24
 // bits and `range` <= 12 bits; ConvertTo truncates toward zero, as suggested by
@@ -46,12 +51,10 @@ namespace hwy {
 namespace HWY_NAMESPACE {
 namespace range_coder {
 
-// The kernel keeps four u32 lanes in local variables and drives them from a
-// small loop, which needs a fixed-size (non-sizeless) 4-lane vector. That rules
-// out HWY_SCALAR (1 lane) and the scalable targets (RVV, SVE), whose vector
-// types cannot be array elements. Those get the scalar reference decoder, which
-// produces identical output; a scalable kernel is a possible follow-up.
-#if HWY_TARGET == HWY_SCALAR || HWY_HAVE_SCALABLE || HWY_TARGET_IS_SVE
+// HWY_SCALAR has a single lane and cannot form the 4-lane vector the kernel
+// needs, so it decodes with the scalar reference implementation, which produces
+// identical output.
+#if HWY_TARGET == HWY_SCALAR
 
 HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src,
                                   size_t comp_size, uint8_t* HWY_RESTRICT dst,
@@ -64,23 +67,13 @@ HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src,
 
 namespace detail {
 
-HWY_INLINE uint32_t ReadBE24(const uint8_t*& src) {
-  const uint32_t res = (static_cast<uint32_t>(src[0]) << 16) |
-                       (static_cast<uint32_t>(src[1]) << 8) |
-                       static_cast<uint32_t>(src[2]);
-  src += 3;
-  return res;
-}
-
 // Decodes one symbol per lane (4 total), writing the 4 symbol bytes to `out4`.
 template <class D>
 HWY_INLINE void Decode(D d, VFromD<D>& value, VFromD<D>& length,
                        const uint32_t* HWY_RESTRICT table,
-                       VFromD<Repartition<uint8_t, D> > pack_idx,
                        uint8_t* HWY_RESTRICT out4) {
   const RebindToSigned<D> di;
   const RebindToFloat<D> df;
-  const Repartition<uint8_t, D> d8;
 
   const VFromD<D> r = ShiftRight<kRangeProbBits>(length);
   const VFromD<D> q =
@@ -90,10 +83,8 @@ HWY_INLINE void Decode(D d, VFromD<D>& value, VFromD<D>& length,
 
   const VFromD<D> e = GatherIndex(d, table, BitCast(di, q));
 
-  // Byte 0 of each u32 lane -> low 4 bytes.
-  HWY_ALIGN uint8_t sym_bytes[16];
-  Store(TableLookupBytesOr0(BitCast(d8, e), pack_idx), d8, sym_bytes);
-  memcpy(out4, sym_bytes, 4);
+  // Byte 0 of each u32 lane is the symbol; keep the low byte of each lane.
+  TruncateStore(e, d, out4);
 
   const VFromD<D> low_prob = And(ShiftRight<8>(e), Set(d, kRangeProbScale - 1));
   const VFromD<D> prob_range = ShiftRight<20>(e);  // 8 + kRangeProbBits
@@ -137,39 +128,55 @@ HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src_start,
                                   uint8_t* HWY_RESTRICT dst_start,
                                   size_t orig_size,
                                   const uint32_t* HWY_RESTRICT table) {
-  // CappedTag gives exactly 4 lanes on every fixed-size target.
-  const CappedTag<uint32_t, 4> d;
-  const Repartition<uint8_t, decltype(d)> d8;
+  // 16 big-endian 24-bit words = 48 header bytes precede the renorm stream.
+  if (comp_size < kRangeLanes * 3u) return false;
 
-  // Gathers byte 0 of each u32 lane into the low 4 bytes (rest zeroed).
-  const VFromD<decltype(d8)> pack_idx =
-      Dup128VecFromValues(d8, 0, 4, 8, 12, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
-                          0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
+  // FixedTag: exactly 4 u32 lanes on every target, including RVV/SVE.
+  const FixedTag<uint32_t, 4> d;
+  const Repartition<uint8_t, decltype(d)> d8;
 
   const RangeShuffleTables& sh = GetRangeShuffleTables();
 
-  const uint8_t* src = src_start;
+  const uint8_t* src = src_start + kRangeLanes * 3u;
   const uint8_t* const src_end = src_start + comp_size;
 
-  VFromD<decltype(d)> value[4];
-  VFromD<decltype(d)> length[4];
-  for (int g = 0; g < 4; ++g) {
-    HWY_ALIGN uint32_t v4[4];
-    for (int l = 0; l < 4; ++l) v4[l] = detail::ReadBE24(src);
-    value[g] = Load(d, v4);
-    length[g] = Set(d, kRangeMaxLen);
-  }
+  // Load the four groups' initial `value` words from a zero-padded copy of the
+  // 48-byte header, one 16-byte load + shuffle per group (the last group's
+  // load would otherwise reach 4 bytes past the header). Each big-endian 24-bit
+  // word b0 b1 b2 becomes the u32 (b0 << 16) | (b1 << 8) | b2.
+  HWY_ALIGN uint8_t hdr[64];
+  memset(hdr, 0, sizeof(hdr));
+  memcpy(hdr, src_start, kRangeLanes * 3u);
+  const VFromD<decltype(d8)> be24 = Dup128VecFromValues(
+      d8, 2, 1, 0, 0x80, 5, 4, 3, 0x80, 8, 7, 6, 0x80, 11, 10, 9, 0x80);
+
+  VFromD<decltype(d)> value0 =
+      BitCast(d, TableLookupBytesOr0(LoadU(d8, hdr + 0), be24));
+  VFromD<decltype(d)> value1 =
+      BitCast(d, TableLookupBytesOr0(LoadU(d8, hdr + 12), be24));
+  VFromD<decltype(d)> value2 =
+      BitCast(d, TableLookupBytesOr0(LoadU(d8, hdr + 24), be24));
+  VFromD<decltype(d)> value3 =
+      BitCast(d, TableLookupBytesOr0(LoadU(d8, hdr + 36), be24));
+
+  const VFromD<decltype(d)> full = Set(d, kRangeMaxLen);
+  VFromD<decltype(d)> length0 = full;
+  VFromD<decltype(d)> length1 = full;
+  VFromD<decltype(d)> length2 = full;
+  VFromD<decltype(d)> length3 = full;
 
   size_t dst_ofs = 0;
   for (; dst_ofs + kRangeLanes <= orig_size && src + 32 <= src_end;
        dst_ofs += kRangeLanes) {
-    for (int g = 0; g < 4; ++g) {
-      detail::Decode(d, value[g], length[g], table, pack_idx,
-                     dst_start + dst_ofs + g * 4);
-    }
-    for (int g = 0; g < 4; ++g) {
-      detail::Normalize(d, value[g], length[g], src, sh);
-    }
+    uint8_t* const out = dst_start + dst_ofs;
+    detail::Decode(d, value0, length0, table, out + 0);
+    detail::Decode(d, value1, length1, table, out + 4);
+    detail::Decode(d, value2, length2, table, out + 8);
+    detail::Decode(d, value3, length3, table, out + 12);
+    detail::Normalize(d, value0, length0, src, sh);
+    detail::Normalize(d, value1, length1, src, sh);
+    detail::Normalize(d, value2, length2, src, sh);
+    detail::Normalize(d, value3, length3, src, sh);
   }
 
   // Scalar tail. The vector loop stopped within 32 bytes of the end (or ran out
@@ -184,10 +191,14 @@ HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src_start,
 
   HWY_ALIGN uint32_t vals[kRangeLanes];
   HWY_ALIGN uint32_t lens[kRangeLanes];
-  for (int g = 0; g < 4; ++g) {
-    Store(value[g], d, vals + g * 4);
-    Store(length[g], d, lens + g * 4);
-  }
+  Store(value0, d, vals + 0);
+  Store(value1, d, vals + 4);
+  Store(value2, d, vals + 8);
+  Store(value3, d, vals + 12);
+  Store(length0, d, lens + 0);
+  Store(length1, d, lens + 4);
+  Store(length2, d, lens + 8);
+  Store(length3, d, lens + 12);
 
   RangeDecoder dec;
   for (; dst_ofs < orig_size; ++dst_ofs) {
@@ -203,7 +214,7 @@ HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src_start,
   return static_cast<size_t>(tp - tail) <= tail_avail;
 }
 
-#endif  // scalar / scalable fallback
+#endif  // scalar fallback
 
 }  // namespace range_coder
 }  // namespace HWY_NAMESPACE

--- a/hwy/contrib/coder/range_coder-inl.h
+++ b/hwy/contrib/coder/range_coder-inl.h
@@ -19,7 +19,7 @@
 // "sserangecoding" (https://github.com/richgel999/sserangecoding); the SSE4.1
 // kernel worked on four u32 lanes at a time, and this keeps that shape: the 16
 // interleaved streams are four groups of four lanes, held in four vector
-// locals and driven from an unrolled loop. The 4-lane vector is FixedTag, so
+// locals and driven from an unrolled loop. The 4-lane vector is Full128, so
 // the same kernel runs on RVV and SVE (masked to four lanes) as well as the
 // fixed-size targets; only HWY_SCALAR, which cannot form a 4-lane vector, uses
 // the scalar reference decoder. Widening the group to Lanes(d) would need the
@@ -131,8 +131,8 @@ HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src_start,
   // 16 big-endian 24-bit words = 48 header bytes precede the renorm stream.
   if (comp_size < kRangeLanes * 3u) return false;
 
-  // FixedTag: exactly 4 u32 lanes on every target, including RVV/SVE.
-  const FixedTag<uint32_t, 4> d;
+  // Exactly 128 bits / 4 u32 lanes on every target, including RVV/SVE.
+  const Full128<uint32_t> d;
   const Repartition<uint8_t, decltype(d)> d8;
 
   const RangeShuffleTables& sh = GetRangeShuffleTables();

--- a/hwy/contrib/coder/range_coder-inl.h
+++ b/hwy/contrib/coder/range_coder-inl.h
@@ -100,8 +100,13 @@ HWY_INLINE void Normalize(D d, VFromD<D>& value, VFromD<D>& length,
                           const uint8_t*& src, const RangeShuffleTables& sh) {
   const Repartition<uint8_t, D> d8;
 
-  const uint64_t b0 = BitsFromMask(d, Lt(length, Set(d, kRangeMinLen)));
-  const uint64_t b1 = BitsFromMask(d, Lt(length, Set(d, uint32_t{256})));
+  // StoreMaskBits (not BitsFromMask, which RVV lacks) writes the 4-lane mask
+  // into the low nibble of one byte.
+  uint8_t mb[8];
+  StoreMaskBits(d, Lt(length, Set(d, kRangeMinLen)), mb);
+  const unsigned b0 = mb[0];
+  StoreMaskBits(d, Lt(length, Set(d, uint32_t{256})), mb);
+  const unsigned b1 = mb[0];
   const size_t msk = static_cast<size_t>(b0 | (b1 << 4));
 
   HWY_ALIGN uint8_t sb[16];

--- a/hwy/contrib/coder/range_coder-inl.h
+++ b/hwy/contrib/coder/range_coder-inl.h
@@ -1,0 +1,213 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SIMD interleaved range decoder. A single source that runs on every Highway
+// target, decoding the bitstream produced by hwy::EncodeInterleaved (see
+// range_coder.h). Ported from Richard Geldreich's public-domain
+// "sserangecoding" (https://github.com/richgel999/sserangecoding); the SSE4.1
+// kernel worked on four u32 lanes at a time, and this keeps that shape
+// (CappedTag<uint32_t, 4>), so the 16 interleaved streams are decoded as four
+// groups of four lanes.
+//
+// The float divide for value/range is exact because `value` is always <= 24
+// bits and `range` <= 12 bits; ConvertTo truncates toward zero, as suggested by
+// Jan Wassenberg for the original.
+
+// Include guard (still compiled once per target)
+#if defined(HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_INL_H_) == \
+    defined(HWY_TARGET_TOGGLE)
+#ifdef HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_INL_H_
+#undef HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_INL_H_
+#else
+#define HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_INL_H_
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>  // memcpy, memset
+
+#include "hwy/contrib/coder/range_coder.h"
+#include "hwy/highway.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+namespace range_coder {
+
+// The kernel keeps four u32 lanes in local variables and drives them from a
+// small loop, which needs a fixed-size (non-sizeless) 4-lane vector. That rules
+// out HWY_SCALAR (1 lane) and the scalable targets (RVV, SVE), whose vector
+// types cannot be array elements. Those get the scalar reference decoder, which
+// produces identical output; a scalable kernel is a possible follow-up.
+#if HWY_TARGET == HWY_SCALAR || HWY_HAVE_SCALABLE || HWY_TARGET_IS_SVE
+
+HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src,
+                                  size_t comp_size, uint8_t* HWY_RESTRICT dst,
+                                  size_t orig_size,
+                                  const uint32_t* HWY_RESTRICT table) {
+  return DecodeInterleavedScalar(src, comp_size, dst, orig_size, table);
+}
+
+#else
+
+namespace detail {
+
+HWY_INLINE uint32_t ReadBE24(const uint8_t*& src) {
+  const uint32_t res = (static_cast<uint32_t>(src[0]) << 16) |
+                       (static_cast<uint32_t>(src[1]) << 8) |
+                       static_cast<uint32_t>(src[2]);
+  src += 3;
+  return res;
+}
+
+// Decodes one symbol per lane (4 total), writing the 4 symbol bytes to `out4`.
+template <class D>
+HWY_INLINE void Decode(D d, VFromD<D>& value, VFromD<D>& length,
+                       const uint32_t* HWY_RESTRICT table,
+                       VFromD<Repartition<uint8_t, D> > pack_idx,
+                       uint8_t* HWY_RESTRICT out4) {
+  const RebindToSigned<D> di;
+  const RebindToFloat<D> df;
+  const Repartition<uint8_t, D> d8;
+
+  const VFromD<D> r = ShiftRight<kRangeProbBits>(length);
+  const VFromD<D> q =
+      And(BitCast(d, ConvertTo(di, Div(ConvertTo(df, BitCast(di, value)),
+                                       ConvertTo(df, BitCast(di, r))))),
+          Set(d, kRangeProbScale - 1));
+
+  const VFromD<D> e = GatherIndex(d, table, BitCast(di, q));
+
+  // Byte 0 of each u32 lane -> low 4 bytes.
+  HWY_ALIGN uint8_t sym_bytes[16];
+  Store(TableLookupBytesOr0(BitCast(d8, e), pack_idx), d8, sym_bytes);
+  memcpy(out4, sym_bytes, 4);
+
+  const VFromD<D> low_prob = And(ShiftRight<8>(e), Set(d, kRangeProbScale - 1));
+  const VFromD<D> prob_range = ShiftRight<20>(e);  // 8 + kRangeProbBits
+
+  value = Sub(value, Mul(low_prob, r));
+  length = Mul(prob_range, r);
+}
+
+// Renormalizes 4 lanes, consuming up to 2 bytes per lane (<= 8 total) from
+// `src`.
+template <class D>
+HWY_INLINE void Normalize(D d, VFromD<D>& value, VFromD<D>& length,
+                          const uint8_t*& src, const RangeShuffleTables& sh) {
+  const Repartition<uint8_t, D> d8;
+
+  const uint64_t b0 = BitsFromMask(d, Lt(length, Set(d, kRangeMinLen)));
+  const uint64_t b1 = BitsFromMask(d, Lt(length, Set(d, uint32_t{256})));
+  const size_t msk = static_cast<size_t>(b0 | (b1 << 4));
+
+  HWY_ALIGN uint8_t sb[16];
+  memset(sb, 0, sizeof(sb));
+  memcpy(sb, src, 8);
+
+  const VFromD<decltype(d8)> shift = LoadU(d8, sh.shift[msk]);
+  const VFromD<decltype(d8)> dist = LoadU(d8, sh.dist[msk]);
+
+  value = BitCast(d, Or(TableLookupBytesOr0(BitCast(d8, value), shift),
+                        TableLookupBytesOr0(LoadU(d8, sb), dist)));
+  length = BitCast(d, TableLookupBytesOr0(BitCast(d8, length), shift));
+
+  src += sh.num_bytes[msk];
+}
+
+}  // namespace detail
+
+// Decodes data produced by hwy::EncodeInterleaved. `table` is from
+// hwy::BuildDecodeTable. Returns false if the input is truncated. Output is
+// identical to hwy::DecodeInterleavedScalar.
+HWY_INLINE bool DecodeInterleaved(const uint8_t* HWY_RESTRICT src_start,
+                                  size_t comp_size,
+                                  uint8_t* HWY_RESTRICT dst_start,
+                                  size_t orig_size,
+                                  const uint32_t* HWY_RESTRICT table) {
+  // CappedTag gives exactly 4 lanes on every fixed-size target.
+  const CappedTag<uint32_t, 4> d;
+  const Repartition<uint8_t, decltype(d)> d8;
+
+  // Gathers byte 0 of each u32 lane into the low 4 bytes (rest zeroed).
+  const VFromD<decltype(d8)> pack_idx =
+      Dup128VecFromValues(d8, 0, 4, 8, 12, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+                          0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
+
+  const RangeShuffleTables& sh = GetRangeShuffleTables();
+
+  const uint8_t* src = src_start;
+  const uint8_t* const src_end = src_start + comp_size;
+
+  VFromD<decltype(d)> value[4];
+  VFromD<decltype(d)> length[4];
+  for (int g = 0; g < 4; ++g) {
+    HWY_ALIGN uint32_t v4[4];
+    for (int l = 0; l < 4; ++l) v4[l] = detail::ReadBE24(src);
+    value[g] = Load(d, v4);
+    length[g] = Set(d, kRangeMaxLen);
+  }
+
+  size_t dst_ofs = 0;
+  for (; dst_ofs + kRangeLanes <= orig_size && src + 32 <= src_end;
+       dst_ofs += kRangeLanes) {
+    for (int g = 0; g < 4; ++g) {
+      detail::Decode(d, value[g], length[g], table, pack_idx,
+                     dst_start + dst_ofs + g * 4);
+    }
+    for (int g = 0; g < 4; ++g) {
+      detail::Normalize(d, value[g], length[g], src, sh);
+    }
+  }
+
+  // Scalar tail. The vector loop stopped within 32 bytes of the end (or ran out
+  // of output), so the remaining input is tiny; copy it into a zero-padded
+  // buffer to keep every read in bounds, then finish byte-by-byte.
+  const size_t tail_avail = static_cast<size_t>(src_end - src);
+  uint8_t tail[64];
+  memset(tail, 0, sizeof(tail));
+  if (tail_avail > sizeof(tail)) return false;  // unreachable for valid input
+  memcpy(tail, src, tail_avail);
+  const uint8_t* tp = tail;
+
+  HWY_ALIGN uint32_t vals[kRangeLanes];
+  HWY_ALIGN uint32_t lens[kRangeLanes];
+  for (int g = 0; g < 4; ++g) {
+    Store(value[g], d, vals + g * 4);
+    Store(length[g], d, lens + g * 4);
+  }
+
+  RangeDecoder dec;
+  for (; dst_ofs < orig_size; ++dst_ofs) {
+    const uint32_t s = static_cast<uint32_t>(dst_ofs) & kRangeLaneMask;
+    dec.length_ = lens[s];
+    dec.value_ = vals[s];
+    dst_start[dst_ofs] = static_cast<uint8_t>(dec.DecodeSymbol(table, tp));
+    lens[s] = dec.length_;
+    vals[s] = dec.value_;
+  }
+
+  // A valid stream consumes no more than the bytes it actually contains.
+  return static_cast<size_t>(tp - tail) <= tail_avail;
+}
+
+#endif  // scalar / scalable fallback
+
+}  // namespace range_coder
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#endif  // include guard

--- a/hwy/contrib/coder/range_coder.cc
+++ b/hwy/contrib/coder/range_coder.cc
@@ -1,0 +1,296 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hwy/contrib/coder/range_coder.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>  // memcpy
+
+#include <vector>
+
+#include "hwy/base.h"  // HWY_DASSERT
+
+namespace hwy {
+
+namespace {
+
+uint32_t ClampU32(uint32_t v, uint32_t lo, uint32_t hi) {
+  return v < lo ? lo : (v > hi ? hi : v);
+}
+
+uint32_t ReadBE24(const uint8_t*& src) {
+  const uint32_t res = (static_cast<uint32_t>(src[0]) << 16) |
+                       (static_cast<uint32_t>(src[1]) << 8) |
+                       static_cast<uint32_t>(src[2]);
+  src += 3;
+  return res;
+}
+
+}  // namespace
+
+bool CreateCumulativeProbs(std::vector<uint32_t>& scaled_cum_prob,
+                           std::vector<uint32_t>& freq) {
+  const uint32_t num_syms = static_cast<uint32_t>(freq.size());
+  if (num_syms < kRangeMinSyms || num_syms > kRangeMaxSyms) return false;
+
+  uint64_t total_freq = 0;
+  uint32_t total_used_syms = 0;
+  for (uint32_t i = 0; i < num_syms; ++i) {
+    total_freq += freq[i];
+    if (freq[i]) ++total_used_syms;
+  }
+  if (total_used_syms == 0) return false;
+
+  // The coder needs at least two live symbols; synthesize a second one.
+  if (total_used_syms == 1) {
+    for (uint32_t i = 0; i < num_syms; ++i) {
+      if (!freq[i]) {
+        freq[i]++;
+        total_freq++;
+        break;
+      }
+    }
+    total_used_syms++;
+  }
+
+  scaled_cum_prob.resize(num_syms + 1);
+
+  uint32_t sym_index_to_boost = 0, boost_amount = 0;
+
+  // Lower the effective scale until no live symbol rounds to a frequency of 0
+  // (those get bumped to 1, which could overshoot the total).
+  uint32_t adjusted_prob_scale = kRangeProbScale;
+  for (;;) {
+    uint32_t num_truncated_syms = 0;
+    for (uint32_t i = 0; i < num_syms; ++i) {
+      if (freq[i]) {
+        const uint32_t l = static_cast<uint32_t>(
+            (static_cast<uint64_t>(freq[i]) * adjusted_prob_scale) /
+            total_freq);
+        if (!l) ++num_truncated_syms;
+      }
+    }
+    if (!num_truncated_syms) break;
+
+    const uint32_t new_scale = kRangeProbScale - num_truncated_syms;
+    if (new_scale == adjusted_prob_scale) break;
+    adjusted_prob_scale = new_scale;
+  }
+
+  for (uint32_t pass = 0; pass < 2; ++pass) {
+    uint32_t most_prob_sym_freq = 0, most_prob_sym_index = 0;
+
+    uint32_t ci = 0;
+    for (uint32_t i = 0; i < num_syms; ++i) {
+      scaled_cum_prob[i] = ci;
+      if (!freq[i]) continue;
+
+      if (freq[i] > most_prob_sym_freq) {
+        most_prob_sym_freq = freq[i];
+        most_prob_sym_index = i;
+      }
+
+      uint32_t l = static_cast<uint32_t>(
+          (static_cast<uint64_t>(freq[i]) * adjusted_prob_scale) / total_freq);
+      l = ClampU32(l, 1, kRangeProbScale - (total_used_syms - 1));
+
+      if (pass && i == sym_index_to_boost) l += boost_amount;
+
+      ci += l;
+      if (ci > kRangeProbScale) return false;
+    }
+    scaled_cum_prob[num_syms] = kRangeProbScale;
+
+    if (ci == kRangeProbScale) break;
+    if (pass) return false;  // should not happen
+
+    sym_index_to_boost = most_prob_sym_index;
+    boost_amount = kRangeProbScale - ci;
+  }
+
+  return true;
+}
+
+void BuildDecodeTable(uint32_t num_syms,
+                      const std::vector<uint32_t>& scaled_cum_prob,
+                      std::vector<uint32_t>& table) {
+  HWY_DASSERT(scaled_cum_prob.size() == num_syms + 1);
+  table.assign(kRangeProbScale, 0);
+
+  for (uint32_t sym = 0; sym < num_syms; ++sym) {
+    const uint32_t lo = scaled_cum_prob[sym];
+    const uint32_t hi = scaled_cum_prob[sym + 1];
+    const uint32_t n = hi - lo;
+    if (!n) continue;
+
+    HWY_DASSERT(lo < kRangeProbScale && n < kRangeProbScale);
+    const uint32_t k = sym | (lo << 8) | (n << 20);
+    for (uint32_t j = 0; j < n; ++j) table[lo + j] = k;
+  }
+}
+
+void EncodeInterleaved(const std::vector<uint8_t>& data,
+                       std::vector<uint8_t>& enc_buf,
+                       const std::vector<uint32_t>& scaled_cum_prob) {
+  const size_t file_size = data.size();
+  HWY_DASSERT(file_size != 0);
+
+  std::vector<RangeEncoder> encs(kRangeLanes);
+  std::vector<uint8_t> bytes_written(file_size);
+  uint64_t total_enc_size = 0;
+
+  for (uint32_t i = 0; i < kRangeLanes; ++i) {
+    encs[i].buf().reserve(1 + file_size / kRangeLanes);
+  }
+
+  for (size_t i = 0; i < file_size; ++i) {
+    const uint32_t sym = data[i];
+    const uint32_t lane = static_cast<uint32_t>(i) & kRangeLaneMask;
+
+    const size_t before = encs[lane].buf().size();
+    encs[lane].Encode(scaled_cum_prob[sym], scaled_cum_prob[sym + 1]);
+    const size_t after = encs[lane].buf().size();
+
+    bytes_written[i] = static_cast<uint8_t>(after - before);
+    total_enc_size += after - before;
+  }
+
+  for (uint32_t lane = 0; lane < kRangeLanes; ++lane) encs[lane].Flush();
+
+  uint32_t cur_ofs[kRangeLanes] = {0};
+  const uint64_t final_size = kRangeLanes * 3 + total_enc_size + 2;
+  enc_buf.resize(static_cast<size_t>(final_size));
+
+  uint8_t* dst = enc_buf.data();
+
+  for (uint32_t lane = 0; lane < kRangeLanes; ++lane) {
+    for (uint32_t j = 0; j < 3; ++j) {
+      *dst++ = encs[lane].buf()[cur_ofs[lane]++];
+    }
+  }
+
+  for (size_t i = 0; i < file_size; ++i) {
+    const uint32_t num_bytes = bytes_written[i];
+    if (!num_bytes) continue;
+    const uint32_t lane = static_cast<uint32_t>(i) & kRangeLaneMask;
+    memcpy(dst, &encs[lane].buf()[cur_ofs[lane]], num_bytes);
+    dst += num_bytes;
+    cur_ofs[lane] += num_bytes;
+  }
+
+  *dst++ = 0;
+  *dst++ = 0;
+  HWY_DASSERT(static_cast<size_t>(dst - enc_buf.data()) == enc_buf.size());
+}
+
+bool DecodeInterleavedScalar(const uint8_t* src, size_t comp_size, uint8_t* dst,
+                             size_t orig_size, const uint32_t* table) {
+  // Decode from a zero-padded copy so a truncated/corrupt stream can never read
+  // out of bounds; a valid stream never reads past `comp_size`.
+  std::vector<uint8_t> buf;
+  buf.reserve(comp_size + 16);
+  buf.assign(src, src + comp_size);
+  buf.resize(comp_size + 16, 0);
+
+  const uint8_t* const p_start = buf.data();
+  const uint8_t* p = p_start;
+
+  uint32_t value[kRangeLanes];
+  uint32_t length[kRangeLanes];
+  for (uint32_t s = 0; s < kRangeLanes; ++s) {
+    value[s] = ReadBE24(p);
+    length[s] = kRangeMaxLen;
+  }
+
+  RangeDecoder dec;
+  for (size_t i = 0; i < orig_size; ++i) {
+    const uint32_t s = static_cast<uint32_t>(i) & kRangeLaneMask;
+    dec.length_ = length[s];
+    dec.value_ = value[s];
+    dst[i] = static_cast<uint8_t>(dec.DecodeSymbol(table, p));
+    length[s] = dec.length_;
+    value[s] = dec.value_;
+  }
+
+  return static_cast<size_t>(p - p_start) <= comp_size;
+}
+
+const RangeShuffleTables& GetRangeShuffleTables() {
+  static const RangeShuffleTables tables = [] {
+    RangeShuffleTables t;
+    memset(&t, 0, sizeof(t));
+
+    for (uint32_t i = 0; i < 256; ++i) {
+      uint32_t nb = 0;
+      for (uint32_t j = 0; j < 4; ++j) {
+        if ((i >> j) & 0x10) {
+          nb += 2;
+        } else if ((i >> j) & 1) {
+          nb += 1;
+        }
+      }
+      t.num_bytes[i] = static_cast<uint8_t>(nb);
+
+      // "shift": rotate each 4-byte lane right to make room for new low bytes.
+      for (uint32_t j = 0; j < 4; ++j) {
+        uint8_t* x = &t.shift[i][j * 4];
+        if ((i >> j) & 0x10) {
+          x[0] = 0x80;
+          x[1] = 0x80;
+          x[2] = static_cast<uint8_t>(j * 4 + 0);
+          x[3] = static_cast<uint8_t>(j * 4 + 1);
+        } else if ((i >> j) & 1) {
+          x[0] = 0x80;
+          x[1] = static_cast<uint8_t>(j * 4 + 0);
+          x[2] = static_cast<uint8_t>(j * 4 + 1);
+          x[3] = static_cast<uint8_t>(j * 4 + 2);
+        } else {
+          x[0] = static_cast<uint8_t>(j * 4 + 0);
+          x[1] = static_cast<uint8_t>(j * 4 + 1);
+          x[2] = static_cast<uint8_t>(j * 4 + 2);
+          x[3] = static_cast<uint8_t>(j * 4 + 3);
+        }
+      }
+
+      // "dist": scatter the freshly loaded source bytes into the freed slots.
+      uint32_t src_ofs = 0;
+      for (uint32_t j = 0; j < 4; ++j) {
+        uint8_t* x = &t.dist[i][j * 4];
+        if ((i >> j) & 0x10) {
+          x[0] = static_cast<uint8_t>(src_ofs + 1);
+          x[1] = static_cast<uint8_t>(src_ofs);
+          x[2] = 0x80;
+          x[3] = 0x80;
+          src_ofs += 2;
+        } else if ((i >> j) & 1) {
+          x[0] = static_cast<uint8_t>(src_ofs++);
+          x[1] = 0x80;
+          x[2] = 0x80;
+          x[3] = 0x80;
+        } else {
+          x[0] = 0x80;
+          x[1] = 0x80;
+          x[2] = 0x80;
+          x[3] = 0x80;
+        }
+      }
+    }
+    return t;
+  }();
+  return tables;
+}
+
+}  // namespace hwy

--- a/hwy/contrib/coder/range_coder.h
+++ b/hwy/contrib/coder/range_coder.h
@@ -1,0 +1,237 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Non-SIMD parts of the interleaved range coder: the scalar encoder/decoder,
+// the probability-model helpers, the (scalar) interleaved encoder, and a
+// scalar reference decoder. The SIMD interleaved decoder is in
+// range_coder-inl.h.
+//
+// This is a re-implementation of Richard Geldreich's public-domain
+// "sserangecoding" (https://github.com/richgel999/sserangecoding), a 24-bit
+// interleaved Pavlov/Subbotin range coder over an 8-bit alphabet with 16
+// interleaved streams. The bitstream format is byte-for-byte identical to that
+// project; only the decoder is expressed via Highway ops so a single source
+// runs on every target.
+
+#ifndef HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_H_
+#define HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>  // memcpy
+
+#include <vector>
+
+#include "hwy/base.h"  // HWY_DASSERT
+
+namespace hwy {
+
+// ------------------------------ Constants (part of the bitstream format)
+
+// Number of fractional bits in a scaled probability; probabilities are in
+// [0, kRangeProbScale].
+constexpr uint32_t kRangeProbBits = 12;
+constexpr uint32_t kRangeProbScale = 1u << kRangeProbBits;  // 4096
+
+// The coder keeps `length` in [kRangeMinLen, kRangeMaxLen] (24-bit range).
+constexpr uint32_t kRangeMinLen = 0x00010000u;
+constexpr uint32_t kRangeMaxLen = 0x00FFFFFFu;
+
+constexpr uint32_t kRangeMinSyms = 2;
+constexpr uint32_t kRangeMaxSyms = 256;
+
+// Number of interleaved streams used by EncodeInterleaved / DecodeInterleaved.
+constexpr uint32_t kRangeLanes = 16;
+constexpr uint32_t kRangeLaneMask = kRangeLanes - 1;
+
+// ------------------------------ Scalar encoder
+
+// Direct translation of sserangecoding's range_enc.
+class RangeEncoder {
+ public:
+  RangeEncoder() { Init(); }
+
+  void Init() {
+    base_ = 0;
+    length_ = kRangeMaxLen;
+    buf_.clear();
+    buf_.reserve(4096);
+  }
+
+  // Encodes the interval [low_prob, high_prob) (both scaled by
+  // kRangeProbScale).
+  void Encode(uint32_t low_prob, uint32_t high_prob) {
+    HWY_DASSERT((low_prob < high_prob) && (high_prob <= kRangeProbScale));
+    HWY_DASSERT((high_prob - low_prob) < kRangeProbScale);
+
+    const uint32_t r = length_ >> kRangeProbBits;
+    const uint32_t l = low_prob * r;
+    const uint32_t h = high_prob * r;
+
+    const uint32_t orig_base = base_;
+    base_ = (base_ + l) & kRangeMaxLen;
+    length_ = h - l;
+
+    if (orig_base > base_) PropagateCarry();
+    if (length_ < kRangeMinLen) RenormEncInterval();
+  }
+
+  void Flush() {
+    const uint32_t orig_base = base_;
+
+    if (length_ > 2 * kRangeMinLen) {
+      base_ = (base_ + kRangeMinLen) & kRangeMaxLen;
+      length_ = kRangeMinLen >> 1;
+    } else {
+      base_ = (base_ + (kRangeMinLen >> 1)) & kRangeMaxLen;
+      length_ = kRangeMinLen >> 9;
+    }
+
+    if (orig_base > base_) PropagateCarry();
+    RenormEncInterval();
+
+    while (buf_.size() < 3) buf_.push_back(0);
+    buf_.push_back(0);
+    buf_.push_back(0);
+  }
+
+  const std::vector<uint8_t>& buf() const { return buf_; }
+  std::vector<uint8_t>& buf() { return buf_; }
+
+ private:
+  void PropagateCarry() {
+    if (buf_.empty()) return;
+    size_t index = buf_.size() - 1;
+    for (;;) {
+      uint8_t& c = buf_[index];
+      if (c == 0xFF) {
+        c = 0;
+      } else {
+        ++c;
+        break;
+      }
+      if (index == 0) break;
+      --index;
+    }
+  }
+
+  void RenormEncInterval() {
+    HWY_DASSERT((base_ & ~kRangeMaxLen) == 0);
+    do {
+      buf_.push_back(static_cast<uint8_t>(base_ >> 16));
+      base_ = (base_ << 8) & kRangeMaxLen;
+      length_ <<= 8;
+    } while (length_ < kRangeMinLen);
+  }
+
+  uint32_t base_;
+  uint32_t length_;
+  std::vector<uint8_t> buf_;
+};
+
+// ------------------------------ Scalar decoder
+
+// Direct translation of sserangecoding's range_dec. Used for the scalar tail of
+// the SIMD decoder and as a reference implementation.
+class RangeDecoder {
+ public:
+  RangeDecoder() : length_(0), value_(0) {}
+
+  // Reads 3 bytes (a big-endian 24-bit value) and advances `p`.
+  void Init(const uint8_t*& p) {
+    length_ = kRangeMaxLen;
+    value_ = static_cast<uint32_t>(p[0]) << 16;
+    value_ |= static_cast<uint32_t>(p[1]) << 8;
+    value_ |= static_cast<uint32_t>(p[2]);
+    p += 3;
+  }
+
+  // Decodes one symbol using `table` (see BuildDecodeTable) and consumes 0..2
+  // bytes from `cur`.
+  uint32_t DecodeSymbol(const uint32_t* table, const uint8_t*& cur) {
+    const uint32_t r = length_ >> kRangeProbBits;
+    const uint32_t q = value_ / r;
+
+    // The AND is only for safety against corrupted input.
+    const uint32_t encoded_val = table[q & (kRangeProbScale - 1)];
+
+    const uint32_t sym = encoded_val & 0xFFu;
+    const uint32_t low_prob = (encoded_val >> 8) & (kRangeProbScale - 1);
+    const uint32_t prob_range = encoded_val >> (8 + kRangeProbBits);
+
+    HWY_DASSERT(q >= low_prob && q < (low_prob + prob_range));
+
+    value_ -= low_prob * r;
+    length_ = prob_range * r;
+
+    while (length_ < kRangeMinLen) {
+      value_ = (value_ << 8) | static_cast<uint32_t>(*cur++);
+      length_ <<= 8;
+    }
+    return sym;
+  }
+
+  uint32_t length_;
+  uint32_t value_;
+};
+
+// ------------------------------ Probability model
+
+// Scales `freq` (per-symbol counts, one entry per symbol) into a cumulative
+// probability table `scaled_cum_prob` of size freq.size() + 1, summing to
+// kRangeProbScale. `freq` may be modified if only one symbol was used. Returns
+// false if the model is degenerate.
+bool CreateCumulativeProbs(std::vector<uint32_t>& scaled_cum_prob,
+                           std::vector<uint32_t>& freq);
+
+// Builds the 4096-entry decode lookup table from `scaled_cum_prob` (as produced
+// by CreateCumulativeProbs for `num_syms` symbols). Each entry packs
+// sym | (cum_prob << 8) | (prob_range << 20).
+void BuildDecodeTable(uint32_t num_syms,
+                      const std::vector<uint32_t>& scaled_cum_prob,
+                      std::vector<uint32_t>& table);
+
+// ------------------------------ Interleaved codec
+
+// Encodes `data` into 16 interleaved range-coded streams, appending the result
+// to `enc_buf` layout expected by DecodeInterleaved (48 header bytes, then the
+// renormalization bytes in stream-round-robin order, then 2 zero pad bytes).
+void EncodeInterleaved(const std::vector<uint8_t>& data,
+                       std::vector<uint8_t>& enc_buf,
+                       const std::vector<uint32_t>& scaled_cum_prob);
+
+// Scalar reference decoder for data produced by EncodeInterleaved. `table` is
+// from BuildDecodeTable. Returns false if the input is truncated. The SIMD
+// version (range_coder-inl.h) produces identical output.
+bool DecodeInterleavedScalar(const uint8_t* src, size_t comp_size, uint8_t* dst,
+                             size_t orig_size, const uint32_t* table);
+
+// ------------------------------ SIMD decoder shuffle tables
+
+// Per-normalization-mask (8-bit: bits 0..3 = "stream needs >=1 byte",
+// bits 4..7 = "stream needs 2 bytes") shuffle constants used by the SIMD
+// decoder. `shift`/`dist` are pshufb-style byte indices (0x80 => zero).
+struct RangeShuffleTables {
+  uint8_t num_bytes[256];
+  uint8_t shift[256][16];
+  uint8_t dist[256][16];
+};
+
+// Returns a lazily-built, immutable instance (thread-safe since C++11).
+const RangeShuffleTables& GetRangeShuffleTables();
+
+}  // namespace hwy
+
+#endif  // HIGHWAY_HWY_CONTRIB_CODER_RANGE_CODER_H_

--- a/hwy/contrib/coder/range_coder_test.cc
+++ b/hwy/contrib/coder/range_coder_test.cc
@@ -36,22 +36,14 @@ namespace {
 
 namespace rc = hwy::HWY_NAMESPACE::range_coder;
 
-// Small deterministic xorshift PRNG (test-only).
-uint64_t NextRandom(uint64_t& state) {
-  state ^= state << 13;
-  state ^= state >> 7;
-  state ^= state << 17;
-  return state;
-}
-
 // Skewed toward small byte values (sum of masked randoms), so it compresses.
 std::vector<uint8_t> MakeSkewed(size_t n, uint64_t seed) {
-  uint64_t state = seed | 1;
+  RandomState rng(seed);
   std::vector<uint8_t> v(n);
   for (size_t i = 0; i < n; ++i) {
     uint32_t x = 0;
     for (int k = 0; k < 3; ++k) {
-      x += static_cast<uint32_t>(NextRandom(state) & 0x3F);
+      x += static_cast<uint32_t>(Random64(&rng) & 0x3F);
     }
     v[i] = static_cast<uint8_t>(x);
   }
@@ -59,10 +51,10 @@ std::vector<uint8_t> MakeSkewed(size_t n, uint64_t seed) {
 }
 
 std::vector<uint8_t> MakeUniform(size_t n, uint64_t seed) {
-  uint64_t state = seed | 1;
+  RandomState rng(seed);
   std::vector<uint8_t> v(n);
   for (size_t i = 0; i < n; ++i) {
-    v[i] = static_cast<uint8_t>(NextRandom(state));
+    v[i] = static_cast<uint8_t>(Random64(&rng));
   }
   return v;
 }
@@ -101,23 +93,33 @@ void RoundTrip(const std::vector<uint8_t>& data, bool expect_shrink) {
 // Round-trips a range of sizes: below one 16-lane block, exactly one, several
 // whole blocks, and whole blocks + a scalar-tail remainder.
 void TestRoundTripSizes() {
-  const size_t kSizes[] = {1,  2,   3,   15,   16,   17,   31,    32,   33,
-                           64, 127, 256, 1023, 4096, 4097, 65535, 65536};
-  for (size_t idx = 0; idx < sizeof(kSizes) / sizeof(kSizes[0]); ++idx) {
-    const size_t n = kSizes[idx];
+  // Small sizes pin the block/tail boundaries exactly.
+  const size_t kExact[] = {1, 2, 3, 15, 16, 17, 31, 32, 33, 64, 127, 256};
+  for (size_t idx = 0; idx < sizeof(kExact) / sizeof(kExact[0]); ++idx) {
+    const size_t n = kExact[idx];
+    RoundTrip(MakeSkewed(n, n * 3 + 1), /*expect_shrink=*/false);
+    RoundTrip(MakeUniform(n, n * 7 + 5), /*expect_shrink=*/false);
+  }
+  // Larger sizes run many vector iterations; AdjustedReps scales them down on
+  // emulated targets (and is the identity on native builds).
+  const size_t kLarge[] = {1023, 4096, 4097, 65535, 65536};
+  for (size_t idx = 0; idx < sizeof(kLarge) / sizeof(kLarge[0]); ++idx) {
+    const size_t n = AdjustedReps(kLarge[idx]);
     RoundTrip(MakeSkewed(n, n * 3 + 1), /*expect_shrink=*/false);
     RoundTrip(MakeUniform(n, n * 7 + 5), /*expect_shrink=*/false);
   }
 }
 
 // A large skewed input must actually compress, and degenerate models
-// (one or two live symbols) must still round-trip.
+// (one or two live symbols) must still round-trip. Sizes are scaled by
+// AdjustedReps so the emulated targets do not run the full loops.
 void TestRoundTripModels() {
-  RoundTrip(MakeSkewed(200000, 0xABCDEF), /*expect_shrink=*/true);
+  RoundTrip(MakeSkewed(AdjustedReps(200000), 0xABCDEF), /*expect_shrink=*/true);
 
-  RoundTrip(std::vector<uint8_t>(5000, 0x42), /*expect_shrink=*/true);
+  RoundTrip(std::vector<uint8_t>(AdjustedReps(5000), 0x42),
+            /*expect_shrink=*/true);
 
-  std::vector<uint8_t> two_syms(4000);
+  std::vector<uint8_t> two_syms(AdjustedReps(4000));
   for (size_t i = 0; i < two_syms.size(); ++i) {
     two_syms[i] = static_cast<uint8_t>((i % 5) ? 0x10 : 0x20);
   }

--- a/hwy/contrib/coder/range_coder_test.cc
+++ b/hwy/contrib/coder/range_coder_test.cc
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <vector>
+
+// clang-format off
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "hwy/contrib/coder/range_coder_test.cc"  // NOLINT
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/contrib/coder/range_coder.h"
+#include "hwy/contrib/coder/range_coder-inl.h"
+#include "hwy/tests/test_util-inl.h"
+// clang-format on
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {  // required: unique per target
+namespace {
+
+namespace rc = hwy::HWY_NAMESPACE::range_coder;
+
+// Small deterministic xorshift PRNG (test-only).
+uint64_t NextRandom(uint64_t& state) {
+  state ^= state << 13;
+  state ^= state >> 7;
+  state ^= state << 17;
+  return state;
+}
+
+// Skewed toward small byte values (sum of masked randoms), so it compresses.
+std::vector<uint8_t> MakeSkewed(size_t n, uint64_t seed) {
+  uint64_t state = seed | 1;
+  std::vector<uint8_t> v(n);
+  for (size_t i = 0; i < n; ++i) {
+    uint32_t x = 0;
+    for (int k = 0; k < 3; ++k) {
+      x += static_cast<uint32_t>(NextRandom(state) & 0x3F);
+    }
+    v[i] = static_cast<uint8_t>(x);
+  }
+  return v;
+}
+
+std::vector<uint8_t> MakeUniform(size_t n, uint64_t seed) {
+  uint64_t state = seed | 1;
+  std::vector<uint8_t> v(n);
+  for (size_t i = 0; i < n; ++i) {
+    v[i] = static_cast<uint8_t>(NextRandom(state));
+  }
+  return v;
+}
+
+// Encodes `data`, decodes it with both the SIMD and the scalar decoder, and
+// checks both reproduce the input exactly.
+void RoundTrip(const std::vector<uint8_t>& data, bool expect_shrink) {
+  HWY_ASSERT(!data.empty());
+
+  std::vector<uint32_t> freq(256, 0);
+  for (size_t i = 0; i < data.size(); ++i) freq[data[i]]++;
+
+  std::vector<uint32_t> cum_prob;
+  HWY_ASSERT(CreateCumulativeProbs(cum_prob, freq));
+
+  std::vector<uint32_t> table;
+  BuildDecodeTable(256, cum_prob, table);
+
+  std::vector<uint8_t> enc;
+  EncodeInterleaved(data, enc, cum_prob);
+  HWY_ASSERT(enc.size() >= kRangeLanes * 3 + 2);
+
+  std::vector<uint8_t> dec(data.size(), 0xCD);
+  HWY_ASSERT(rc::DecodeInterleaved(enc.data(), enc.size(), dec.data(),
+                                   data.size(), table.data()));
+  HWY_ASSERT(memcmp(dec.data(), data.data(), data.size()) == 0);
+
+  std::vector<uint8_t> dec_scalar(data.size(), 0xAB);
+  HWY_ASSERT(DecodeInterleavedScalar(enc.data(), enc.size(), dec_scalar.data(),
+                                     data.size(), table.data()));
+  HWY_ASSERT(memcmp(dec_scalar.data(), data.data(), data.size()) == 0);
+
+  if (expect_shrink) HWY_ASSERT(enc.size() < data.size());
+}
+
+// Round-trips a range of sizes: below one 16-lane block, exactly one, several
+// whole blocks, and whole blocks + a scalar-tail remainder.
+void TestRoundTripSizes() {
+  const size_t kSizes[] = {1,  2,   3,   15,   16,   17,   31,    32,   33,
+                           64, 127, 256, 1023, 4096, 4097, 65535, 65536};
+  for (size_t idx = 0; idx < sizeof(kSizes) / sizeof(kSizes[0]); ++idx) {
+    const size_t n = kSizes[idx];
+    RoundTrip(MakeSkewed(n, n * 3 + 1), /*expect_shrink=*/false);
+    RoundTrip(MakeUniform(n, n * 7 + 5), /*expect_shrink=*/false);
+  }
+}
+
+// A large skewed input must actually compress, and degenerate models
+// (one or two live symbols) must still round-trip.
+void TestRoundTripModels() {
+  RoundTrip(MakeSkewed(200000, 0xABCDEF), /*expect_shrink=*/true);
+
+  RoundTrip(std::vector<uint8_t>(5000, 0x42), /*expect_shrink=*/true);
+
+  std::vector<uint8_t> two_syms(4000);
+  for (size_t i = 0; i < two_syms.size(); ++i) {
+    two_syms[i] = static_cast<uint8_t>((i % 5) ? 0x10 : 0x20);
+  }
+  RoundTrip(two_syms, /*expect_shrink=*/true);
+}
+
+}  // namespace
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace hwy {
+HWY_BEFORE_TEST(RangeCoderTest);
+HWY_EXPORT_AND_TEST_P(RangeCoderTest, TestRoundTripSizes);
+HWY_EXPORT_AND_TEST_P(RangeCoderTest, TestRoundTripModels);
+HWY_AFTER_TEST();
+}  // namespace hwy
+#endif

--- a/hwy_tests.bzl
+++ b/hwy_tests.bzl
@@ -43,6 +43,11 @@ HWY_CONTRIB_TESTS = (
         [":bit_pack"],
     ),
     (
+        "hwy/contrib/coder/",
+        "range_coder_test",
+        [":range_coder"],
+    ),
+    (
         "hwy/contrib/dot/",
         "dot_test",
         [":dot"],

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,8 @@ hwy_sources = files(
 hwy_contrib_headers = files(
     'hwy/contrib/base64/base64-inl.h',
     'hwy/contrib/bit_pack/bit_pack-inl.h',
+    'hwy/contrib/coder/range_coder.h',
+    'hwy/contrib/coder/range_coder-inl.h',
     'hwy/contrib/dot/dot-inl.h',
     'hwy/contrib/hash/hash-inl.h',
     'hwy/contrib/hash/highwayhash-inl.h',
@@ -168,6 +170,7 @@ hwy_contrib_headers = files(
 )
 
 hwy_contrib_sources = files(
+    'hwy/contrib/coder/range_coder.cc',
     'hwy/contrib/image/image.cc',
     'hwy/contrib/hash/cuckoo2x2.cc',
     'hwy/contrib/hash/phast.cc',
@@ -701,6 +704,7 @@ if tests_enabled
             'hwy/contrib/algo/minmax_value_test.cc',
             'hwy/contrib/algo/transform_test.cc',
             'hwy/contrib/bit_pack/bit_pack_test.cc',
+            'hwy/contrib/coder/range_coder_test.cc',
             'hwy/contrib/dot/dot_test.cc',
             'hwy/contrib/hash/hash_test.cc',
             'hwy/contrib/hash/highwayhash_test.cc',


### PR DESCRIPTION
Implements the **Range coder** item from `g3doc/op_wishlist.md`: a Highway
port of Richard Geldreich's public-domain
[`sserangecoding`](https://github.com/richgel999/sserangecoding) — a 24-bit
interleaved Pavlov/Subbotin range coder over an 8-bit alphabet with 16
interleaved streams. The SSE4.1 decode kernel is re-expressed with Highway
ops so a single source runs on every target.

### What's here

| file | contents |
|---|---|
| `hwy/contrib/coder/range_coder.h` / `.cc` | scalar `RangeEncoder` / `RangeDecoder`, the probability-model helpers (`CreateCumulativeProbs`, `BuildDecodeTable`), the scalar interleaved encoder (`EncodeInterleaved`, not vectorized in the original either) and a scalar reference decoder (`DecodeInterleavedScalar`) |
| `hwy/contrib/coder/range_coder-inl.h` | **SIMD `DecodeInterleaved`** over `Full128<uint32_t>` — the 16 streams as four groups of four lanes, held in `value0..value3` / `length0..length3` locals and driven from an unrolled loop, matching the reference's 128-bit kernel. Uses `GatherIndex` for the decode table, `TruncateStore` for the four symbol bytes, one 16-byte `LoadU` + `TableLookupBytes` per group for the big-endian 24-bit header, `TableLookupBytesOr0` for the renormalization shuffles, and float divide + truncating `ConvertTo` for the exact 24-bit `value / range` (per the note in the original crediting @jan-wassenberg for the `_mm_cvttps_epi32` suggestion). Runs on RVV and SVE (masked to four lanes) as well as the fixed-size targets; only `HWY_SCALAR`, which cannot form a 4-lane vector, falls back to the scalar decoder, which produces identical output. Widening the group past 128 bits would need the renorm shuffle tables reworked per block — a possible follow-up. |
| `hwy/contrib/coder/range_coder_test.cc` | round-trips a range of sizes (below/at/above one 16-lane block, plus a scalar-tail remainder; `AdjustedReps` on the large sizes) and models (skewed, uniform, one and two live symbols), cross-checking the SIMD and scalar decoders |

Wired into CMake, Bazel (`BUILD`, `hwy_tests.bzl`) and Meson; wishlist entry removed.

### Validation

- `range_coder_test` passes on AVX3/AVX2/SSE4/SSSE3/SSE2/EMU128 locally.
- Strict `-Werror` build with the Linux CI flag set (`-Wconversion -Wsign-conversion -Wcast-align -Wshadow -Wmissing-declarations -Wextra-semi -Wunreachable-code …`): clean. `clang-format` clean.
- **The encoder is byte-for-byte identical to `sserangecoding`.** Building the upstream encoder and comparing: `book1` → the same 436229-byte stream (56.7 %, within 0.27 % of the order-0 entropy), and both the SIMD and scalar decoders round-trip it.

The one deliberate difference from the reference: `DecodeInterleaved` never reads outside `[src, src + comp_size)` (the reference's `pSrc_end` is deliberately loose); it rejects `comp_size < 48` up front and the short scalar tail decodes from a zero-padded copy, so a truncated/corrupt stream cannot over-read.
