### PR TITLE
Add Iguana ANS32 entropy decoder to hwy/contrib/iguana

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -457,6 +457,24 @@ cc_library(
 )
 
 cc_library(
+    name = "iguana_ans",
+    srcs = [
+        "hwy/contrib/iguana/ans.cc",
+    ],
+    hdrs = [
+        "hwy/contrib/iguana/ans.h",
+    ],
+    compatible_with = [],
+    copts = COPTS,
+    textual_hdrs = [
+        "hwy/contrib/iguana/ans-inl.h",
+    ],
+    deps = [
+        ":hwy",
+    ],
+)
+
+cc_library(
     name = "hash",
     compatible_with = [],
     copts = COPTS,

--- a/BUILD
+++ b/BUILD
@@ -463,6 +463,7 @@ cc_library(
     ],
     hdrs = [
         "hwy/contrib/iguana/ans.h",
+        "hwy/contrib/iguana/ans_detail.h",
     ],
     compatible_with = [],
     copts = COPTS,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/dot/dot-inl.h
     hwy/contrib/iguana/ans.cc
     hwy/contrib/iguana/ans.h
+    hwy/contrib/iguana/ans_detail.h
     hwy/contrib/iguana/ans-inl.h
     hwy/contrib/hash/hash-inl.h
     hwy/contrib/hash/highwayhash-inl.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,9 @@ list(APPEND HWY_CONTRIB_SOURCES
     hwy/contrib/coder/range_coder.h
     hwy/contrib/coder/range_coder-inl.h
     hwy/contrib/dot/dot-inl.h
+    hwy/contrib/iguana/ans.cc
+    hwy/contrib/iguana/ans.h
+    hwy/contrib/iguana/ans-inl.h
     hwy/contrib/hash/hash-inl.h
     hwy/contrib/hash/highwayhash-inl.h
     hwy/contrib/hash/phast.cc
@@ -1041,6 +1044,7 @@ list(APPEND HWY_TEST_FILES
   hwy/contrib/bit_pack/bit_pack_test.cc
   hwy/contrib/coder/range_coder_test.cc
   hwy/contrib/dot/dot_test.cc
+  hwy/contrib/iguana/ans_test.cc
   hwy/contrib/hash/cuckoo2x2_test.cc
   hwy/contrib/hash/hash_test.cc
   hwy/contrib/hash/highwayhash_test.cc

--- a/hwy/contrib/iguana/ans-inl.h
+++ b/hwy/contrib/iguana/ans-inl.h
@@ -22,15 +22,17 @@
 // lanes whose state fell below 2^16 by pulling one 16-bit word each from the
 // forward / reverse halves of the payload - vectorized with Expand.
 //
-// State is held in up to 4 named vectors per half (fwd0..fwd3, rev0..rev3),
-// not an array: RVV/SVE vectors are sizeless types and cannot be array
-// elements. HWY_SCALAR is excluded at compile time (its 1-lane-only ops
-// can't instantiate RenormLane's multi-lane Repartition/LoadU at all, not
-// just uselessly -- confirmed by trying, not assumed). `Ans32DecodePayload`
-// additionally falls back to the scalar reference decoder at *runtime* for
-// a scalable (RVV/SVE) target whose hardware vector length is unusually
-// small -- everywhere else, including RVV/SVE with a typical vector length,
-// this vectorizes.
+// The 16+16 states are held in named vector locals (fwd0..fwd3, rev0..rev3):
+// RVV/SVE vectors are sizeless and cannot be array elements. The number of
+// groups (16 / Lanes(d), so 1, 2 or 4) is a template argument kNumVectors, so
+// each instantiation is straight-line `if constexpr`-guarded code the compiler
+// keeps in registers -- no pointer-to-vector array. `Ans32DecodePayload`
+// dispatches on it: a fixed target instantiates only the one group count its
+// (compile-time) Lanes(d) produces; a scalable target instantiates all three.
+// HWY_SCALAR is excluded at compile time (its 1-lane ops can't instantiate
+// RenormLane's multi-lane Repartition/LoadU -- confirmed by trying), and a
+// scalable target with an unusually small hardware vector length falls back to
+// the scalar reference decoder at runtime.
 
 #if defined(HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_) == defined(HWY_TARGET_TOGGLE)
 #ifdef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_
@@ -119,41 +121,20 @@ HWY_INLINE hn::VFromD<D> RenormLane(D d, hn::VFromD<D> x, const uint8_t*& p) {
       mask, hn::Or(hn::ShiftLeft<hi::kAnsWordLBits>(x), expanded), x);
 }
 
-// Decodes `payload` (the rANS data, without the frequency table) using an
-// already-built dense `table`. Mirrors Ans32DecodePayloadScalar.
-HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
-                                   size_t payload_size,
-                                   const hi::AnsDenseTable& table,
-                                   uint8_t* HWY_RESTRICT dst,
-                                   size_t orig_size) {
-  if (payload_size < 128) return false;
-  const uint32_t* HWY_RESTRICT tab = table.data();
-
-  const hn::CappedTag<uint32_t, 16> d;
-  const size_t n = hn::Lanes(d);  // <= 16; typically 4, 8 or 16
-  const size_t nv = n == 0 ? 0 : 16 / n;
-  // Falls back to the scalar reference decoder for lane counts that don't
-  // divide 16 into at most 4 groups -- only reachable here on a scalable
-  // (RVV/SVE) target with an unusually narrow hardware vector length
-  // (HWY_SCALAR is excluded at compile time above, never reaches this).
-  // Produces identical output, just without vectorization for that rare case.
-  if (n == 0 || nv == 0 || nv > 4 || n * nv != 16) {
-    return hi::Ans32DecodePayloadScalar(payload, payload_size, table, dst,
-                                        orig_size);
-  }
-
-  // Named variables, not an array: RVV/SVE vectors are sizeless types and
-  // cannot be array elements. A fixed array of POINTERS to them is fine
-  // (pointers are ordinary, fixed-size objects) and lets the loops below
-  // stay index-based like the original, unrolled-by-hand version -- only
-  // `nv` (<=4) of each are ever read.
-  using V = hn::VFromD<decltype(d)>;
-  V fwd0 = hn::Zero(d), fwd1 = hn::Zero(d), fwd2 = hn::Zero(d),
-    fwd3 = hn::Zero(d);
-  V rev0 = hn::Zero(d), rev1 = hn::Zero(d), rev2 = hn::Zero(d),
-    rev3 = hn::Zero(d);
-  V* const fwd[4] = {&fwd0, &fwd1, &fwd2, &fwd3};
-  V* const rev[4] = {&rev0, &rev1, &rev2, &rev3};
+// Decodes `payload` with `kNumVectors` (1, 2 or 4) vector groups per half.
+// The group count is a template argument so the unrolled body is straight-line
+// code in named locals rather than a runtime loop over an array of pointers.
+template <size_t kNumVectors, class D>
+HWY_INLINE bool Ans32DecodePayloadT(D d, size_t n,
+                                    const uint8_t* HWY_RESTRICT payload,
+                                    size_t payload_size,
+                                    const uint32_t* HWY_RESTRICT tab,
+                                    uint8_t* HWY_RESTRICT dst,
+                                    size_t orig_size) {
+  using V = hn::VFromD<D>;
+  V fwd0 = hn::Zero(d), rev0 = hn::Zero(d);
+  HWY_MAYBE_UNUSED V fwd1 = hn::Zero(d), fwd2 = hn::Zero(d), fwd3 = hn::Zero(d);
+  HWY_MAYBE_UNUSED V rev1 = hn::Zero(d), rev2 = hn::Zero(d), rev3 = hn::Zero(d);
 
   {
     HWY_ALIGN uint32_t s[32];
@@ -169,9 +150,17 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
                      (static_cast<uint32_t>(payload[o + 2]) << 16) |
                      (static_cast<uint32_t>(payload[o + 3]) << 24);
     }
-    for (size_t g = 0; g < nv; ++g) {
-      *fwd[g] = hn::LoadU(d, s + g * n);
-      *rev[g] = hn::LoadU(d, s + 16 + g * n);
+    fwd0 = hn::LoadU(d, s + 0 * n);
+    rev0 = hn::LoadU(d, s + 16 + 0 * n);
+    if constexpr (kNumVectors >= 2) {
+      fwd1 = hn::LoadU(d, s + 1 * n);
+      rev1 = hn::LoadU(d, s + 16 + 1 * n);
+    }
+    if constexpr (kNumVectors >= 4) {
+      fwd2 = hn::LoadU(d, s + 2 * n);
+      rev2 = hn::LoadU(d, s + 16 + 2 * n);
+      fwd3 = hn::LoadU(d, s + 3 * n);
+      rev3 = hn::LoadU(d, s + 16 + 3 * n);
     }
   }
 
@@ -184,22 +173,46 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
   // halves are independent within a round, so interleaving them changes
   // neither the result nor which bytes of `pf`/`pr` each touches.
   while (pos + 32 <= orig_size && pf + 64 <= pr - 64) {
-    for (size_t g = 0; g < nv; ++g) {
-      *fwd[g] = DecodeLane(d, *fwd[g], tab, dst + pos + g * n);
-      *rev[g] = DecodeLane(d, *rev[g], tab, dst + pos + 16 + g * n);
+    fwd0 = DecodeLane(d, fwd0, tab, dst + pos + 0 * n);
+    rev0 = DecodeLane(d, rev0, tab, dst + pos + 16 + 0 * n);
+    if constexpr (kNumVectors >= 2) {
+      fwd1 = DecodeLane(d, fwd1, tab, dst + pos + 1 * n);
+      rev1 = DecodeLane(d, rev1, tab, dst + pos + 16 + 1 * n);
+    }
+    if constexpr (kNumVectors >= 4) {
+      fwd2 = DecodeLane(d, fwd2, tab, dst + pos + 2 * n);
+      rev2 = DecodeLane(d, rev2, tab, dst + pos + 16 + 2 * n);
+      fwd3 = DecodeLane(d, fwd3, tab, dst + pos + 3 * n);
+      rev3 = DecodeLane(d, rev3, tab, dst + pos + 16 + 3 * n);
     }
     pos += 32;
-    for (size_t g = 0; g < nv; ++g) {
-      *fwd[g] = RenormLane<true>(d, *fwd[g], pf);
-      *rev[g] = RenormLane<false>(d, *rev[g], pr);
+    fwd0 = RenormLane<true>(d, fwd0, pf);
+    rev0 = RenormLane<false>(d, rev0, pr);
+    if constexpr (kNumVectors >= 2) {
+      fwd1 = RenormLane<true>(d, fwd1, pf);
+      rev1 = RenormLane<false>(d, rev1, pr);
+    }
+    if constexpr (kNumVectors >= 4) {
+      fwd2 = RenormLane<true>(d, fwd2, pf);
+      rev2 = RenormLane<false>(d, rev2, pr);
+      fwd3 = RenormLane<true>(d, fwd3, pf);
+      rev3 = RenormLane<false>(d, rev3, pr);
     }
   }
 
   // Scalar tail: spill state and finish exactly like the reference.
   HWY_ALIGN uint32_t state[32];
-  for (size_t g = 0; g < nv; ++g) {
-    hn::StoreU(*fwd[g], d, state + g * n);
-    hn::StoreU(*rev[g], d, state + 16 + g * n);
+  hn::StoreU(fwd0, d, state + 0 * n);
+  hn::StoreU(rev0, d, state + 16 + 0 * n);
+  if constexpr (kNumVectors >= 2) {
+    hn::StoreU(fwd1, d, state + 1 * n);
+    hn::StoreU(rev1, d, state + 16 + 1 * n);
+  }
+  if constexpr (kNumVectors >= 4) {
+    hn::StoreU(fwd2, d, state + 2 * n);
+    hn::StoreU(rev2, d, state + 16 + 2 * n);
+    hn::StoreU(fwd3, d, state + 3 * n);
+    hn::StoreU(rev3, d, state + 16 + 3 * n);
   }
   size_t cursor_fwd = static_cast<size_t>(pf - payload);
   size_t cursor_rev = static_cast<size_t>(pr - payload);
@@ -240,6 +253,54 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
     }
   }
   return true;
+}
+
+// Decodes `payload` (the rANS data, without the frequency table) using an
+// already-built dense `table`. Mirrors Ans32DecodePayloadScalar. Computes the
+// group count (16 / Lanes(d)) at runtime and dispatches to the matching
+// Ans32DecodePayloadT instantiation; the `if constexpr` guards keep a
+// fixed-size target from compiling the group counts it can never see.
+HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
+                                   size_t payload_size,
+                                   const hi::AnsDenseTable& table,
+                                   uint8_t* HWY_RESTRICT dst,
+                                   size_t orig_size) {
+  if (payload_size < 128) return false;
+  const uint32_t* HWY_RESTRICT tab = table.data();
+
+  const hn::CappedTag<uint32_t, 16> d;
+  const size_t n = hn::Lanes(d);  // <= 16; typically 4, 8 or 16
+  const size_t nv = n == 0 ? 0 : 16 / n;
+
+  if constexpr (!HWY_HAVE_SCALABLE) {
+    // Fixed target: Lanes(d) is a compile-time constant, so only the one
+    // group count it produces is instantiated.
+    constexpr size_t kNV = 16 / size_t{HWY_MAX_LANES_D(decltype(d))};
+    if (n * kNV == 16) {
+      return Ans32DecodePayloadT<kNV>(d, n, payload, payload_size, tab, dst,
+                                      orig_size);
+    }
+  } else if (n * nv == 16) {
+    // Scalable target: the hardware vector length picks nv at runtime.
+    if (nv == 4) {
+      return Ans32DecodePayloadT<4>(d, n, payload, payload_size, tab, dst,
+                                    orig_size);
+    }
+    if (nv == 2) {
+      return Ans32DecodePayloadT<2>(d, n, payload, payload_size, tab, dst,
+                                    orig_size);
+    }
+    if (nv == 1) {
+      return Ans32DecodePayloadT<1>(d, n, payload, payload_size, tab, dst,
+                                    orig_size);
+    }
+  }
+
+  // Lane counts that don't split 16 into 1/2/4 groups -- only reachable on a
+  // scalable target with an unusually narrow vector length. Identical output,
+  // just not vectorized.
+  return hi::Ans32DecodePayloadScalar(payload, payload_size, table, dst,
+                                      orig_size);
 }
 
 // Decodes a full ANS32 block (rANS payload + serialized frequency table).

--- a/hwy/contrib/iguana/ans-inl.h
+++ b/hwy/contrib/iguana/ans-inl.h
@@ -21,6 +21,16 @@
 // a gather into the dense table and one multiply-add, then renormalizes the
 // lanes whose state fell below 2^16 by pulling one 16-bit word each from the
 // forward / reverse halves of the payload - vectorized with Expand.
+//
+// State is held in up to 4 named vectors per half (fwd0..fwd3, rev0..rev3),
+// not an array: RVV/SVE vectors are sizeless types and cannot be array
+// elements. HWY_SCALAR is excluded at compile time (its 1-lane-only ops
+// can't instantiate RenormLane's multi-lane Repartition/LoadU at all, not
+// just uselessly -- confirmed by trying, not assumed). `Ans32DecodePayload`
+// additionally falls back to the scalar reference decoder at *runtime* for
+// a scalable (RVV/SVE) target whose hardware vector length is unusually
+// small -- everywhere else, including RVV/SVE with a typical vector length,
+// this vectorizes.
 
 #if defined(HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_) == defined(HWY_TARGET_TOGGLE)
 #ifdef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_
@@ -34,20 +44,29 @@
 #include <string.h>  // memcpy
 
 #include "hwy/contrib/iguana/ans.h"
+#include "hwy/contrib/iguana/ans_detail.h"
 #include "hwy/highway.h"
 
 HWY_BEFORE_NAMESPACE();
 namespace hwy {
-namespace HWY_NAMESPACE {
 namespace iguana_ans {
+namespace HWY_NAMESPACE {
 
 namespace hi = hwy::iguana;
+namespace hn = hwy::HWY_NAMESPACE;
 
-// The kernel keeps the 32 rANS states in fixed-size 4-lane-or-wider u32 vectors
-// held in local arrays, which rules out HWY_SCALAR and the scalable targets
-// (RVV/SVE, whose vectors cannot be array elements). Those use the scalar
-// reference decoder, which produces identical output.
-#if HWY_TARGET == HWY_SCALAR || HWY_HAVE_SCALABLE || HWY_TARGET_IS_SVE
+// HWY_SCALAR is fundamentally 1-lane and doesn't support the multi-lane
+// Repartition/LoadU that RenormLane needs (confirmed by trying to compile
+// it, not assumed: D::kPrivateLanes==1 is baked into HWY_SCALAR's LoadU
+// overload set, so instantiating RenormLane<HWY_SCALAR's D> is a hard
+// compile error, independent of whether that code path ever runs -- C++
+// instantiates called templates whether or not they're reachable at
+// runtime). Scalable targets (RVV/SVE) don't have this problem -- they're
+// genuine multi-lane SIMD, just with a width unknown until runtime -- so
+// only HWY_SCALAR needs a compile-time exclusion; the runtime nv check in
+// Ans32DecodePayload below (not a compile-time one) is what protects
+// scalable targets with an unusually small hardware vector length.
+#if HWY_TARGET == HWY_SCALAR
 
 HWY_INLINE bool Ans32Decode(const uint8_t* src, size_t src_size, uint8_t* dst,
                             size_t orig_size) {
@@ -59,44 +78,45 @@ HWY_INLINE bool Ans32Decode(const uint8_t* src, size_t src_size, uint8_t* dst,
 // Decodes one symbol per lane of `x`; returns the updated state and writes the
 // `Lanes(d)` symbol bytes to `out`.
 template <class D>
-HWY_INLINE VFromD<D> DecodeLane(D d, VFromD<D> x,
-                                const uint32_t* HWY_RESTRICT table,
-                                uint8_t* HWY_RESTRICT out) {
-  const RebindToSigned<D> di;
-  const VFromD<D> slot = And(x, Set(d, hi::kAnsFreqMask));
-  const VFromD<D> t = GatherIndex(d, table, BitCast(di, slot));
-  const VFromD<D> freq = And(t, Set(d, hi::kAnsFreqMask));
-  const VFromD<D> bias =
-      And(ShiftRight<hi::kAnsWordMBits>(t), Set(d, hi::kAnsFreqMask));
+HWY_INLINE hn::VFromD<D> DecodeLane(D d, hn::VFromD<D> x,
+                                    const uint32_t* HWY_RESTRICT table,
+                                    uint8_t* HWY_RESTRICT out) {
+  const hn::RebindToSigned<D> di;
+  const hn::VFromD<D> slot = hn::And(x, hn::Set(d, hi::kAnsFreqMask));
+  const hn::VFromD<D> t = hn::GatherIndex(d, table, hn::BitCast(di, slot));
+  const hn::VFromD<D> freq = hn::And(t, hn::Set(d, hi::kAnsFreqMask));
+  const hn::VFromD<D> bias = hn::And(hn::ShiftRight<hi::kAnsWordMBits>(t),
+                                     hn::Set(d, hi::kAnsFreqMask));
 
-  HWY_ALIGN uint32_t syms[16];
-  StoreU(ShiftRight<24>(t), d, syms);
-  for (size_t i = 0; i < Lanes(d); ++i) out[i] = static_cast<uint8_t>(syms[i]);
+  const hn::Rebind<uint8_t, D> d8;
+  hn::StoreU(hn::TruncateTo(d8, hn::ShiftRight<24>(t)), d8, out);
 
-  return Add(Mul(freq, ShiftRight<hi::kAnsWordMBits>(x)), bias);
+  return hn::MulAdd(freq, hn::ShiftRight<hi::kAnsWordMBits>(x), bias);
 }
 
 // Renormalizes the lanes of `x` whose state < 2^16, consuming 16-bit words from
 // `p` (advanced by the number consumed). `forward` selects the read direction.
 template <bool kForward, class D>
-HWY_INLINE VFromD<D> RenormLane(D d, VFromD<D> x, const uint8_t*& p) {
-  const Rebind<uint16_t, D> d16;
-  const Repartition<uint8_t, decltype(d16)> d16_bytes;
+HWY_INLINE hn::VFromD<D> RenormLane(D d, hn::VFromD<D> x, const uint8_t*& p) {
+  const hn::Rebind<uint16_t, D> d16;
+  const hn::Repartition<uint8_t, decltype(d16)> d16_bytes;
 
-  const MFromD<D> mask = Lt(x, Set(d, hi::kAnsWordL));
-  const size_t cnt = CountTrue(d, mask);
+  const hn::MFromD<D> mask = hn::Lt(x, hn::Set(d, hi::kAnsWordL));
+  const size_t cnt = hn::CountTrue(d, mask);
 
-  VFromD<decltype(d16)> words;
+  hn::VFromD<decltype(d16)> words;
   HWY_IF_CONSTEXPR(kForward) {
-    words = BitCast(d16, LoadU(d16_bytes, p));
+    words = hn::BitCast(d16, hn::LoadU(d16_bytes, p));
     p += 2 * cnt;
   }
   else {
-    words = Reverse(d16, BitCast(d16, LoadU(d16_bytes, p - 2 * Lanes(d))));
+    words = hn::Reverse(
+        d16, hn::BitCast(d16, hn::LoadU(d16_bytes, p - 2 * hn::Lanes(d))));
     p -= 2 * cnt;
   }
-  const VFromD<D> expanded = Expand(PromoteTo(d, words), mask);
-  return IfThenElse(mask, Or(ShiftLeft<hi::kAnsWordLBits>(x), expanded), x);
+  const hn::VFromD<D> expanded = hn::Expand(hn::PromoteTo(d, words), mask);
+  return hn::IfThenElse(
+      mask, hn::Or(hn::ShiftLeft<hi::kAnsWordLBits>(x), expanded), x);
 }
 
 // Decodes `payload` (the rANS data, without the frequency table) using an
@@ -109,12 +129,32 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
   if (payload_size < 128) return false;
   const uint32_t* HWY_RESTRICT tab = table.data();
 
-  const CappedTag<uint32_t, 16> d;
-  const size_t n = Lanes(d);  // 4, 8 or 16
-  const size_t nv = 16 / n;
+  const hn::CappedTag<uint32_t, 16> d;
+  const size_t n = hn::Lanes(d);  // <= 16; typically 4, 8 or 16
+  const size_t nv = n == 0 ? 0 : 16 / n;
+  // Falls back to the scalar reference decoder for lane counts that don't
+  // divide 16 into at most 4 groups -- only reachable here on a scalable
+  // (RVV/SVE) target with an unusually narrow hardware vector length
+  // (HWY_SCALAR is excluded at compile time above, never reaches this).
+  // Produces identical output, just without vectorization for that rare case.
+  if (n == 0 || nv == 0 || nv > 4 || n * nv != 16) {
+    return hi::Ans32DecodePayloadScalar(payload, payload_size, table, dst,
+                                        orig_size);
+  }
 
-  VFromD<decltype(d)> fwd[4];
-  VFromD<decltype(d)> rev[4];
+  // Named variables, not an array: RVV/SVE vectors are sizeless types and
+  // cannot be array elements. A fixed array of POINTERS to them is fine
+  // (pointers are ordinary, fixed-size objects) and lets the loops below
+  // stay index-based like the original, unrolled-by-hand version -- only
+  // `nv` (<=4) of each are ever read.
+  using V = hn::VFromD<decltype(d)>;
+  V fwd0 = hn::Zero(d), fwd1 = hn::Zero(d), fwd2 = hn::Zero(d),
+    fwd3 = hn::Zero(d);
+  V rev0 = hn::Zero(d), rev1 = hn::Zero(d), rev2 = hn::Zero(d),
+    rev3 = hn::Zero(d);
+  V* const fwd[4] = {&fwd0, &fwd1, &fwd2, &fwd3};
+  V* const rev[4] = {&rev0, &rev1, &rev2, &rev3};
+
   {
     HWY_ALIGN uint32_t s[32];
     const size_t rev_off = payload_size - 64;
@@ -130,8 +170,8 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
                      (static_cast<uint32_t>(payload[o + 3]) << 24);
     }
     for (size_t g = 0; g < nv; ++g) {
-      fwd[g] = LoadU(d, s + g * n);
-      rev[g] = LoadU(d, s + 16 + g * n);
+      *fwd[g] = hn::LoadU(d, s + g * n);
+      *rev[g] = hn::LoadU(d, s + 16 + g * n);
     }
   }
 
@@ -140,23 +180,26 @@ HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
   size_t pos = 0;
 
   // Vectorized rounds, kept clear of the point where the two halves meet.
+  // fwd/rev decode fused into one loop (likewise for renorm below): the two
+  // halves are independent within a round, so interleaving them changes
+  // neither the result nor which bytes of `pf`/`pr` each touches.
   while (pos + 32 <= orig_size && pf + 64 <= pr - 64) {
     for (size_t g = 0; g < nv; ++g) {
-      fwd[g] = DecodeLane(d, fwd[g], tab, dst + pos + g * n);
-    }
-    for (size_t g = 0; g < nv; ++g) {
-      rev[g] = DecodeLane(d, rev[g], tab, dst + pos + 16 + g * n);
+      *fwd[g] = DecodeLane(d, *fwd[g], tab, dst + pos + g * n);
+      *rev[g] = DecodeLane(d, *rev[g], tab, dst + pos + 16 + g * n);
     }
     pos += 32;
-    for (size_t g = 0; g < nv; ++g) fwd[g] = RenormLane<true>(d, fwd[g], pf);
-    for (size_t g = 0; g < nv; ++g) rev[g] = RenormLane<false>(d, rev[g], pr);
+    for (size_t g = 0; g < nv; ++g) {
+      *fwd[g] = RenormLane<true>(d, *fwd[g], pf);
+      *rev[g] = RenormLane<false>(d, *rev[g], pr);
+    }
   }
 
   // Scalar tail: spill state and finish exactly like the reference.
   HWY_ALIGN uint32_t state[32];
   for (size_t g = 0; g < nv; ++g) {
-    StoreU(fwd[g], d, state + g * n);
-    StoreU(rev[g], d, state + 16 + g * n);
+    hn::StoreU(*fwd[g], d, state + g * n);
+    hn::StoreU(*rev[g], d, state + 16 + g * n);
   }
   size_t cursor_fwd = static_cast<size_t>(pf - payload);
   size_t cursor_rev = static_cast<size_t>(pr - payload);
@@ -208,10 +251,10 @@ HWY_INLINE bool Ans32Decode(const uint8_t* HWY_RESTRICT src, size_t src_size,
   return Ans32DecodePayload(src, payload, table, dst, orig_size);
 }
 
-#endif  // scalar / scalable fallback
+#endif  // HWY_TARGET == HWY_SCALAR
 
-}  // namespace iguana_ans
 }  // namespace HWY_NAMESPACE
+}  // namespace iguana_ans
 }  // namespace hwy
 HWY_AFTER_NAMESPACE();
 

--- a/hwy/contrib/iguana/ans-inl.h
+++ b/hwy/contrib/iguana/ans-inl.h
@@ -1,0 +1,218 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SIMD decoder for Iguana's ANS32 entropy stage (32-way interleaved rANS). A
+// single source that runs on every Highway target and returns output identical
+// to hwy::iguana::Ans32DecodeScalar. Ported from the Go reference (ans32.go).
+//
+// Each round decodes 32 symbols (16 "forward" lanes + 16 "reverse" lanes) with
+// a gather into the dense table and one multiply-add, then renormalizes the
+// lanes whose state fell below 2^16 by pulling one 16-bit word each from the
+// forward / reverse halves of the payload - vectorized with Expand.
+
+#if defined(HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_) == defined(HWY_TARGET_TOGGLE)
+#ifdef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_
+#undef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_
+#else
+#define HIGHWAY_HWY_CONTRIB_IGUANA_ANS_INL_H_
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>  // memcpy
+
+#include "hwy/contrib/iguana/ans.h"
+#include "hwy/highway.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+namespace iguana_ans {
+
+namespace hi = hwy::iguana;
+
+// The kernel keeps the 32 rANS states in fixed-size 4-lane-or-wider u32 vectors
+// held in local arrays, which rules out HWY_SCALAR and the scalable targets
+// (RVV/SVE, whose vectors cannot be array elements). Those use the scalar
+// reference decoder, which produces identical output.
+#if HWY_TARGET == HWY_SCALAR || HWY_HAVE_SCALABLE || HWY_TARGET_IS_SVE
+
+HWY_INLINE bool Ans32Decode(const uint8_t* src, size_t src_size, uint8_t* dst,
+                            size_t orig_size) {
+  return hi::Ans32DecodeScalar(src, src_size, dst, orig_size);
+}
+
+#else
+
+// Decodes one symbol per lane of `x`; returns the updated state and writes the
+// `Lanes(d)` symbol bytes to `out`.
+template <class D>
+HWY_INLINE VFromD<D> DecodeLane(D d, VFromD<D> x,
+                                const uint32_t* HWY_RESTRICT table,
+                                uint8_t* HWY_RESTRICT out) {
+  const RebindToSigned<D> di;
+  const VFromD<D> slot = And(x, Set(d, hi::kAnsFreqMask));
+  const VFromD<D> t = GatherIndex(d, table, BitCast(di, slot));
+  const VFromD<D> freq = And(t, Set(d, hi::kAnsFreqMask));
+  const VFromD<D> bias =
+      And(ShiftRight<hi::kAnsWordMBits>(t), Set(d, hi::kAnsFreqMask));
+
+  HWY_ALIGN uint32_t syms[16];
+  StoreU(ShiftRight<24>(t), d, syms);
+  for (size_t i = 0; i < Lanes(d); ++i) out[i] = static_cast<uint8_t>(syms[i]);
+
+  return Add(Mul(freq, ShiftRight<hi::kAnsWordMBits>(x)), bias);
+}
+
+// Renormalizes the lanes of `x` whose state < 2^16, consuming 16-bit words from
+// `p` (advanced by the number consumed). `forward` selects the read direction.
+template <bool kForward, class D>
+HWY_INLINE VFromD<D> RenormLane(D d, VFromD<D> x, const uint8_t*& p) {
+  const Rebind<uint16_t, D> d16;
+  const Repartition<uint8_t, decltype(d16)> d16_bytes;
+
+  const MFromD<D> mask = Lt(x, Set(d, hi::kAnsWordL));
+  const size_t cnt = CountTrue(d, mask);
+
+  VFromD<decltype(d16)> words;
+  HWY_IF_CONSTEXPR(kForward) {
+    words = BitCast(d16, LoadU(d16_bytes, p));
+    p += 2 * cnt;
+  }
+  else {
+    words = Reverse(d16, BitCast(d16, LoadU(d16_bytes, p - 2 * Lanes(d))));
+    p -= 2 * cnt;
+  }
+  const VFromD<D> expanded = Expand(PromoteTo(d, words), mask);
+  return IfThenElse(mask, Or(ShiftLeft<hi::kAnsWordLBits>(x), expanded), x);
+}
+
+// Decodes `payload` (the rANS data, without the frequency table) using an
+// already-built dense `table`. Mirrors Ans32DecodePayloadScalar.
+HWY_INLINE bool Ans32DecodePayload(const uint8_t* HWY_RESTRICT payload,
+                                   size_t payload_size,
+                                   const hi::AnsDenseTable& table,
+                                   uint8_t* HWY_RESTRICT dst,
+                                   size_t orig_size) {
+  if (payload_size < 128) return false;
+  const uint32_t* HWY_RESTRICT tab = table.data();
+
+  const CappedTag<uint32_t, 16> d;
+  const size_t n = Lanes(d);  // 4, 8 or 16
+  const size_t nv = 16 / n;
+
+  VFromD<decltype(d)> fwd[4];
+  VFromD<decltype(d)> rev[4];
+  {
+    HWY_ALIGN uint32_t s[32];
+    const size_t rev_off = payload_size - 64;
+    for (int lane = 0; lane < 16; ++lane) {
+      s[lane] = static_cast<uint32_t>(payload[lane * 4]) |
+                (static_cast<uint32_t>(payload[lane * 4 + 1]) << 8) |
+                (static_cast<uint32_t>(payload[lane * 4 + 2]) << 16) |
+                (static_cast<uint32_t>(payload[lane * 4 + 3]) << 24);
+      const size_t o = rev_off + static_cast<size_t>(lane) * 4;
+      s[lane + 16] = static_cast<uint32_t>(payload[o]) |
+                     (static_cast<uint32_t>(payload[o + 1]) << 8) |
+                     (static_cast<uint32_t>(payload[o + 2]) << 16) |
+                     (static_cast<uint32_t>(payload[o + 3]) << 24);
+    }
+    for (size_t g = 0; g < nv; ++g) {
+      fwd[g] = LoadU(d, s + g * n);
+      rev[g] = LoadU(d, s + 16 + g * n);
+    }
+  }
+
+  const uint8_t* pf = payload + 64;
+  const uint8_t* pr = payload + payload_size - 64;
+  size_t pos = 0;
+
+  // Vectorized rounds, kept clear of the point where the two halves meet.
+  while (pos + 32 <= orig_size && pf + 64 <= pr - 64) {
+    for (size_t g = 0; g < nv; ++g) {
+      fwd[g] = DecodeLane(d, fwd[g], tab, dst + pos + g * n);
+    }
+    for (size_t g = 0; g < nv; ++g) {
+      rev[g] = DecodeLane(d, rev[g], tab, dst + pos + 16 + g * n);
+    }
+    pos += 32;
+    for (size_t g = 0; g < nv; ++g) fwd[g] = RenormLane<true>(d, fwd[g], pf);
+    for (size_t g = 0; g < nv; ++g) rev[g] = RenormLane<false>(d, rev[g], pr);
+  }
+
+  // Scalar tail: spill state and finish exactly like the reference.
+  HWY_ALIGN uint32_t state[32];
+  for (size_t g = 0; g < nv; ++g) {
+    StoreU(fwd[g], d, state + g * n);
+    StoreU(rev[g], d, state + 16 + g * n);
+  }
+  size_t cursor_fwd = static_cast<size_t>(pf - payload);
+  size_t cursor_rev = static_cast<size_t>(pr - payload);
+
+  for (;;) {
+    bool stop = false;
+    for (int lane = 0; lane < 32; ++lane) {
+      const uint32_t x = state[lane];
+      const uint32_t t = tab[x & hi::kAnsFreqMask];
+      const uint32_t freq = t & hi::kAnsFreqMask;
+      const uint32_t bias = (t >> hi::kAnsWordMBits) & hi::kAnsFreqMask;
+      state[lane] = freq * (x >> hi::kAnsWordMBits) + bias;
+      if (pos < orig_size) {
+        dst[pos++] = static_cast<uint8_t>(t >> 24);
+      } else {
+        stop = true;
+        break;
+      }
+    }
+    if (stop) break;
+    for (int lane = 0; lane < 16; ++lane) {
+      if (state[lane] < hi::kAnsWordL) {
+        if (cursor_fwd + 2 > cursor_rev) return false;
+        state[lane] = (state[lane] << hi::kAnsWordLBits) |
+                      (static_cast<uint32_t>(payload[cursor_fwd]) |
+                       (static_cast<uint32_t>(payload[cursor_fwd + 1]) << 8));
+        cursor_fwd += 2;
+      }
+    }
+    for (int lane = 16; lane < 32; ++lane) {
+      if (state[lane] < hi::kAnsWordL) {
+        if (cursor_rev < cursor_fwd + 2) return false;
+        state[lane] = (state[lane] << hi::kAnsWordLBits) |
+                      (static_cast<uint32_t>(payload[cursor_rev - 2]) |
+                       (static_cast<uint32_t>(payload[cursor_rev - 1]) << 8));
+        cursor_rev -= 2;
+      }
+    }
+  }
+  return true;
+}
+
+// Decodes a full ANS32 block (rANS payload + serialized frequency table).
+HWY_INLINE bool Ans32Decode(const uint8_t* HWY_RESTRICT src, size_t src_size,
+                            uint8_t* HWY_RESTRICT dst, size_t orig_size) {
+  hi::AnsDenseTable table;
+  const size_t payload = hi::DeserializeAnsTable(table, src, src_size);
+  if (payload == SIZE_MAX) return false;
+  return Ans32DecodePayload(src, payload, table, dst, orig_size);
+}
+
+#endif  // scalar / scalable fallback
+
+}  // namespace iguana_ans
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#endif  // include guard

--- a/hwy/contrib/iguana/ans.cc
+++ b/hwy/contrib/iguana/ans.cc
@@ -1,0 +1,390 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hwy/contrib/iguana/ans.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <vector>
+
+#include "hwy/base.h"  // HWY_DASSERT
+
+namespace hwy {
+namespace iguana {
+
+namespace {
+
+uint32_t Read16LE(const uint8_t* p) {
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8);
+}
+uint32_t Read32LE(const uint8_t* p) {
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+         (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+void Append16LE(std::vector<uint8_t>& v, uint32_t x) {
+  v.push_back(static_cast<uint8_t>(x));
+  v.push_back(static_cast<uint8_t>(x >> 8));
+}
+void Append16BE(std::vector<uint8_t>& v, uint32_t x) {
+  v.push_back(static_cast<uint8_t>(x >> 8));
+  v.push_back(static_cast<uint8_t>(x));
+}
+void Append32LE(std::vector<uint8_t>& v, uint32_t x) {
+  Append16LE(v, x & 0xFFFF);
+  Append16LE(v, x >> 16);
+}
+void Append32BE(std::vector<uint8_t>& v, uint32_t x) {
+  Append16BE(v, x >> 16);
+  Append16BE(v, x & 0xFFFF);
+}
+
+// rANS renormalization threshold for a symbol of the given frequency.
+uint32_t RenormThreshold(uint32_t freq) {
+  return ((kAnsWordL >> kAnsWordMBits) << kAnsWordLBits) * freq;
+}
+
+// ------------------------------ Frequency model (Iguana "observe")
+
+struct RawStats {
+  uint32_t freqs[256] = {};
+  uint32_t cum[257] = {};
+};
+
+int Histogram(uint32_t freqs[256], const uint8_t* src, size_t n) {
+  uint32_t h[4][256] = {};
+  const size_t e = n & ~size_t{3};
+  for (size_t i = 0; i < e; i += 4) {
+    h[0][src[i + 0]]++;
+    h[1][src[i + 1]]++;
+    h[2][src[i + 2]]++;
+    h[3][src[i + 3]]++;
+  }
+  for (size_t i = e; i < n; ++i) h[0][src[i]]++;
+  for (int i = 0; i < 256; ++i) {
+    freqs[i] = h[0][i] + h[1][i] + h[2][i] + h[3][i];
+  }
+  for (int i = 0; i < 256; ++i) {
+    if (freqs[i] != 0) return i;
+  }
+  return -1;
+}
+
+void NormalizeFreqs(RawStats& s) {
+  for (int i = 0; i < 256; ++i) s.cum[i + 1] = s.cum[i] + s.freqs[i];
+
+  const uint32_t cur = s.cum[256];
+  for (int i = 1; i <= 256; ++i) {
+    s.cum[i] = static_cast<uint32_t>(
+        (static_cast<uint64_t>(kAnsWordM) * s.cum[i]) / cur);
+  }
+
+  // Any symbol that was rounded to zero frequency steals range from the
+  // smallest symbol that still has more than one.
+  for (int i = 0; i < 256; ++i) {
+    if (s.freqs[i] != 0 && s.cum[i + 1] == s.cum[i]) {
+      uint32_t best_freq = ~uint32_t{0};
+      int best_steal = -1;
+      for (int j = 0; j < 256; ++j) {
+        const uint32_t f = s.cum[j + 1] - s.cum[j];
+        if (f > 1 && f < best_freq) {
+          best_freq = f;
+          best_steal = j;
+        }
+      }
+      if (best_steal < i) {
+        for (int j = best_steal + 1; j <= i; ++j) s.cum[j]--;
+      } else {
+        for (int j = i + 1; j <= best_steal; ++j) s.cum[j]++;
+      }
+    }
+  }
+
+  for (int i = 0; i < 256; ++i) s.freqs[i] = s.cum[i + 1] - s.cum[i];
+}
+
+// ------------------------------ Serialized-table bit stream (LSB-first)
+
+struct BitWriter {
+  uint64_t acc = 0;
+  int cnt = 0;
+  std::vector<uint8_t> buf;
+  void Add(uint32_t v, uint32_t k) {
+    const uint32_t mask = ~(~uint32_t{0} << k);
+    acc |= static_cast<uint64_t>(v & mask) << cnt;
+    cnt += static_cast<int>(k);
+    while (cnt >= 8) {
+      buf.push_back(static_cast<uint8_t>(acc));
+      acc >>= 8;
+      cnt -= 8;
+    }
+  }
+  void Flush() {
+    while (cnt > 0) {
+      buf.push_back(static_cast<uint8_t>(acc));
+      acc >>= 8;
+      cnt -= 8;
+    }
+  }
+};
+
+// Reads nibbles back-to-front; `idx` counts nibbles, `ok` clears on underflow.
+uint32_t FetchNibble(const uint8_t* src, int& idx, bool& ok) {
+  if (idx < 0) {
+    ok = false;
+    return 0;
+  }
+  const uint8_t x = src[static_cast<size_t>(idx) >> 1];
+  const uint32_t r = (idx & 1) ? static_cast<uint32_t>(x & 0x0F)
+                               : static_cast<uint32_t>(x >> 4);
+  --idx;
+  return r;
+}
+
+void BuildDenseTable(AnsDenseTable& table, const uint32_t freqs[256]) {
+  table.assign(kAnsWordM, 0);
+  uint32_t start = 0;
+  for (uint32_t sym = 0; sym < 256; ++sym) {
+    const uint32_t freq = freqs[sym];
+    for (uint32_t i = 0; i < freq; ++i) {
+      table[start + i] = (sym << 24) | (i << kAnsWordMBits) | freq;
+    }
+    start += freq;
+  }
+}
+
+}  // namespace
+
+AnsStatistics AnsStatistics::FromData(const uint8_t* data, size_t size) {
+  RawStats s;
+  if (size == 0) {
+    s.freqs[254] = kAnsWordM / 2;
+    s.freqs[255] = kAnsWordM / 2;
+    s.cum[255] = kAnsWordM / 2;
+    s.cum[256] = kAnsWordM;
+  } else {
+    const int nz = Histogram(s.freqs, data, size);
+    HWY_DASSERT(nz >= 0);
+    if (s.freqs[nz] == static_cast<uint32_t>(size)) {
+      // Single distinct byte: give it kAnsWordM - 1 so the total is encodable.
+      s.freqs[nz] = kAnsWordM - 1;
+      for (int i = nz + 1; i < 257; ++i) s.cum[i] = kAnsWordM - 1;
+    } else {
+      NormalizeFreqs(s);
+    }
+  }
+
+  AnsStatistics out;
+  for (int i = 0; i < 256; ++i) {
+    out.packed[i] = (s.cum[i] << kAnsWordMBits) | s.freqs[i];
+  }
+  return out;
+}
+
+void AnsStatistics::Serialize(std::vector<uint8_t>& out) const {
+  BitWriter ctrl, data;
+  for (int i = 0; i < 256; ++i) {
+    const uint32_t f = Freq(static_cast<size_t>(i));
+    if (f < 5) {
+      ctrl.Add(f, 3);
+    } else if (f < 21) {
+      ctrl.Add(0b101, 3);
+      data.Add(f - 5, 4);
+    } else if (f < 277) {
+      ctrl.Add(0b110, 3);
+      data.Add(f - 21, 8);
+    } else {
+      ctrl.Add(0b111, 3);
+      data.Add(f - 277, 12);
+    }
+  }
+  ctrl.Flush();
+  data.Flush();
+
+  const size_t base = out.size();
+  out.resize(base + data.buf.size() + ctrl.buf.size());
+  for (size_t i = 0; i < data.buf.size(); ++i) {
+    out[base + data.buf.size() - i - 1] = data.buf[i];
+  }
+  if (!ctrl.buf.empty()) {
+    memcpy(&out[base + data.buf.size()], ctrl.buf.data(), ctrl.buf.size());
+  }
+  out.push_back(0);  // "full table" compression level
+}
+
+size_t DeserializeAnsTable(AnsDenseTable& table, const uint8_t* src,
+                           size_t size) {
+  if (size < 1 + kAnsCtrlBlockSize) return SIZE_MAX;
+  const uint8_t level = src[size - 1];
+  if (level != 0) return SIZE_MAX;  // only the full table is supported here
+  size -= 1;
+
+  const uint8_t* ctrl = src + size - kAnsCtrlBlockSize;
+  int nibidx = static_cast<int>(size - kAnsCtrlBlockSize - 1) * 2 + 1;
+  uint32_t freqs[256] = {};
+  bool ok = true;
+  int k = 0;
+  for (size_t i = 0; i < kAnsCtrlBlockSize; i += 3) {
+    uint32_t x = static_cast<uint32_t>(ctrl[i]) |
+                 (static_cast<uint32_t>(ctrl[i + 1]) << 8) |
+                 (static_cast<uint32_t>(ctrl[i + 2]) << 16);
+    for (int j = 0; j < 8; ++j, ++k) {
+      const uint32_t v = x & 7;
+      x >>= 3;
+      if (v == 7) {
+        const uint32_t x0 = FetchNibble(src, nibidx, ok);
+        const uint32_t x1 = FetchNibble(src, nibidx, ok);
+        const uint32_t x2 = FetchNibble(src, nibidx, ok);
+        freqs[k] = (x0 | (x1 << 4) | (x2 << 8)) + 277;
+      } else if (v == 6) {
+        const uint32_t x0 = FetchNibble(src, nibidx, ok);
+        const uint32_t x1 = FetchNibble(src, nibidx, ok);
+        freqs[k] = (x0 | (x1 << 4)) + 21;
+      } else if (v == 5) {
+        freqs[k] = FetchNibble(src, nibidx, ok) + 5;
+      } else {
+        freqs[k] = v;
+      }
+    }
+  }
+  if (!ok) return SIZE_MAX;
+
+  // The normalized frequencies sum to kAnsWordM, except for the single-symbol
+  // edge case where they sum to kAnsWordM - 1 (see AnsStatistics::FromData).
+  uint64_t total = 0;
+  for (uint32_t f : freqs) total += f;
+  if (total > kAnsWordM) return SIZE_MAX;
+
+  BuildDenseTable(table, freqs);
+  return static_cast<size_t>((nibidx + 1) >> 1);
+}
+
+// ------------------------------ ANS32 encoder (scalar; unchanged from Iguana)
+
+std::vector<uint8_t> Ans32Encode(const uint8_t* data, size_t size) {
+  const AnsStatistics stats = AnsStatistics::FromData(data, size);
+
+  uint32_t state[kAnsLanes];
+  for (int i = 0; i < kAnsLanes; ++i) state[i] = kAnsWordL;
+  std::vector<uint8_t> fwd, rev;
+
+  const auto put = [&](const uint8_t* chunk, size_t avail) {
+    for (int lane = 15; lane >= 0; --lane) {
+      if (static_cast<size_t>(lane) >= avail) continue;
+      const uint32_t freq = stats.Freq(chunk[lane]);
+      const uint32_t start = stats.CumFreq(chunk[lane]);
+      uint32_t x = state[lane];
+      if (x >= RenormThreshold(freq)) {
+        Append16BE(fwd, x & 0xFFFF);
+        x >>= kAnsWordLBits;
+      }
+      state[lane] = ((x / freq) << kAnsWordMBits) + (x % freq) + start;
+    }
+    for (int lane = 31; lane >= 16; --lane) {
+      if (static_cast<size_t>(lane) >= avail) continue;
+      const uint32_t freq = stats.Freq(chunk[lane]);
+      const uint32_t start = stats.CumFreq(chunk[lane]);
+      uint32_t x = state[lane];
+      if (x >= RenormThreshold(freq)) {
+        Append16LE(rev, x & 0xFFFF);
+        x >>= kAnsWordLBits;
+      }
+      state[lane] = ((x / freq) << kAnsWordMBits) + (x % freq) + start;
+    }
+  };
+
+  const size_t last = size % 32;
+  size_t k = size - last;
+  put(data + k, last);
+  for (long kk = static_cast<long>(k) - 32; kk >= 0; kk -= 32) {
+    put(data + static_cast<size_t>(kk), 32);
+  }
+
+  for (int lane = 15; lane >= 0; --lane) Append32BE(fwd, state[lane]);
+  for (int lane = 16; lane < 32; ++lane) Append32LE(rev, state[lane]);
+
+  std::vector<uint8_t> out(fwd.rbegin(), fwd.rend());
+  out.insert(out.end(), rev.begin(), rev.end());
+
+  AnsStatistics::FromData(data, size).Serialize(out);
+  return out;
+}
+
+// ------------------------------ ANS32 scalar reference decoder
+
+bool Ans32DecodePayloadScalar(const uint8_t* src, size_t src_size,
+                              const AnsDenseTable& table, uint8_t* dst,
+                              size_t orig_size) {
+  if (src_size < 128) return false;
+
+  uint32_t state[kAnsLanes];
+  size_t cursor_fwd = 64;
+  size_t cursor_rev = src_size - 64;
+  for (int lane = 0; lane < 16; ++lane) {
+    state[lane] = Read32LE(src + lane * 4);
+    state[lane + 16] =
+        Read32LE(src + static_cast<size_t>(lane) * 4 + cursor_rev);
+  }
+
+  size_t cursor_dst = 0;
+  for (;;) {
+    bool stop = false;
+    for (int lane = 0; lane < 32; ++lane) {
+      const uint32_t x = state[lane];
+      const uint32_t t = table[x & kAnsFreqMask];
+      const uint32_t freq = t & kAnsFreqMask;
+      const uint32_t bias = (t >> kAnsWordMBits) & kAnsFreqMask;
+      state[lane] = freq * (x >> kAnsWordMBits) + bias;
+      if (cursor_dst < orig_size) {
+        dst[cursor_dst++] = static_cast<uint8_t>(t >> 24);
+      } else {
+        stop = true;
+        break;
+      }
+    }
+    if (stop) break;
+
+    for (int lane = 0; lane < 16; ++lane) {
+      if (state[lane] < kAnsWordL) {
+        if (cursor_fwd + 2 > cursor_rev) return false;
+        state[lane] =
+            (state[lane] << kAnsWordLBits) | Read16LE(src + cursor_fwd);
+        cursor_fwd += 2;
+      }
+    }
+    for (int lane = 16; lane < 32; ++lane) {
+      if (state[lane] < kAnsWordL) {
+        if (cursor_rev < cursor_fwd + 2) return false;
+        state[lane] =
+            (state[lane] << kAnsWordLBits) | Read16LE(src + cursor_rev - 2);
+        cursor_rev -= 2;
+      }
+    }
+  }
+  return true;
+}
+
+bool Ans32DecodeScalar(const uint8_t* src, size_t src_size, uint8_t* dst,
+                       size_t orig_size) {
+  AnsDenseTable table;
+  const size_t payload = DeserializeAnsTable(table, src, src_size);
+  if (payload == SIZE_MAX) return false;
+  return Ans32DecodePayloadScalar(src, payload, table, dst, orig_size);
+}
+
+}  // namespace iguana
+}  // namespace hwy

--- a/hwy/contrib/iguana/ans.cc
+++ b/hwy/contrib/iguana/ans.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "hwy/base.h"  // HWY_DASSERT
+#include "hwy/contrib/iguana/ans_detail.h"
 
 namespace hwy {
 namespace iguana {

--- a/hwy/contrib/iguana/ans.h
+++ b/hwy/contrib/iguana/ans.h
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Non-SIMD parts of Iguana's ANS32 entropy coder: the frequency model, the
+// dense-table (de)serialization, and the scalar encoder / reference decoder.
+// The SIMD decoder is in ans-inl.h.
+//
+// This is a port of the 32-way interleaved rANS entropy stage of Iguana
+// (github.com/SnellerInc/sneller, ion/zion/iguana), which is the "10 GB/s"
+// core of that compressor. It is based on the pure-Go reference implementation
+// (ans32.go, ans_statistics.go); the bitstream is byte-for-byte compatible.
+// The rANS scheme itself is Fabian Giesen's ryg_rans.
+//
+// This covers only the entropy stage. Iguana's LZ77 layer is a possible
+// follow-up.
+
+#ifndef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_H_
+#define HIGHWAY_HWY_CONTRIB_IGUANA_ANS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
+namespace hwy {
+namespace iguana {
+
+// ------------------------------ Constants (bitstream format)
+
+constexpr uint32_t kAnsWordLBits = 16;
+constexpr uint32_t kAnsWordL = uint32_t{1} << kAnsWordLBits;  // 65536
+constexpr uint32_t kAnsWordMBits = 12;
+constexpr uint32_t kAnsWordM = uint32_t{1} << kAnsWordMBits;  // 4096
+constexpr uint32_t kAnsFreqMask = kAnsWordM - 1;
+
+// 32 interleaved rANS streams: 16 written/read forwards, 16 backwards.
+constexpr int kAnsLanes = 32;
+
+// Longest possible serialized frequency table.
+constexpr size_t kAnsCtrlBlockSize = 96;
+constexpr size_t kAnsDenseTableMaxLength = kAnsCtrlBlockSize + 384;
+
+// ------------------------------ Frequency model
+
+// Normalized per-symbol frequencies, summing to kAnsWordM. `packed[i]` is
+// (cumulative_freq[i] << 12) | freq[i]; `Freq()` / `CumFreq()` unpack it.
+struct AnsStatistics {
+  uint32_t packed[256] = {};
+
+  uint32_t Freq(size_t sym) const { return packed[sym] & kAnsFreqMask; }
+  uint32_t CumFreq(size_t sym) const {
+    return (packed[sym] >> kAnsWordMBits) & kAnsFreqMask;
+  }
+
+  // Builds the model from `data` (the Iguana "observe" step: histogram +
+  // normalization, with the empty-input and single-symbol edge cases).
+  static AnsStatistics FromData(const uint8_t* data, size_t size);
+
+  // Appends the serialized table (Iguana "EncodeFull" + a zero level byte).
+  void Serialize(std::vector<uint8_t>& out) const;
+};
+
+// 4096-entry rANS decoding table: entry = (sym << 24) | (i << 12) | freq.
+using AnsDenseTable = std::vector<uint32_t>;
+
+// Parses a table serialized by AnsStatistics::Serialize from the END of
+// `src[0, size)`. Returns the length of the data that precedes it (the rANS
+// payload), or SIZE_MAX on malformed input.
+size_t DeserializeAnsTable(AnsDenseTable& table, const uint8_t* src,
+                           size_t size);
+
+// ------------------------------ ANS32 codec
+
+// Encodes `data` into the 32-way interleaved rANS payload followed by the
+// serialized frequency table (i.e. a complete ANS32 block).
+std::vector<uint8_t> Ans32Encode(const uint8_t* data, size_t size);
+
+// Scalar reference decoder for a block produced by Ans32Encode. `orig_size` is
+// the decompressed length. Returns false on malformed input. The SIMD decoder
+// (ans-inl.h) produces identical output.
+bool Ans32DecodeScalar(const uint8_t* src, size_t src_size, uint8_t* dst,
+                       size_t orig_size);
+
+// Same, but the frequency table has already been parsed: `payload` is the rANS
+// data only (DeserializeAnsTable's prefix length), `table` its dense table.
+bool Ans32DecodePayloadScalar(const uint8_t* payload, size_t payload_size,
+                              const AnsDenseTable& table, uint8_t* dst,
+                              size_t orig_size);
+
+}  // namespace iguana
+}  // namespace hwy
+
+#endif  // HIGHWAY_HWY_CONTRIB_IGUANA_ANS_H_

--- a/hwy/contrib/iguana/ans.h
+++ b/hwy/contrib/iguana/ans.h
@@ -38,19 +38,14 @@ namespace hwy {
 namespace iguana {
 
 // ------------------------------ Constants (bitstream format)
+//
+// Only what AnsStatistics's inline methods below need is public here; the
+// rest (word/lane layout, serialized-table sizing) is an implementation
+// detail shared by ans.cc/ans-inl.h -- see ans_detail.h.
 
-constexpr uint32_t kAnsWordLBits = 16;
-constexpr uint32_t kAnsWordL = uint32_t{1} << kAnsWordLBits;  // 65536
 constexpr uint32_t kAnsWordMBits = 12;
 constexpr uint32_t kAnsWordM = uint32_t{1} << kAnsWordMBits;  // 4096
 constexpr uint32_t kAnsFreqMask = kAnsWordM - 1;
-
-// 32 interleaved rANS streams: 16 written/read forwards, 16 backwards.
-constexpr int kAnsLanes = 32;
-
-// Longest possible serialized frequency table.
-constexpr size_t kAnsCtrlBlockSize = 96;
-constexpr size_t kAnsDenseTableMaxLength = kAnsCtrlBlockSize + 384;
 
 // ------------------------------ Frequency model
 

--- a/hwy/contrib/iguana/ans_detail.h
+++ b/hwy/contrib/iguana/ans_detail.h
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal bitstream-format constants shared by ans.cc (scalar codec) and
+// ans-inl.h (SIMD decoder). Not part of the public interface: callers of
+// ans.h's Ans32Encode/Ans32DecodeScalar/AnsStatistics never need these
+// directly. kAnsWordMBits/kAnsWordM/kAnsFreqMask stay in ans.h instead,
+// since AnsStatistics::Freq/CumFreq (defined inline there) need them.
+
+#ifndef HIGHWAY_HWY_CONTRIB_IGUANA_ANS_DETAIL_H_
+#define HIGHWAY_HWY_CONTRIB_IGUANA_ANS_DETAIL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace hwy {
+namespace iguana {
+
+constexpr uint32_t kAnsWordLBits = 16;
+constexpr uint32_t kAnsWordL = uint32_t{1} << kAnsWordLBits;  // 65536
+
+// 32 interleaved rANS streams: 16 written/read forwards, 16 backwards.
+constexpr int kAnsLanes = 32;
+
+// Longest possible serialized frequency table.
+constexpr size_t kAnsCtrlBlockSize = 96;
+constexpr size_t kAnsDenseTableMaxLength = kAnsCtrlBlockSize + 384;
+
+}  // namespace iguana
+}  // namespace hwy
+
+#endif  // HIGHWAY_HWY_CONTRIB_IGUANA_ANS_DETAIL_H_

--- a/hwy/contrib/iguana/ans_test.cc
+++ b/hwy/contrib/iguana/ans_test.cc
@@ -34,26 +34,18 @@ namespace hwy {
 namespace HWY_NAMESPACE {
 namespace {
 
-namespace ans = hwy::HWY_NAMESPACE::iguana_ans;
-
-uint64_t NextRandom(uint64_t& state) {
-  state ^= state << 13;
-  state ^= state >> 7;
-  state ^= state << 17;
-  return state;
-}
+namespace ans = hwy::iguana_ans::HWY_NAMESPACE;
 
 // Skewed toward small values (compressible), or uniform when skew == 0.
 std::vector<uint8_t> MakeData(size_t n, uint64_t seed, int skew) {
-  uint64_t state = seed | 1;
+  RandomState rng(seed);
   std::vector<uint8_t> v(n);
   for (auto& x : v) {
     if (skew == 0) {
-      x = static_cast<uint8_t>(NextRandom(state));
+      x = static_cast<uint8_t>(Random32(&rng));
     } else {
       uint32_t a = 0;
-      for (int k = 0; k < skew; ++k)
-        a += static_cast<uint32_t>(NextRandom(state) & 0x3F);
+      for (int k = 0; k < skew; ++k) a += Random32(&rng) & 0x3F;
       x = static_cast<uint8_t>(a);
     }
   }
@@ -77,11 +69,21 @@ void RoundTrip(const std::vector<uint8_t>& data) {
 }
 
 void TestRoundTripSizes() {
-  const size_t kSizes[] = {0,    1,    2,     31,    32,   33,  63,
-                           64,   65,   100,   255,   256,  257, 1024,
-                           4096, 4097, 65535, 65536, 70000};
-  for (size_t idx = 0; idx < sizeof(kSizes) / sizeof(kSizes[0]); ++idx) {
-    const size_t n = kSizes[idx];
+  const size_t kSmallSizes[] = {0,   1,   2,   31,  32,  33,  63,
+                                64,  65,  100, 255, 256, 257, 1024};
+  for (size_t n : kSmallSizes) {
+    RoundTrip(MakeData(n, n * 3 + 1, 3));
+    RoundTrip(MakeData(n, n * 5 + 2, 1));
+    RoundTrip(MakeData(n, n * 7 + 3, 0));
+  }
+
+  // >1024: AdjustedReps keeps release builds at the original sizes but
+  // shrinks them for slow debug/emulated (RVV, ARM, MSVC) runs, so the
+  // test doesn't time out there.
+  const size_t kLargeSizes[] = {AdjustedReps(4096), AdjustedReps(4097),
+                                AdjustedReps(65535), AdjustedReps(65536),
+                                AdjustedReps(70000)};
+  for (size_t n : kLargeSizes) {
     RoundTrip(MakeData(n, n * 3 + 1, 3));
     RoundTrip(MakeData(n, n * 5 + 2, 1));
     RoundTrip(MakeData(n, n * 7 + 3, 0));
@@ -90,11 +92,11 @@ void TestRoundTripSizes() {
 
 void TestRoundTripModels() {
   // Large skewed input (compresses; exercises many vector rounds).
-  RoundTrip(MakeData(300000, 0xABCDEF, 3));
+  RoundTrip(MakeData(AdjustedReps(300000), 0xABCDEF, 3));
   // Single distinct byte.
-  RoundTrip(std::vector<uint8_t>(5000, 0x42));
+  RoundTrip(std::vector<uint8_t>(AdjustedReps(5000), 0x42));
   // Two symbols.
-  std::vector<uint8_t> two(4000);
+  std::vector<uint8_t> two(AdjustedReps(4000));
   for (size_t i = 0; i < two.size(); ++i) {
     two[i] = static_cast<uint8_t>((i % 7) ? 0x10 : 0x20);
   }

--- a/hwy/contrib/iguana/ans_test.cc
+++ b/hwy/contrib/iguana/ans_test.cc
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <vector>
+
+// clang-format off
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "hwy/contrib/iguana/ans_test.cc"  // NOLINT
+#include "hwy/foreach_target.h"  // IWYU pragma: keep
+#include "hwy/highway.h"
+#include "hwy/contrib/iguana/ans.h"
+#include "hwy/contrib/iguana/ans-inl.h"
+#include "hwy/tests/test_util-inl.h"
+// clang-format on
+
+HWY_BEFORE_NAMESPACE();
+namespace hwy {
+namespace HWY_NAMESPACE {
+namespace {
+
+namespace ans = hwy::HWY_NAMESPACE::iguana_ans;
+
+uint64_t NextRandom(uint64_t& state) {
+  state ^= state << 13;
+  state ^= state >> 7;
+  state ^= state << 17;
+  return state;
+}
+
+// Skewed toward small values (compressible), or uniform when skew == 0.
+std::vector<uint8_t> MakeData(size_t n, uint64_t seed, int skew) {
+  uint64_t state = seed | 1;
+  std::vector<uint8_t> v(n);
+  for (auto& x : v) {
+    if (skew == 0) {
+      x = static_cast<uint8_t>(NextRandom(state));
+    } else {
+      uint32_t a = 0;
+      for (int k = 0; k < skew; ++k)
+        a += static_cast<uint32_t>(NextRandom(state) & 0x3F);
+      x = static_cast<uint8_t>(a);
+    }
+  }
+  return v;
+}
+
+void RoundTrip(const std::vector<uint8_t>& data) {
+  std::vector<uint8_t> enc = hwy::iguana::Ans32Encode(data.data(), data.size());
+  HWY_ASSERT(!enc.empty());
+
+  std::vector<uint8_t> dec(data.size(), 0xCD);
+  HWY_ASSERT(ans::Ans32Decode(enc.data(), enc.size(), dec.data(), data.size()));
+  HWY_ASSERT(data.empty() || memcmp(dec.data(), data.data(), data.size()) == 0);
+
+  // The SIMD decoder must match the scalar reference bit-for-bit.
+  std::vector<uint8_t> dec2(data.size(), 0xAB);
+  HWY_ASSERT(hwy::iguana::Ans32DecodeScalar(enc.data(), enc.size(), dec2.data(),
+                                            data.size()));
+  HWY_ASSERT(data.empty() ||
+             memcmp(dec2.data(), data.data(), data.size()) == 0);
+}
+
+void TestRoundTripSizes() {
+  const size_t kSizes[] = {0,    1,    2,     31,    32,   33,  63,
+                           64,   65,   100,   255,   256,  257, 1024,
+                           4096, 4097, 65535, 65536, 70000};
+  for (size_t idx = 0; idx < sizeof(kSizes) / sizeof(kSizes[0]); ++idx) {
+    const size_t n = kSizes[idx];
+    RoundTrip(MakeData(n, n * 3 + 1, 3));
+    RoundTrip(MakeData(n, n * 5 + 2, 1));
+    RoundTrip(MakeData(n, n * 7 + 3, 0));
+  }
+}
+
+void TestRoundTripModels() {
+  // Large skewed input (compresses; exercises many vector rounds).
+  RoundTrip(MakeData(300000, 0xABCDEF, 3));
+  // Single distinct byte.
+  RoundTrip(std::vector<uint8_t>(5000, 0x42));
+  // Two symbols.
+  std::vector<uint8_t> two(4000);
+  for (size_t i = 0; i < two.size(); ++i) {
+    two[i] = static_cast<uint8_t>((i % 7) ? 0x10 : 0x20);
+  }
+  RoundTrip(two);
+}
+
+}  // namespace
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace hwy
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace hwy {
+HWY_BEFORE_TEST(IguanaAnsTest);
+HWY_EXPORT_AND_TEST_P(IguanaAnsTest, TestRoundTripSizes);
+HWY_EXPORT_AND_TEST_P(IguanaAnsTest, TestRoundTripModels);
+HWY_AFTER_TEST();
+}  // namespace hwy
+#endif

--- a/hwy_tests.bzl
+++ b/hwy_tests.bzl
@@ -53,6 +53,11 @@ HWY_CONTRIB_TESTS = (
         [":dot"],
     ),
     (
+        "hwy/contrib/iguana/",
+        "ans_test",
+        [":iguana_ans"],
+    ),
+    (
         "hwy/contrib/image/",
         "image_test",
         [":image"],

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,8 @@ hwy_contrib_headers = files(
     'hwy/contrib/coder/range_coder.h',
     'hwy/contrib/coder/range_coder-inl.h',
     'hwy/contrib/dot/dot-inl.h',
+    'hwy/contrib/iguana/ans.h',
+    'hwy/contrib/iguana/ans-inl.h',
     'hwy/contrib/hash/hash-inl.h',
     'hwy/contrib/hash/highwayhash-inl.h',
     'hwy/contrib/hash/phast.h',
@@ -171,6 +173,7 @@ hwy_contrib_headers = files(
 
 hwy_contrib_sources = files(
     'hwy/contrib/coder/range_coder.cc',
+    'hwy/contrib/iguana/ans.cc',
     'hwy/contrib/image/image.cc',
     'hwy/contrib/hash/cuckoo2x2.cc',
     'hwy/contrib/hash/phast.cc',
@@ -706,6 +709,7 @@ if tests_enabled
             'hwy/contrib/bit_pack/bit_pack_test.cc',
             'hwy/contrib/coder/range_coder_test.cc',
             'hwy/contrib/dot/dot_test.cc',
+            'hwy/contrib/iguana/ans_test.cc',
             'hwy/contrib/hash/hash_test.cc',
             'hwy/contrib/hash/highwayhash_test.cc',
             'hwy/contrib/hash/cuckoo2x2_test.cc',

--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,7 @@ hwy_contrib_headers = files(
     'hwy/contrib/coder/range_coder-inl.h',
     'hwy/contrib/dot/dot-inl.h',
     'hwy/contrib/iguana/ans.h',
+    'hwy/contrib/iguana/ans_detail.h',
     'hwy/contrib/iguana/ans-inl.h',
     'hwy/contrib/hash/hash-inl.h',
     'hwy/contrib/hash/highwayhash-inl.h',


### PR DESCRIPTION
First step of the **Iguana** `op_wishlist.md` item: a Highway port of Iguana's
**ANS32 entropy stage** — the 32-way interleaved rANS coder that is the
"decompress at 10+ GB/s" core of that compressor
(github.com/SnellerInc/sneller, `ion/zion/iguana`).

The upstream repo is gone, so this is ported from the pure-Go reference
(`ans32.go`, `ans_statistics.go`, recovered via the Go module proxy). The
bitstream is byte-for-byte compatible with it.

### What's here (`hwy/contrib/iguana/`)

| file | contents |
|---|---|
| `ans.h` / `ans.cc` | the frequency model (`observe`: 4-way histogram + normalization, with the empty-input and single-symbol edge cases), the dense-table (de)serialization (`EncodeFull` / `ansDecodeFullTable`), the scalar ANS32 encoder, and a scalar reference decoder |
| `ans-inl.h` | **SIMD `Ans32Decode`**. Each round decodes 32 symbols (16 "forward" + 16 "reverse" lanes) with `GatherIndex` into the dense table and one `Mul`/`Add`, then renormalizes the lanes whose state dropped below 2^16 by pulling one 16-bit word each from the two ends of the payload — vectorized with `Expand` (+ `Reverse` for the backward half). Works on `CappedTag<uint32_t, 16>`, so 4 / 8 / 16 lanes per group depending on the target. `HWY_SCALAR` and the scalable targets fall back to the scalar reference. |
| `ans_test.cc` | round-trips a range of sizes (0, sub-round, many rounds, tail remainders) and models (skewed / uniform / one / two symbols), and checks the SIMD decoder against the scalar reference bit-for-bit |

Wired into CMake, Bazel and Meson.

### Validation

- `ans_test` passes on AVX3 / AVX2 / SSE4 / SSSE3 / SSE2 / EMU128 locally.
- Strict `-Werror` build (`-Wconversion -Wsign-conversion -Wshadow -Wcast-align
  …`) and `clang-format` are clean.
- A standalone C++ port of the Go reference (built separately) round-trips every
  test case; the encoder here produces the same block, and both decoders
  reproduce the input.

### Not in this PR

Iguana's LZ77 layer (`decoder.go`), and `ANS1` / `ANS_nibble`. The ANS32
decoder's final reduction is still partly scalar (the sub-32-symbol tail);
`Expand`-heavy targets could also use a `TruncateTo` for the symbol pack. All
straightforward follow-ups.
