### PR TITLE
Add AllOf/AnyOf/NoneOf to contrib/algo

### DIFF
--- a/g3doc/op_wishlist.md
+++ b/g3doc/op_wishlist.md
@@ -37,8 +37,6 @@ fmod, ilogb, logb, modf, nextafter, nexttoward, scalbn
 
 ### Remaining STL functions for hwy/contrib/algo
 
-*   IndexOfMin/Max
-*   AllOf / AnyOf / NoneOf
 *   EqualSpan
 *   ReverseSpan
 *   ShuffleSpan
@@ -190,3 +188,5 @@ For SVE (svld1sb_u32)+WASM? Compiler can probably already fuse.
 *   ~~lgamma~~
 *   ~~ReduceMin/MaxOrNaN~~
 *   ~~Document Reduce/Min NaN behavior~~
+*   ~~IndexOfMin/Max~~ (algo)
+*   ~~AllOf / AnyOf / NoneOf~~ (algo)

--- a/hwy/contrib/algo/find-inl.h
+++ b/hwy/contrib/algo/find-inl.h
@@ -108,6 +108,92 @@ size_t FindIf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
   return count;  // not found
 }
 
+// AnyOf/AllOf/NoneOf unroll 4x, matching AllUnique below rather than the 2x in
+// Find/FindIf: none of them needs the position of a match, so an iteration is
+// just the loads, the predicate and one mask test, with no loop-carried state.
+
+// Returns true if `func(d, vec)` is true for at least one element of
+// `in[0, count)`, like std::any_of. Returns false if `count` is 0. Stops
+// reading as soon as the answer is known.
+template <class D, class Func, typename T = TFromD<D>>
+bool AnyOf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
+  HWY_LANES_CONSTEXPR size_t N = Lanes(d);
+
+  size_t i = 0;
+  if (HWY_LIKELY(count >= 4 * N)) {
+    for (; i <= count - 4 * N; i += 4 * N) {
+      const Mask<D> m0 = func(d, LoadU(d, in + i + 0 * N));
+      const Mask<D> m1 = func(d, LoadU(d, in + i + 1 * N));
+      const Mask<D> m2 = func(d, LoadU(d, in + i + 2 * N));
+      const Mask<D> m3 = func(d, LoadU(d, in + i + 3 * N));
+      if (HWY_UNLIKELY(!AllFalse(d, Or(Or(m0, m1), Or(m2, m3))))) return true;
+    }
+  }
+
+  for (; i + N <= count; i += N) {
+    if (HWY_UNLIKELY(!AllFalse(d, func(d, LoadU(d, in + i))))) return true;
+  }
+
+  const size_t remaining = count - i;
+  HWY_DASSERT(remaining < N);
+  if (remaining != 0) {
+    // LoadN zeros the lanes past `remaining` and `func` may well return true
+    // for a zero, so restrict the result to lanes holding a real element.
+    const Mask<D> mask = FirstN(d, remaining);
+    if (!AllFalse(d, And(mask, func(d, LoadN(d, in + i, remaining))))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Returns true if `func(d, vec)` is true for every element of `in[0, count)`,
+// like std::all_of. Returns true if `count` is 0. Stops reading as soon as the
+// answer is known.
+template <class D, class Func, typename T = TFromD<D>>
+bool AllOf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
+  HWY_LANES_CONSTEXPR size_t N = Lanes(d);
+
+  size_t i = 0;
+  if (HWY_LIKELY(count >= 4 * N)) {
+    for (; i <= count - 4 * N; i += 4 * N) {
+      const Mask<D> m0 = func(d, LoadU(d, in + i + 0 * N));
+      const Mask<D> m1 = func(d, LoadU(d, in + i + 1 * N));
+      const Mask<D> m2 = func(d, LoadU(d, in + i + 2 * N));
+      const Mask<D> m3 = func(d, LoadU(d, in + i + 3 * N));
+      if (HWY_UNLIKELY(!AllTrue(d, And(And(m0, m1), And(m2, m3))))) {
+        return false;
+      }
+    }
+  }
+
+  for (; i + N <= count; i += N) {
+    if (HWY_UNLIKELY(!AllTrue(d, func(d, LoadU(d, in + i))))) return false;
+  }
+
+  const size_t remaining = count - i;
+  HWY_DASSERT(remaining < N);
+  if (remaining != 0) {
+    // AndNot(a, b) is "a is false and b is true", so this is the set of lanes
+    // that hold a real element and failed the predicate. Asking whether that
+    // is empty is cheaper than forcing the padding lanes true.
+    const Mask<D> mask = FirstN(d, remaining);
+    if (!AllFalse(d, AndNot(func(d, LoadN(d, in + i, remaining)), mask))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Returns true if `func(d, vec)` is false for every element of `in[0, count)`,
+// like std::none_of. Returns true if `count` is 0.
+template <class D, class Func, typename T = TFromD<D>>
+bool NoneOf(D d, const T* HWY_RESTRICT in, size_t count, const Func& func) {
+  return !AnyOf(d, in, count, func);
+}
+
 // Like std::unique: removes consecutive duplicates in [in, in + count) and
 // returns the number of unique elements. Requires sorted/grouped input.
 // Operates in-place: the unique elements are packed to the front of `in`.

--- a/hwy/contrib/algo/find_test.cc
+++ b/hwy/contrib/algo/find_test.cc
@@ -15,7 +15,7 @@
 
 #include <stdio.h>
 
-#include <algorithm>  // std::find_if, std::unique
+#include <algorithm>  // std::find_if, std::any_of, std::unique
 #include <vector>
 
 #include "hwy/aligned_allocator.h"
@@ -181,6 +181,71 @@ void TestAllFindIf() {
   ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestFindIf>>());
 }
 
+struct TestAnyAllNone {
+  template <class D>
+  void operator()(D d, size_t count, size_t misalign, RandomState& rng) {
+    using T = TFromD<D>;
+    // Must allocate at least one even if count is zero.
+    AlignedFreeUniquePtr<T[]> storage =
+        AllocateAligned<T>(HWY_MAX(1, misalign + count));
+    HWY_ASSERT(storage);
+    T* in = storage.get() + misalign;
+    for (size_t i = 0; i < count; ++i) {
+      in[i] = Random<T>(rng);
+    }
+
+    // Same sweep as TestFindIf: unsigned T must not be compared against a
+    // negative value, and 9 is out of range so the predicate is never true.
+    const int min_val = IsSigned<T>() ? -9 : 0;
+    for (int val = min_val; val <= 9; ++val) {
+      const auto greater = [val](const auto d2, const auto v) HWY_ATTR {
+        return Gt(v, Set(d2, ConvertScalarTo<T>(val)));
+      };
+      const auto scalar = [val](T x) { return x > ConvertScalarTo<T>(val); };
+
+      const bool any = AnyOf(d, in, count, greater);
+      const bool all = AllOf(d, in, count, greater);
+      const bool none = NoneOf(d, in, count, greater);
+
+      const bool expected_any = std::any_of(in, in + count, scalar);
+      const bool expected_all = std::all_of(in, in + count, scalar);
+      const bool expected_none = std::none_of(in, in + count, scalar);
+
+      if (any != expected_any || all != expected_all || none != expected_none) {
+        fprintf(stderr,
+                "%s count %d val %d: any %d want %d, all %d want %d, none %d "
+                "want %d\n",
+                hwy::TypeName(T(), Lanes(d)).c_str(), static_cast<int>(count),
+                val, any, expected_any, all, expected_all, none, expected_none);
+        hwy::detail::PrintArray(hwy::detail::MakeTypeInfo<T>(), "in", in, count,
+                                0, count);
+        HWY_ASSERT(false);
+      }
+    }
+
+    // The sweep above never satisfies the predicate for every element of an
+    // unsigned array, because zero is not greater than zero. Pin both extremes
+    // explicitly: a predicate that holds everywhere, and one that holds
+    // nowhere.
+    const auto always = [](const auto d2, const auto v) HWY_ATTR {
+      return Ge(v, Set(d2, LowestValue<TFromD<decltype(d2)>>()));
+    };
+    const auto never = [](const auto d2, const auto v) HWY_ATTR {
+      return Lt(v, Set(d2, LowestValue<TFromD<decltype(d2)>>()));
+    };
+    HWY_ASSERT(AllOf(d, in, count, always));
+    HWY_ASSERT(NoneOf(d, in, count, never));
+    HWY_ASSERT(!AnyOf(d, in, count, never));
+    // Empty input has nothing to find, but vacuously satisfies AllOf.
+    HWY_ASSERT_EQ(count != 0, AnyOf(d, in, count, always));
+    HWY_ASSERT(AllOf(d, in, 0, never));
+  }
+};
+
+void TestAllAnyAllNone() {
+  ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestAnyAllNone>>());
+}
+
 struct TestUnique {
   template <class D>
   void operator()(D d, size_t count, size_t misalign, RandomState& rng) {
@@ -302,6 +367,7 @@ namespace {
 HWY_BEFORE_TEST(FindTest);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllFind);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllFindIf);
+HWY_EXPORT_AND_TEST_P(FindTest, TestAllAnyAllNone);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllUnique);
 HWY_AFTER_TEST();
 }  // namespace


### PR DESCRIPTION
Implements three of the "Remaining STL functions for hwy/contrib/algo" from g3doc/op_wishlist.md: AllOf, AnyOf and NoneOf, matching std::all_of, std::any_of and std::none_of.

They go in find-inl.h next to FindIf, which they are closest to. Three notes on the implementation.

Not wrappers over FindIf. AnyOf could be FindIf(...) != count, but FindIf calls FindFirstTrue to compute where the match is and none of these three need that. Built directly on AllFalse/AllTrue, a loop iteration is the loads, the predicate and one mask test.

Unrolled 4x rather than the 2x in Find/FindIf, matching AllUnique, the other early-exit scan in this file. There is no loop-carried dependency here.

The tail is the part worth reviewing. LoadN zero-fills the lanes past the end, and a predicate like x > -5 is true for those zeros, so they have to be excluded. AnyOf masks with FirstN. AllOf uses AndNot(pred, FirstN), which is the set of lanes holding a real element that failed, so it never has to force the padding lanes true.

Tests compare against the STL over 512 random counts, three misalignments, all types and 20 predicate thresholds, plus predicates pinned always-true and always-false so unsigned types still exercise the AllOf-true path. I checked that the tests actually bite by breaking each tail mask: dropping the AnyOf mask gives "i8x32 count 2 val -5: any 1 want 0", and dropping the AllOf one gives "count 1 val 0: all 0 want 1".

Full build and ctest are green locally, 2475 of 2475.

Also strikes IndexOfMin/Max off the wishlist, since #3253 added it. I can drop that line if you would rather keep it separate.