### PR TITLE
fix(sort): use a default capture in TestSelectWithNaNForType comparator

### DIFF
--- a/hwy/contrib/sort/sort_test.cc
+++ b/hwy/contrib/sort/sort_test.cc
@@ -376,7 +376,7 @@ void TestSelectWithNaNForType(Order order) {
     if (!ScalarIsNaN(x)) nonnan_in.push_back(x);
   }
   std::sort(nonnan_in.begin(), nonnan_in.end());
-  std::sort(ref.begin(), ref.end(), [asc](float a, float b) {
+  std::sort(ref.begin(), ref.end(), [&](float a, float b) {
     if (ScalarIsNaN(a)) return false;  // NaN sorts to the back
     if (ScalarIsNaN(b)) return true;
     return asc ? (a < b) : (a > b);


### PR DESCRIPTION
`Build and test Clang-22` is currently failing on master, so it shows up red on every open pull request.

The cause is in `TestSelectWithNaNForType`. #3366 changed the comparator lambda from `[]` to `[asc]` so MSVC would stop reporting C3493, which asks for a default capture mode. That fixed MSVC, but `asc` is `constexpr`, so reading it inside the lambda is not an odr-use and the explicit capture is redundant. Clang 22 then rejects it:

```
hwy/contrib/sort/sort_test.cc:379:38: error: lambda capture 'asc' is not required to be
captured for this use [-Werror,-Wunused-lambda-capture]
```

`[&]` satisfies both: MSVC gets the default capture mode C3493 asks for, and Clang has no explicit capture left to call unnecessary. Neither form actually captures anything, since the use is not an odr-use, so there is no behaviour change.

This was easy to miss because the `Build / test` workflow runs on `pull_request` and a weekly schedule, not on pushes to master, so a regression only becomes visible once somebody opens the next PR. The Saturday cron would have caught it.

**Verification.** With Clang 22.1.8, the same version CI uses, and the warning set from CMakeLists plus `-Werror`: master reports the error above, this branch reports none. GCC is clean, and `sort_test` passes 35 of 35 including `TestSelectWithNaN`. I have no MSVC available to confirm that side directly, so if C3493 somehow still fires there, `[=]` is the other form that works and I am glad to switch.

Line 379 is the only explicit-capture lambda in the file, so this should be all of it.
