### PR TITLE
fix(hash): avoid undefined shift behavior for full-width bit masks

### DIFF
--- a/hwy/contrib/hash/hash-inl.h
+++ b/hwy/contrib/hash/hash-inl.h
@@ -151,7 +151,7 @@ class MaskedWeakTwoMul {
   }
 
   static constexpr uint32_t kMask =
-      kBits == 32 ? ~uint32_t{0} : (uint32_t{1} << kBits) - 1;
+      kBits == 32 ? ~uint32_t{0} : (uint32_t{1} << (kBits & 31)) - 1;
 
   MaskedWeakTwoMul() = default;
   explicit MaskedWeakTwoMul(uint32_t key)
@@ -222,7 +222,7 @@ class MaskedTriple32 {
   }
 
   static constexpr uint32_t kMask =
-      kBits == 32 ? ~uint32_t{0} : (uint32_t{1} << kBits) - 1;
+      kBits == 32 ? ~uint32_t{0} : (uint32_t{1} << (kBits & 31)) - 1;
 
   MaskedTriple32() = default;
   explicit MaskedTriple32(uint32_t key)
@@ -307,7 +307,7 @@ class MaskedMoremur {
   }
 
   static constexpr uint64_t kMask =
-      kBits == 64 ? ~uint64_t{0} : (uint64_t{1} << kBits) - 1;
+      kBits == 64 ? ~uint64_t{0} : (uint64_t{1} << (kBits & 63)) - 1;
 
   MaskedMoremur() = default;
   explicit MaskedMoremur(uint64_t key)
@@ -381,7 +381,7 @@ class MaskedWeakXMX {
   }
 
   static constexpr uint64_t kMask =
-      kBits == 64 ? ~uint64_t{0} : (uint64_t{1} << kBits) - 1;
+      kBits == 64 ? ~uint64_t{0} : (uint64_t{1} << (kBits & 63)) - 1;
 
   MaskedWeakXMX() = default;
   explicit MaskedWeakXMX(uint64_t key)


### PR DESCRIPTION
### Problem
In `hwy/contrib/hash/hash-inl.h`, the compile-time mask `kMask` is defined as:
```cpp
static constexpr uint32_t kMask =
    kBits == 32 ? ~uint32_t{0} : (uint32_t{1} << kBits) - 1;
```
in `MaskedWeakTwoMul` and `MaskedTriple32`, and similarly:
```cpp
static constexpr uint64_t kMask =
    kBits == 64 ? ~uint64_t{0} : (uint64_t{1} << kBits) - 1;
```
in `MaskedMoremur` and `MaskedWeakXMX`.

When instantiated with full width (`kBits == 32` or `kBits == 64`), the ternary operator's true branch is selected. However, the compiler still instantiates the false branch `(uint32_t{1} << 32) - 1` or `(uint64_t{1} << 64) - 1`. Shifting an integer by its bit width or greater is undefined behavior under the C++ standard and triggers compiler warnings such as MSVC `warning C4293: '<<': shift count negative or too big, undefined behavior`.

### Solution
Mask the shift count with `(kBits & 31)` for 32-bit types and `(kBits & 63)` for 64-bit types:
- When `kBits == 32` / `kBits == 64`, the shift count becomes `0`, preventing UB while the ternary operator selects `~0`.
- When `kBits < 32` / `kBits < 64`, `kBits & 31` / `kBits & 63` evaluates to `kBits`, preserving the exact intended mask.

### Verification
- Built and ran `hash_test.exe` on Windows (MSVC 2022).
- Verified `warning C4293` is eliminated.
- Verified all hash tests pass (`TestAllAvalanche`, `TestAllBias`, `TestAllBuckets`, `TestAllBijection`, `TestAllEdgeCases`, `TestAllMasked`).
