### PR TITLE
Added Partition op

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1707,6 +1707,12 @@ false is zero, true has all bits set:
     d, T* p)</code>: combination of `CompressStore` and `CompressBits`, see
     remarks there.
 
+*   <code>V **Partition**(D d, V v, M mask)</code>:
+    Equivalent to `SlideUpLanesOr(Compress(d, v, mask), d, CompressNot(d, v, mask),
+    CountTrue(d, mask))`, but `Partition(d, v, mask)` is usually more efficient in
+    the cases where `MaxLanes(d) == 1` or `CompressIsPartition<TFromD<D>>::value`
+    are true.
+
 #### Expand
 
 *   <code>V **Expand**(V v, M m)</code>: returns `r` such that `r[i]` is zero

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -7386,6 +7386,27 @@ HWY_API size_t CompressBitsStore(VFromD<D> v, const uint8_t* HWY_RESTRICT bits,
 
 #endif  // HWY_NATIVE_COMPRESS16_32_64
 
+// ------------------------------ Partition
+
+template <class D>
+HWY_API VFromD<D> Partition(D d, VFromD<D> v, MFromD<D> mask) {
+  (void)d;
+  (void)mask;
+
+  VFromD<D> result = v;
+#if HWY_TARGET != HWY_SCALAR
+  HWY_IF_CONSTEXPR(HWY_MAX_LANES_D(D) > 1) {
+    result = Compress(d, result, mask);
+    HWY_IF_CONSTEXPR(!CompressIsPartition<TFromD<D>>::value) {
+      result = SlideUpLanesOr(result, d, CompressNot(d, v, mask),
+                              CountTrue(d, mask));
+    }
+  }
+#endif
+
+  return result;
+}
+
 // ------------------------------ CompressBlocksNot
 
 #if (defined(HWY_NATIVE_COMPRESS_BLOCKS_NOT) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/tests/compress_test.cc
+++ b/hwy/tests/compress_test.cc
@@ -272,6 +272,52 @@ HWY_NOINLINE void TestAllCompressBlocks() {
   ForGE128Vectors<TestCompressBlocks>()(uint64_t());
 }
 
+struct TestPartition {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    RandomState rng;
+
+    using TI = MakeSigned<T>;  // For mask > 0 comparison
+    const Rebind<TI, D> di;
+    const size_t N = Lanes(d);
+
+    auto in_lanes = AllocateAligned<T>(N);
+    auto mask_lanes = AllocateAligned<TI>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(in_lanes && mask_lanes && expected);
+
+    // Each lane should have a chance of having mask=true.
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        in_lanes[i] = RandomFiniteValue<T>(&rng);
+        mask_lanes[i] = (Random32(&rng) & 1024) ? TI(1) : TI(0);
+      }
+
+      size_t expected_pos = 0;
+      for (size_t i = 0; i < N; ++i) {
+        if (mask_lanes[i] != 0) {
+          expected[expected_pos++] = in_lanes[i];
+        }
+      }
+
+      for (size_t i = 0; i < N && expected_pos < N; ++i) {
+        if (mask_lanes[i] == 0) {
+          expected[expected_pos++] = in_lanes[i];
+        }
+      }
+
+      const auto in = Load(d, in_lanes.get());
+      const auto mask = RebindMask(d, Gt(Load(di, mask_lanes.get()), Zero(di)));
+
+      HWY_ASSERT_VEC_EQ(d, expected.get(), Partition(d, in, mask));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllPartition() {
+  ForAllTypes(ForPartialVectors<TestPartition>());
+}
+
 #endif  // !HWY_PRINT_TABLES
 
 #if HWY_PRINT_TABLES || HWY_IDE
@@ -843,6 +889,7 @@ HWY_EXPORT_AND_TEST_P(HwyCompressTest, PrintTables);
 #else
 HWY_EXPORT_AND_TEST_P(HwyCompressTest, TestAllCompress);
 HWY_EXPORT_AND_TEST_P(HwyCompressTest, TestAllCompressBlocks);
+HWY_EXPORT_AND_TEST_P(HwyCompressTest, TestAllPartition);
 #endif
 HWY_AFTER_TEST();
 }  // namespace


### PR DESCRIPTION
Resolves one of the issues raised in issue #3142.

`Partition(d, v, m)` returns the lanes of `v` for which `m[i]` is true, followed by the lanes of `v` for which `m[i]` is false.

There is a use case for updating StoreLeftRight in hwy/contrib/sort/vqsort-inl.h to possibly use Partition.