### PR TITLE
fix(sort): capture asc in std::sort lambda in TestSelectWithNaNForType

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -376,7 +376,7 @@ void TestSelectWithNaNForType(Order order) {
     if (!ScalarIsNaN(x)) nonnan_in.push_back(x);
   }
   std::sort(nonnan_in.begin(), nonnan_in.end());
-  std::sort(ref.begin(), ref.end(), [](float a, float b) {
+  std::sort(ref.begin(), ref.end(), [asc](float a, float b) {
     if (ScalarIsNaN(a)) return false;  // NaN sorts to the back
     if (ScalarIsNaN(b)) return true;
     return asc ? (a < b) : (a > b);


### PR DESCRIPTION
### Summary
This PR resolves two MSVC compilation errors affecting Highway:

1. **`sort_test.cc` error C3493**:
   In `TestSelectWithNaNForType`, the custom comparator lambda for `std::sort` references the local `constexpr bool asc`, but used an empty capture `[]`. On MSVC conforming mode, this triggers:
   ```
   error C3493: 'asc' cannot be implicitly captured because no default capture mode has been specified
   ```
   Fix: Explicitly capture `[asc]`.

2. **`sorting_networks-inl.h` and `x86_128-inl.h` error C2039**:
   In `hwy/contrib/sort/sorting_networks-inl.h`, the `#else` (`!VQSORT_ENABLED`) block was wrapped in a nested `namespace detail { ... }` while already inside `namespace detail`. This created a nested `hwy::N_SSSE3::detail::detail` namespace.
   Inside `hwy/ops/x86_128-inl.h` (and `loongarch_lsx-inl.h`, `ppc_vsx-inl.h`), `CompressBits` and `CompressNotBits` inside `namespace detail` called `detail::IndicesFromBits128(...)`. Under MSVC two-phase name lookup, `detail::` resolved to `detail::detail` and failed with:
   ```
   error C2039: 'IndicesFromBits128': is not a member of 'hwy::N_SSSE3::detail::detail'
   ```
   Fix: Remove the redundant nested `namespace detail` in `sorting_networks-inl.h` and remove the redundant `detail::` qualifiers on `IndicesFromBits128` / `IndicesFromNotBits128` inside `namespace detail`.

### Testing
- Verified MSVC build (`Release` config) of `hwy_contrib`, `sort_test`, and `copy_test`.
- Ran `sort_test.exe` (35 test suites) and `copy_test.exe` across AVX2, SSE4, SSSE3, SSE2, EMU128 - all passed with 0 errors.
