### PR TITLE
fix(sort): check VQSortHaveFloat16/64 in TestFloatInf (fixes #2259)

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -364,8 +364,6 @@ template <typename T, class Order>
 void TestSelectWithNaNForType(Order order) {
   const size_t num = AdjustedReps(40 * 1000);
   if (num < 32) return;
-  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
-
   size_t num_nan;
   const std::vector<T> input = MakeNaNInfInput<T>(num, 123456789, num_nan);
 
@@ -376,10 +374,10 @@ void TestSelectWithNaNForType(Order order) {
     if (!ScalarIsNaN(x)) nonnan_in.push_back(x);
   }
   std::sort(nonnan_in.begin(), nonnan_in.end());
-  std::sort(ref.begin(), ref.end(), [asc](float a, float b) {
+  std::sort(ref.begin(), ref.end(), [](float a, float b) {
     if (ScalarIsNaN(a)) return false;  // NaN sorts to the back
     if (ScalarIsNaN(b)) return true;
-    return asc ? (a < b) : (a > b);
+    return hwy::IsSame<Order, hwy::SortAscending>() ? (a < b) : (a > b);
   });
 
   // A finite-region k and a NaN-region k; the latter catches the +inf/NaN

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -364,6 +364,8 @@ template <typename T, class Order>
 void TestSelectWithNaNForType(Order order) {
   const size_t num = AdjustedReps(40 * 1000);
   if (num < 32) return;
+  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
+
   size_t num_nan;
   const std::vector<T> input = MakeNaNInfInput<T>(num, 123456789, num_nan);
 

--- a/hwy/contrib/sort/sort_unit_test.cc
+++ b/hwy/contrib/sort/sort_unit_test.cc
@@ -114,6 +114,16 @@ HWY_NOINLINE void TestAllFloatLargerSmaller() {
 struct TestFloatInf {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T, D d) {
+#if HWY_HAVE_FLOAT64
+    if (hwy::IsSame<T, double>() && !hwy::VQSortHaveFloat64()) {
+      return;
+    }
+#endif
+#if HWY_HAVE_FLOAT16
+    if (hwy::IsSame<T, float16_t>() && !hwy::VQSortHaveFloat16()) {
+      return;
+    }
+#endif
     const size_t N = Lanes(d);
     const size_t num = N * 3;
     auto in = hwy::AllocateAligned<T>(num);


### PR DESCRIPTION
Fixes #2259.

### Problem

In \SortTestGroup/SortTest.TestAllFloatInf/EMU128\, running on 32-bit ARM (such as Debian armhf) causes an abort at \qsort_f64a.cc:36\ (\HWY_ASSERT(0)\).

The root cause is that \TestAllFloatInf\ iterates over float types using \ForFloatTypesDynamic(ForPartialVectors<TestFloatInf>())\. When testing the \EMU128\ fallback target:
1. \N_EMU128\ has \HWY_HAVE_FLOAT64 == 1\, and \hwy::HaveFloat64()\ returns true on platforms with hardware floating point (e.g. VFPv3/v4).
2. \TestFloatInf::operator()\ is invoked with \T = double\.
3. It calls \hwy::VQSort(in.get(), num, SortAscending())\, which uses \HWY_DYNAMIC_DISPATCH\.
4. \HWY_DYNAMIC_DISPATCH\ selects the best available SIMD instruction set on the CPU, which is \HWY_NEON\ on ARMv7.
5. On 32-bit ARM NEON, 64-bit vector float instructions do not exist (\HWY_HAVE_FLOAT64 == 0\). Hence, \N_NEON::SortF64Asc\ hits \HWY_ASSERT(0)\.

Commit 4f846162 introduced \hwy::VQSortHaveFloat16()\ and \hwy::VQSortHaveFloat64()\ to resolve similar dispatch mismatches in \sort_test.cc\, but \sort_unit_test.cc\'s \TestFloatInf\ was not updated to guard its \VQSort\ calls.

### Solution

In \TestFloatInf::operator()\, check \hwy::VQSortHaveFloat64()\ when \T == double\ and \hwy::VQSortHaveFloat16()\ when \T == float16_t\ before calling \VQSort\, skipping the test if the dynamic dispatch target does not support that float type.