### PR TITLE
Add EqualSpan and ReverseSpan to hwy/contrib/algo

### DIFF
--- a/g3doc/op_wishlist.md
+++ b/g3doc/op_wishlist.md
@@ -37,8 +37,6 @@ fmod, ilogb, logb, modf, nextafter, nexttoward, scalbn
 
 ### Remaining STL functions for hwy/contrib/algo
 
-*   EqualSpan
-*   ReverseSpan
 *   ShuffleSpan
 *   Reduce
 
@@ -190,3 +188,5 @@ For SVE (svld1sb_u32)+WASM? Compiler can probably already fuse.
 *   ~~Document Reduce/Min NaN behavior~~
 *   ~~IndexOfMin/Max~~ (algo)
 *   ~~AllOf / AnyOf / NoneOf~~ (algo)
+*   ~~EqualSpan~~ (algo)
+*   ~~ReverseSpan~~ (algo)

--- a/hwy/contrib/algo/copy-inl.h
+++ b/hwy/contrib/algo/copy-inl.h
@@ -137,6 +137,49 @@ T* CopyIf(D d, const T* HWY_RESTRICT from, size_t count, T* HWY_RESTRICT to,
   return to;
 }
 
+// Reverses `inout[0, count)` in place, like std::reverse. `count` may be zero.
+template <class D, typename T = TFromD<D>>
+void ReverseSpan(D d, T* HWY_RESTRICT inout, size_t count) {
+  const size_t N = Lanes(d);
+
+  // [lo, hi) is the region not yet reversed. Each iteration takes one vector
+  // from each end, reverses it, and stores it at the opposite end.
+  size_t lo = 0;
+  size_t hi = count;
+  while (lo + 2 * N <= hi) {
+    const Vec<D> v_lo = LoadU(d, inout + lo);
+    const Vec<D> v_hi = LoadU(d, inout + hi - N);
+    StoreU(Reverse(d, v_hi), d, inout + lo);
+    StoreU(Reverse(d, v_lo), d, inout + hi - N);
+    lo += N;
+    hi -= N;
+  }
+
+  const size_t remaining = hi - lo;
+  HWY_DASSERT(remaining < 2 * N);
+
+  if (remaining >= N) {
+    // The two vectors overlap when `remaining` < 2 * N, which is why both are
+    // loaded before either is stored. The overlapping lanes are written twice
+    // and the second write is the correct one, because the halves are swapped.
+    const Vec<D> v_lo = LoadU(d, inout + lo);
+    const Vec<D> v_hi = LoadU(d, inout + hi - N);
+    StoreU(Reverse(d, v_hi), d, inout + lo);
+    StoreU(Reverse(d, v_lo), d, inout + hi - N);
+    return;
+  }
+
+  // Fewer than N elements left, and a single element is already reversed.
+  if (remaining > 1) {
+    // LoadN zero-fills the lanes past `remaining`, so Reverse leaves the real
+    // elements in the top `remaining` lanes; slide them back down to lane 0.
+    // LoadN/StoreN are used rather than LoadU/StoreU because there may be no
+    // readable memory past `hi`.
+    const Vec<D> rev = Reverse(d, LoadN(d, inout + lo, remaining));
+    StoreN(SlideDownLanes(d, rev, N - remaining), d, inout + lo, remaining);
+  }
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy

--- a/hwy/contrib/algo/copy_test.cc
+++ b/hwy/contrib/algo/copy_test.cc
@@ -161,6 +161,71 @@ struct TestCopyIf {
   }
 };
 
