### PR TITLE
feat(detect_targets): enable HWY_WASM by default on WebAssembly (fixes #2831)

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -364,8 +364,6 @@ template <typename T, class Order>
 void TestSelectWithNaNForType(Order order) {
   const size_t num = AdjustedReps(40 * 1000);
   if (num < 32) return;
-  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
-
   size_t num_nan;
   const std::vector<T> input = MakeNaNInfInput<T>(num, 123456789, num_nan);
 
@@ -376,10 +374,10 @@ void TestSelectWithNaNForType(Order order) {
     if (!ScalarIsNaN(x)) nonnan_in.push_back(x);
   }
   std::sort(nonnan_in.begin(), nonnan_in.end());
-  std::sort(ref.begin(), ref.end(), [asc](float a, float b) {
+  std::sort(ref.begin(), ref.end(), [](float a, float b) {
     if (ScalarIsNaN(a)) return false;  // NaN sorts to the back
     if (ScalarIsNaN(b)) return true;
-    return asc ? (a < b) : (a > b);
+    return hwy::IsSame<Order, hwy::SortAscending>() ? (a < b) : (a > b);
   });
 
   // A finite-region k and a NaN-region k; the latter catches the +inf/NaN

--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -364,6 +364,8 @@ template <typename T, class Order>
 void TestSelectWithNaNForType(Order order) {
   const size_t num = AdjustedReps(40 * 1000);
   if (num < 32) return;
+  constexpr bool asc = hwy::IsSame<Order, hwy::SortAscending>();
+
   size_t num_nan;
   const std::vector<T> input = MakeNaNInfInput<T>(num, 123456789, num_nan);
 

--- a/hwy/detect_targets.h
+++ b/hwy/detect_targets.h
@@ -443,7 +443,11 @@
 // Also check HWY_ARCH to ensure that simulating unknown platforms ends up with
 // HWY_TARGET == HWY_BASELINE_SCALAR.
 
-#if HWY_ARCH_WASM && defined(__wasm_simd128__)
+// WASM SIMD (simd128) is now widespread across modern runtimes, so enable it as
+// the baseline target without requiring -msimd128. Code paths that need a
+// non-SIMD fallback binary can opt out by adding HWY_WASM to
+// HWY_DISABLED_TARGETS or defining HWY_COMPILE_ONLY_SCALAR.
+#if HWY_ARCH_WASM
 #if defined(HWY_WANT_WASM2)
 #define HWY_BASELINE_WASM HWY_WASM_EMU256
 #else


### PR DESCRIPTION
### Problem
As reported in #2831, `hwy::DispatchedTarget` previously returned `HWY_EMU128` on WebAssembly unless the `-msimd128` compiler flag was passed explicitly, because `HWY_BASELINE_WASM` checked `defined(__wasm_simd128__)`.

### Solution
Enable `HWY_WASM` by default on `HWY_ARCH_WASM` without requiring `-msimd128`, as discussed in #2831. WASM SIMD (simd128) is now widespread across modern web browsers and runtimes.

Developers building a non-SIMD fallback WebAssembly binary can cleanly opt out by specifying `HWY_DISABLED_TARGETS=HWY_WASM` (or `HWY_COMPILE_ONLY_SCALAR`), which falls back to `HWY_EMU128` / `HWY_SCALAR`.

Fixes #2831.
