### PR TITLE
algo_bench.cc improvements. Add BenchCopyIf

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -949,6 +949,7 @@ cc_test(
     ],
     deps = HWY_TEST_DEPS + [
         ":algo",
+        ":stats",
     ],
 )
 

--- a/hwy/contrib/algo/algo_bench.cc
+++ b/hwy/contrib/algo/algo_bench.cc
@@ -19,6 +19,7 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
+#include <array>
 
 // clang-format off
 #undef HWY_TARGET_INCLUDE
@@ -27,17 +28,22 @@
 
 // After foreach_target
 #include "hwy/contrib/algo/find-inl.h"
+#include "hwy/contrib/algo/copy-inl.h"
 #include "hwy/tests/test_util-inl.h"
 #include "hwy/nanobenchmark.h"
 #include "hwy/timer.h"
+#include "hwy/stats.h"
 // clang-format on
 
 HWY_BEFORE_NAMESPACE();
 namespace hwy {
 namespace HWY_NAMESPACE {
 namespace {
+constexpr bool kPrintOnlySummary = false;
+
 constexpr bool kBenchUnique = true;
 constexpr bool kBenchAllUnique = true;
+constexpr bool kBenchCopyIf = true;
 
 // copied from sort
 enum class BenchmarkModes {
@@ -117,63 +123,97 @@ struct Ctx {
   Gen gen;
   RandomState rng;
   size_t size; // every algo function has a size field
-  size_t inner_reps;
+};
+
+struct BenchSummary {
+  const char* name_ = nullptr;
+  Stats stats;
+  double l6_sum = 0;
+  void Add(const char* name, double ns) {
+    HWY_ASSERT(name_ == nullptr || name_ == name);
+    name_ = name;
+    stats.Notify(static_cast<float>(ns));
+    l6_sum += std::pow(ns, 6);
+  }
+  double L6() const {
+    const int64_t n = stats.Count();
+    return n == 0 ? 0.0 : std::pow(l6_sum / static_cast<double>(n), 1.0 / 6);
+  }
+  void Print() const {
+    printf("%-10s:    L6 norm (ns/elem): %f\n", name_, L6());
+    printf("%-10s:    GeoMean (ns/elem): %f\n", name_, stats.GeometricMean());
+  }
 };
 
 // A generator is a functor, all kParams variants are run. Its fields are:
 // kName = the name in the output string
 // PrintParam = the parameter output format
 // kParams = the parameter list
-// operator() = generates input. It receives Ctx, the pointer and p - parameter
+// operator() = generates input. It receives Ctx, array of pointers and p - parameter
 
 // A measured function is a functor. Its fields are:
+// kBench8 = whether the function supports 8-bit values
 // kName = the name in the output string
-// operator() = runs the function. Generates data via ctx.gen and measures the total
-// time of inner_reps runs. Receives: Ctx, the array of pointers and p - generator parameter
+// kNumBuffers = number of buffers the function needs
+// operator() = runs the function. Receives: Ctx and the array of pointers
 
 // Benchmarks are run via BenchAllTypes(Func{}, Gen{}, size)
 
 template <class T, class Func, class Gen>
-void Bench(Func func, Gen gen, size_t size, double& L6_acc, size_t& L6_cnt) {
+void Bench(Func func, Gen gen, size_t size, BenchSummary& summary) {
   RandomState rng(static_cast<uint64_t>(Unpredictable1() * 42));
 
   const size_t inner_reps = HWY_MIN(kInnerRepsMax, HWY_MAX(kElemsPerInnerRep / size, size_t{3}));
 
-  std::vector<AlignedFreeUniquePtr<T[]>> ptrs(inner_reps);
-  Ctx<Gen> ctx{gen, rng, size, inner_reps};
+  Ctx<Gen> ctx{gen, rng, size};
 
   const ScalableTag<T> d;
   const size_t N = Lanes(d);
 
-  for (size_t i = 0; i < inner_reps; ++i) {
-    ptrs[i] = AllocateAligned<T>(size + N);
-  }
+  std::vector<std::array<AlignedFreeUniquePtr<T[]>, Func::kNumBuffers>> ptrs(inner_reps);
+  std::vector<std::array<T*, Func::kNumBuffers>> aligned(inner_reps);
 
-  std::vector<T*> aligned(inner_reps);
-  for (size_t i = 0; i < ctx.inner_reps; ++i) {
-    aligned[i] = ptrs[i].get();
+  for (size_t i = 0; i < inner_reps; ++i) {
+    for (size_t j = 0; j < Func::kNumBuffers; ++j) {
+      ptrs[i][j] = AllocateAligned<T>(size + N);
+      aligned[i][j] = ptrs[i][j].get();
+    }
   }
   for (size_t p : gen.kParams) {
     std::vector<double> ns;
     for (size_t rep = 0; rep < kOuterReps; ++rep) {
-      ns.push_back(func(ctx, aligned, p));
+      for (size_t i = 0; i < inner_reps; ++i) ctx.gen(ctx, aligned[i], p);
+
+      size_t total = 0;
+      const Timestamp t0;
+
+      for (size_t i = 0; i < inner_reps; ++i) {
+        total += func(ctx, aligned[i]);
+      }
+
+      double res = SecondsSince(t0);
+      PreventElision(total);
+      ns.push_back(res * 1e9);
     }
-    printf("%s: %9s: %12s", TargetName(DispatchedTarget()), func.kName, gen.kName);
-    Gen::PrintParam(p);
-    printf(":%4s %7zu", hwy::TypeName(T(), 1).c_str(), size);
-    const double time = SummarizeMeasurements(ns) / static_cast<double>(ctx.inner_reps);
-    printf(" %10.1f ns, %10f GB/s\n", time, static_cast<double>(ctx.gen.ElemsProcessed(size, p)) * sizeof(T) / time);
-    L6_acc += std::pow(time / static_cast<double>(size), 6);
-    L6_cnt++;
+    const double time = SummarizeMeasurements(ns) / static_cast<double>(inner_reps);
+    if (!kPrintOnlySummary) {
+      printf("%s: %9s: %12s", TargetName(DispatchedTarget()), func.kName, gen.kName);
+      Gen::PrintParam(p);
+      printf(":%4s %7zu", hwy::TypeName(T(), 1).c_str(), size);
+      printf(" %10.1f ns, %10f GB/s\n", time, static_cast<double>(ctx.gen.ElemsProcessed(size, p)) * sizeof(T) / time);
+    }
+    summary.Add(func.kName, time / static_cast<double>(size));
   }
 }
 
 template <class Func, class Gen>
-HWY_NOINLINE void BenchAllTypes(Func func, Gen gen, size_t size, double& L6_acc, size_t& L6_cnt) {
-  Bench<uint8_t>(func, gen, size, L6_acc, L6_cnt);
-  Bench<int16_t>(func, gen, size, L6_acc, L6_cnt);
-  Bench<int32_t>(func, gen, size, L6_acc, L6_cnt);
-  Bench<int64_t>(func, gen, size, L6_acc, L6_cnt);
+HWY_NOINLINE void BenchAllTypes(Func func, Gen gen, size_t size, BenchSummary& summary) {
+  if constexpr (func.kBench8) {
+    Bench<uint8_t>(func, gen, size, summary);
+  }
+  Bench<int16_t>(func, gen, size, summary);
+  Bench<int32_t>(func, gen, size, summary);
+  Bench<int64_t>(func, gen, size, summary);
 }
 
 // p = probability in % that two adjacent elements are equal
@@ -183,12 +223,12 @@ struct RandomRuns01 {
     printf("%14zu%%", p);
   }
   static constexpr const size_t kParams[] = {0, 10, 20, 50, 80, 90, 100};
-  template <class T>
-  void operator()(Ctx<RandomRuns01>& ctx, T* HWY_RESTRICT aligned, size_t p) const {
+  template <class T, size_t kNumBuffers>
+  void operator()(Ctx<RandomRuns01>& ctx, std::array<T*, kNumBuffers> buffers, size_t p) const {
     T prev = 0;
 
     for (size_t i = 0; i < ctx.size; ++i) {
-      aligned[i] = static_cast<T>(prev = (ctx.rng() % 100 >= p) ? static_cast<T>(1 - prev) : prev);
+      buffers[0][i] = static_cast<T>(prev = (ctx.rng() % 100 >= p) ? static_cast<T>(1 - prev) : prev);
     }
   }
   size_t ElemsProcessed(size_t n, size_t /*p*/) const {
@@ -202,13 +242,13 @@ struct FixedRuns01 {
     printf("   period =%4zu", p); // at all padding = 15, same as RandomRuns01
   }
   static constexpr const size_t kParams[] = {1, 31, 63, 127, 255, 511};
-  template <class T>
-  void operator()(Ctx<FixedRuns01>& ctx, T* HWY_RESTRICT aligned, size_t p) const {
+  template <class T, size_t kNumBuffers>
+  void operator()(Ctx<FixedRuns01>& ctx, std::array<T*, kNumBuffers> buffers, size_t p) const {
     T prev = 0;
 
     for (size_t i = 0; i < ctx.size; ++i) {
       if (i % p == p - 1) prev = static_cast<T>(1 - prev);
-      aligned[i] = prev;
+      buffers[0][i] = prev;
     }
   }
   size_t ElemsProcessed(size_t n, size_t /*p*/) const {
@@ -224,13 +264,13 @@ struct AltPrefixThenConstTail {
 
   static constexpr const char* kName = "alt-prefix";
   static constexpr size_t kParams[] = {25, 50, 75, 100};
-  template <class T>
-  void operator()(Ctx<AltPrefixThenConstTail>& ctx, T* HWY_RESTRICT aligned, size_t p) const {
+  template <class T, size_t kNumBuffers>
+  void operator()(Ctx<AltPrefixThenConstTail>& ctx, std::array<T*, kNumBuffers> buffers, size_t p) const {
     size_t idx = ctx.size * p / 100;
     T prev = 0;
     for (size_t i = 0; i < ctx.size; ++i) {
       prev = (i < idx) ? static_cast<T>(1 - prev) : prev;
-      aligned[i] = prev;
+      buffers[0][i] = prev;
     }
   }
   size_t ElemsProcessed(size_t n, size_t p) const {
@@ -238,67 +278,88 @@ struct AltPrefixThenConstTail {
   }
 };
 
+// p = density of ones, percentage of elements passing the predicate
+struct RandomDensity01 {
+  static constexpr const char* kName = "random-density";
+  static void PrintParam(size_t p) {
+    printf("%12zu%%", p);
+  }
+  static constexpr const size_t kParams[] = {0, 10, 20, 50, 80, 90, 100};
+  template <class T, size_t kNumBuffers>
+  void operator()(Ctx<RandomDensity01>& ctx, std::array<T*, kNumBuffers> buffers, size_t p) const {
+    for (size_t i = 0; i < ctx.size; ++i) {
+      buffers[0][i] = static_cast<T>(ctx.rng() % 100 < p);
+    }
+  }
+  size_t ElemsProcessed(size_t n, size_t p) const {
+    return n + n * p / 100;
+  }
+};
+
 struct BenchUnique {
+  static constexpr bool kBench8 = true;
   static constexpr const char* kName = "unique";
+  static constexpr const size_t kNumBuffers = 1;
   template <class Gen, class T>
-  double operator()(Ctx<Gen>& ctx, std::vector<T*>& aligned, size_t p) const {
+  size_t operator()(Ctx<Gen>& ctx, std::array<T*, kNumBuffers>& buffers) const {
     const ScalableTag<T> d;
-    for (size_t i = 0; i < ctx.inner_reps; ++i) {
-      ctx.gen(ctx, aligned[i], p);
-    }
-    const Timestamp t0;
-    size_t total = 0;
-    for (size_t i = 0; i < ctx.inner_reps; ++i) {
-      total += Unique(d, aligned[i], ctx.size);
-    }
-    double res = SecondsSince(t0);
-    PreventElision(total);
-    return res * 1e9;
+    return Unique(d, buffers[0], ctx.size);
   }
 };
 
 struct BenchAllUnique {
+  static constexpr bool kBench8 = true;
   static constexpr const char* kName = "AllUnique";
+  static constexpr const size_t kNumBuffers = 1;
 
   template <class Gen, class T>
-  double operator()(Ctx<Gen>& ctx, std::vector<T*>& aligned, size_t p) const {
+  size_t operator()(Ctx<Gen>& ctx, std::array<T*, kNumBuffers>& buffers) const {
     const ScalableTag<T> d;
-    for (size_t i = 0; i < ctx.inner_reps; ++i) {
-      ctx.gen(ctx, aligned[i], p);
-    }
-    const Timestamp t0;
-    size_t total = 0;
-    for (size_t i = 0; i < ctx.inner_reps; ++i) {
-      total += AllUnique(d, aligned[i], ctx.size);
-    }
-    double res = SecondsSince(t0);
-    PreventElision(total);
-    return res * 1e9;
+    return AllUnique(d, buffers[0], ctx.size);
   }
 };
 
-HWY_NOINLINE void BenchAll() {
-  double L6_acc_Unique = 0;
-  size_t L6_cnt_Unique = 0;
-  double L6_acc_AllUnique = 0;
-  size_t L6_cnt_AllUnique = 0;
-  for (size_t size : SizesToBenchmark(BenchmarkModes::kSmallPow2)) {
-    if (kBenchUnique) {
-      BenchAllTypes(BenchUnique{}, RandomRuns01{}, size, L6_acc_Unique, L6_cnt_Unique);
-      BenchAllTypes(BenchUnique{}, FixedRuns01{}, size, L6_acc_Unique, L6_cnt_Unique);
-    }
-    if (kBenchAllUnique) {
-      BenchAllTypes(BenchAllUnique{}, AltPrefixThenConstTail{}, size, L6_acc_AllUnique, L6_cnt_AllUnique);
-    }
+struct BenchCopyIf {
+  static constexpr bool kBench8 = false;
+  static constexpr const char* kName = "CopyIf";
+  static constexpr const size_t kNumBuffers = 2;
+
+  template <class Gen, class T>
+  size_t operator()(Ctx<Gen>& ctx, std::array<T*, kNumBuffers>& buffers) const {
+    const ScalableTag<T> d;
+    const auto is_one = [](const auto d2, const auto v) HWY_ATTR {
+      return Eq(v, Set(d2, T{1}));
+    };
+    return static_cast<size_t>(CopyIf(d, buffers[0], ctx.size, buffers[1], is_one) - buffers[1]);
   }
-  if (kBenchUnique) {
-    printf("Unique:    L6 norm (ns/elem): %f\n", std::pow(L6_acc_Unique / static_cast<double>(L6_cnt_Unique), 1.0 / 6));
-  }
-  if (kBenchAllUnique) {
-    printf("AllUnique: L6 norm (ns/elem): %f\n", std::pow(L6_acc_AllUnique / static_cast<double>(L6_cnt_AllUnique), 1.0 / 6));
+};
+
+template<typename Func, typename Gen>
+void RunAllSizes(Func func, Gen gen, const std::vector<size_t>& sizes, BenchSummary& summary) {
+  for (size_t size : sizes) {
+    BenchAllTypes(func, gen, size, summary);
   }
 }
-}  // namespace 
+HWY_NOINLINE void BenchAll() {
+  std::vector<size_t> sizes = SizesToBenchmark(BenchmarkModes::kSmallPow2);
+  if (kBenchUnique) {
+    BenchSummary summary;
+    RunAllSizes(BenchUnique{}, RandomRuns01{}, sizes, summary);
+    RunAllSizes(BenchUnique{}, FixedRuns01{}, sizes, summary);
+    summary.Print();
+  }
+  if (kBenchAllUnique) {
+    BenchSummary summary;
+    RunAllSizes(BenchAllUnique{}, AltPrefixThenConstTail{}, sizes, summary);
+    summary.Print();
+  }
+  if (kBenchCopyIf) {
+    BenchSummary summary;
+    RunAllSizes(BenchCopyIf{}, RandomDensity01{}, sizes, summary);
+    summary.Print();
+  }
+}
+}  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy


### PR DESCRIPTION
Now operator() runs the measured function only once, and Bench handles data generation and iteration over inner_reps. Also added a way to measure functions with multiple buffers by specifying kNumBuffers. For functions like CopyIf that are not benchmarked at 8bit I add kBench8 = false. Added struct BenchSummary instead of L6_cnt and L6_acc, and now also prints GeoMean. With the kPrintOnlySummary flag prints only L6 and GeoMean