+// ReverseSpan needs its own sweep: ForeachCountAndMisalign above stops below
+// 2 * N, so the main loop would never run.
+struct TestReverseSpan {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) const {
+    RandomState rng;
+    const size_t N = Lanes(d);
+    const size_t misalignments[3] = {0, N / 4, 3 * N / 5};
+
+    // Exhaustive to 4 * N: covers every tail length, the count == 2 * N point
+    // where the main loop first runs, and the N <= remaining < 2 * N overlap.
+    for (size_t count = 0; count <= 4 * N; ++count) {
+      for (size_t misalign : misalignments) {
+        Check(d, count, misalign, rng);
+      }
+    }
+  }
+
+  template <class D, typename T = TFromD<D>>
+  static void Check(D d, size_t count, size_t misalign, RandomState& rng) {
+    // One extra element holds a sentinel, so a store past the end is caught.
+    AlignedFreeUniquePtr<T[]> storage =
+        AllocateAligned<T>(misalign + count + 1);
+    // Built by hand rather than with std::reverse over a std::vector: GCC 16
+    // cannot bound `count` through that inlining and emits a spurious
+    // -Wstringop-overflow for every instantiation.
+    AlignedFreeUniquePtr<T[]> orig =
+        AllocateAligned<T>(HWY_MAX(size_t{1}, count));
+    AlignedFreeUniquePtr<T[]> rev =
+        AllocateAligned<T>(HWY_MAX(size_t{1}, count));
+    HWY_ASSERT(storage && orig && rev);
+
+    T* inout = storage.get() + misalign;
+    for (size_t i = 0; i < count; ++i) {
+      const T v = Random7Bit<T>(rng);
+      inout[i] = v;
+      orig[i] = v;
+      rev[count - 1 - i] = v;
+    }
+    const T sentinel = ConvertScalarTo<T>(99);
+    inout[count] = sentinel;
+
+    const auto info = hwy::detail::MakeTypeInfo<T>();
+    const char* target_name = hwy::TargetName(HWY_TARGET);
+
+    ReverseSpan(d, inout, count);
+    if (count != 0) {
+      hwy::detail::AssertArrayEqual(info, rev.get(), inout, count, target_name,
+                                    __FILE__, __LINE__);
+    }
+    // Nothing may be written at or past `count`.
+    HWY_ASSERT(ConvertScalarTo<double>(inout[count]) ==
+               ConvertScalarTo<double>(sentinel));
+
+    // Reversing twice restores the input.
+    ReverseSpan(d, inout, count);
+    if (count != 0) {
+      hwy::detail::AssertArrayEqual(info, orig.get(), inout, count, target_name,
+                                    __FILE__, __LINE__);
+    }
+  }
+};
+
+void TestAllReverseSpan() { ForAllTypes(ForPartialVectors<TestReverseSpan>()); }
+
 void TestAllCopyIf() {
   ForUI163264(ForPartialVectors<ForeachCountAndMisalign<TestCopyIf>>());
 }
@@ -178,6 +243,7 @@ HWY_BEFORE_TEST(CopyTest);
 HWY_EXPORT_AND_TEST_P(CopyTest, TestAllFill);
 HWY_EXPORT_AND_TEST_P(CopyTest, TestAllCopy);
 HWY_EXPORT_AND_TEST_P(CopyTest, TestAllCopyIf);
+HWY_EXPORT_AND_TEST_P(CopyTest, TestAllReverseSpan);
 HWY_AFTER_TEST();
 }  // namespace
 }  // namespace hwy

--- a/hwy/contrib/algo/find-inl.h
+++ b/hwy/contrib/algo/find-inl.h
@@ -326,6 +326,50 @@ bool AllUnique(D d, const T* HWY_RESTRICT in, size_t count) {
   return true;
 }
 
+// Returns true if `a[0, count)` and `b[0, count)` are equal element-wise, like
+// std::equal. Returns true if `count` is 0, and stops reading as soon as a
+// mismatch is found. As with std::equal and `operator==`, a NaN is not equal to
+// itself, so spans holding a NaN at the same index are reported as unequal.
+// Argument order follows Dot::Compute(d, pa, pb, num) in contrib/dot, the other
+// function here that reads two spans of the same length.
+template <class D, typename T = TFromD<D>>
+bool EqualSpan(D d, const T* HWY_RESTRICT a, const T* HWY_RESTRICT b,
+               size_t count) {
+  HWY_LANES_CONSTEXPR size_t N = Lanes(d);
+
+  // Unrolls 4x like AnyOf above, for the same reason: the position of the
+  // mismatch is never needed, so an iteration is the loads, the compares and a
+  // single mask test.
+  size_t i = 0;
+  if (HWY_LIKELY(count >= 4 * N)) {
+    for (; i <= count - 4 * N; i += 4 * N) {
+      const Mask<D> m0 = Ne(LoadU(d, a + i + 0 * N), LoadU(d, b + i + 0 * N));
+      const Mask<D> m1 = Ne(LoadU(d, a + i + 1 * N), LoadU(d, b + i + 1 * N));
+      const Mask<D> m2 = Ne(LoadU(d, a + i + 2 * N), LoadU(d, b + i + 2 * N));
+      const Mask<D> m3 = Ne(LoadU(d, a + i + 3 * N), LoadU(d, b + i + 3 * N));
+      if (HWY_UNLIKELY(!AllFalse(d, Or(Or(m0, m1), Or(m2, m3))))) return false;
+    }
+  }
+
+  for (; i + N <= count; i += N) {
+    const Mask<D> ne = Ne(LoadU(d, a + i), LoadU(d, b + i));
+    if (HWY_UNLIKELY(!AllFalse(d, ne))) return false;
+  }
+
+  const size_t remaining = count - i;
+  HWY_DASSERT(remaining < N);
+  if (remaining != 0) {
+    // No FirstN mask here, unlike AnyOf: LoadN zero-fills the lanes past
+    // `remaining` on both sides, so those lanes hold the same value and cannot
+    // produce a spurious mismatch.
+    const Mask<D> ne =
+        Ne(LoadN(d, a + i, remaining), LoadN(d, b + i, remaining));
+    if (!AllFalse(d, ne)) return false;
+  }
+
+  return true;
+}
+
 // NOLINTNEXTLINE(google-readability-namespace-comments)
 }  // namespace HWY_NAMESPACE
 }  // namespace hwy

--- a/hwy/contrib/algo/find_test.cc
+++ b/hwy/contrib/algo/find_test.cc
@@ -350,6 +350,87 @@ struct TestUniqueBoundary {
   }
 };
 
+struct TestEqualSpan {
+  template <class D>
+  void operator()(D d, size_t count, size_t misalign, RandomState& rng) {
+    using T = TFromD<D>;
+    // Two separate allocations: EqualSpan takes HWY_RESTRICT pointers, so the
+    // spans must not overlap. Must allocate at least one even if count is zero.
+    AlignedFreeUniquePtr<T[]> storage_a =
+        AllocateAligned<T>(HWY_MAX(1, misalign + count));
+    AlignedFreeUniquePtr<T[]> storage_b =
+        AllocateAligned<T>(HWY_MAX(1, misalign + count));
+    HWY_ASSERT(storage_a && storage_b);
+    T* a = storage_a.get() + misalign;
+    T* b = storage_b.get() + misalign;
+    for (size_t i = 0; i < count; ++i) {
+      a[i] = Random<T>(rng);
+      b[i] = a[i];
+    }
+
+    // HWY_ATTR because the lambda calls EqualSpan: clang does not propagate
+    // the enclosing function's target attribute into a lambda body.
+    const auto check = [&](bool expected, size_t pos) HWY_ATTR {
+      const bool actual = EqualSpan(d, a, b, count);
+      // std::equal is the reference; `expected` additionally pins down what the
+      // caller believes, so a bug in either one is visible.
+      const bool reference = std::equal(a, a + count, b);
+      if (actual != expected || reference != expected) {
+        fprintf(stderr,
+                "%s count %d misalign %d differing pos %d: got %d, std %d, "
+                "want %d\n",
+                hwy::TypeName(T(), Lanes(d)).c_str(), static_cast<int>(count),
+                static_cast<int>(misalign), static_cast<int>(pos), actual,
+                reference, expected);
+        HWY_ASSERT(false);
+      }
+    };
+
+    // Identical contents, including count == 0.
+    check(true, count);
+
+    // Random<T> returns values in [-8, 8], so 9 never occurs and is guaranteed
+    // to differ from whatever is already there.
+    const T differs = ConvertScalarTo<T>(9);
+
+    // A single differing element must be found wherever it is. Sweeping the
+    // final N indices is what catches a tail that is skipped, over-read, or
+    // masked off: those are the lanes LoadN zero-fills.
+    const size_t N = Lanes(d);
+    const size_t tail_begin = count > N ? count - N : 0;
+    for (size_t pos = tail_begin; pos < count; ++pos) {
+      const T old = b[pos];
+      b[pos] = differs;
+      check(false, pos);
+      b[pos] = old;
+    }
+
+    // Plus the first and middle elements, which land in the unrolled loop.
+    for (size_t pos : {size_t{0}, count / 2}) {
+      if (pos >= count) continue;
+      const T old = b[pos];
+      b[pos] = differs;
+      check(false, pos);
+      b[pos] = old;
+    }
+
+    // Restored: equal again.
+    check(true, count);
+
+    // A shorter count must ignore a difference beyond it.
+    if (count != 0) {
+      const T old = b[count - 1];
+      b[count - 1] = differs;
+      HWY_ASSERT(EqualSpan(d, a, b, count - 1));
+      b[count - 1] = old;
+    }
+  }
+};
+
+void TestAllEqualSpan() {
+  ForAllTypes(ForPartialVectors<ForeachCountAndMisalign<TestEqualSpan>>());
+}
+
 void TestAllUnique() {
   ForUI(ForPartialVectors<ForeachCountAndMisalign<TestUnique>>());
   ForUI(ForGEVectors<64, TestUniqueBoundary>());
@@ -368,6 +449,7 @@ HWY_BEFORE_TEST(FindTest);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllFind);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllFindIf);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllAnyAllNone);
+HWY_EXPORT_AND_TEST_P(FindTest, TestAllEqualSpan);
 HWY_EXPORT_AND_TEST_P(FindTest, TestAllUnique);
 HWY_AFTER_TEST();
 }  // namespace


### PR DESCRIPTION
Implements `EqualSpan` and `ReverseSpan` from the "Remaining STL functions for
hwy/contrib/algo" list in op_wishlist.md, following #3370. That leaves
`ShuffleSpan` and `Reduce`, which I have asked about in #3374 rather than
guessing at the API.

### EqualSpan (find-inl.h)

Returns whether `a[0, count)` and `b[0, count)` are equal element-wise, like
std::equal, stopping at the first mismatch.

The tail takes no FirstN mask, unlike AnyOf. LoadN zero-fills the lanes past
`remaining` on both sides, so those lanes hold the same value and compare
equal. A mask there would be dead work.

Argument order is `(d, a, b, count)` rather than the `(from, count, to)` used
by Copy/CopyIf. Copy has a direction, so `count` attaches to the source; here
the two spans are symmetric and share one count. `Dot::Compute(d, pa, pb, num)`
in contrib/dot is the closest precedent and does the same. Happy to change it
if you prefer the Copy shape.

It unrolls 4x like AnyOf rather than 2x like Find, since the position of the
mismatch is never needed.

NaN follows std::equal and `operator==`, so a NaN is not equal to itself and
spans holding a NaN at the same index are reported unequal. That is documented
on the function.

### ReverseSpan (copy-inl.h)

Reverses a span in place, like std::reverse. Each iteration takes one vector
from each end, reverses it and stores it at the opposite end. Three cases:

- the main loop, while `lo + 2 * N <= hi`
- `N <= remaining < 2 * N`, where the two vectors overlap. Both are loaded
  before either is stored, and the overlapping lanes are written twice with
  the second write being the correct one
- fewer than N elements left, handled with LoadN, Reverse and
  SlideDownLanes(N - remaining) so that no memory past the end is read

I kept the overlapping pair as its own block rather than folding it into the
loop with a second exit, because the three cases read more clearly separated.
Glad to restructure if you would rather see one copy of the body.

### Verification

`find_test` 25 of 25 and `copy_test` 20 of 20 on AVX2, SSE4, SSSE3, SSE2 and
EMU128. Compiled clean for AVX3, AVX3_DL, AVX3_ZEN4, AVX3_SPR and AVX10_2, and
separately for HWY_SCALAR. The two -inl.h headers also compile under C++11 with
HWY_COMPILE_ALL_ATTAINABLE. Zero warnings from both GCC 16 and Clang 22 under
the warning set in CMakeLists, including -Wconversion and -Wsign-conversion.

The tests sweep every count up to `4 * Lanes(d)` with three misalignments and
all types. ReverseSpan additionally checks a sentinel one past the end, so an
over-store is caught, and checks that reversing twice restores the input.

I broke each implementation on purpose to confirm the tests would notice:

| Mutation | Caught at |
| --- | --- |
| EqualSpan tail check removed | count 324, differing element at 320 |
| EqualSpan 4th vector dropped from the Or | count 450, differing element at 225 |
| ReverseSpan made a no-op | count 2 |
| ReverseSpan short-tail branch skipped | count 2 |
| ReverseSpan overlap branch skipped | count 33 |

I have not run NEON, SVE, RVV, WASM or the big-endian targets, only compiled
what this x86 box can reach.

One note on the test for ReverseSpan: it builds its reference by hand instead
of calling std::reverse on a std::vector. GCC 16 cannot bound `count` through
that inlining and emits a spurious -Wstringop-overflow for every instantiation,
418 of them in my first version.
