### PR TITLE
Annotate range_coder and iguana exports with HWY_CONTRIB_DLLEXPORT (fixes #3378)

### DIFF
--- a/hwy/contrib/coder/range_coder.cc
+++ b/hwy/contrib/coder/range_coder.cc
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include "hwy/base.h"  // HWY_DASSERT
+#include "hwy/base.h"  // HWY_DASSERT, HWY_CONTRIB_DLLEXPORT
 
 namespace hwy {
 
@@ -41,8 +41,9 @@ uint32_t ReadBE24(const uint8_t*& src) {
 
 }  // namespace
 
-bool CreateCumulativeProbs(std::vector<uint32_t>& scaled_cum_prob,
-                           std::vector<uint32_t>& freq) {
+HWY_CONTRIB_DLLEXPORT bool CreateCumulativeProbs(
+    std::vector<uint32_t>& scaled_cum_prob,
+    std::vector<uint32_t>& freq) {
   const uint32_t num_syms = static_cast<uint32_t>(freq.size());
   if (num_syms < kRangeMinSyms || num_syms > kRangeMaxSyms) return false;
 
@@ -124,9 +125,10 @@ bool CreateCumulativeProbs(std::vector<uint32_t>& scaled_cum_prob,
   return true;
 }
 
-void BuildDecodeTable(uint32_t num_syms,
-                      const std::vector<uint32_t>& scaled_cum_prob,
-                      std::vector<uint32_t>& table) {
+HWY_CONTRIB_DLLEXPORT void BuildDecodeTable(
+    uint32_t num_syms,
+    const std::vector<uint32_t>& scaled_cum_prob,
+    std::vector<uint32_t>& table) {
   HWY_DASSERT(scaled_cum_prob.size() == num_syms + 1);
   table.assign(kRangeProbScale, 0);
 
@@ -142,9 +144,10 @@ void BuildDecodeTable(uint32_t num_syms,
   }
 }
 
-void EncodeInterleaved(const std::vector<uint8_t>& data,
-                       std::vector<uint8_t>& enc_buf,
-                       const std::vector<uint32_t>& scaled_cum_prob) {
+HWY_CONTRIB_DLLEXPORT void EncodeInterleaved(
+    const std::vector<uint8_t>& data,
+    std::vector<uint8_t>& enc_buf,
+    const std::vector<uint32_t>& scaled_cum_prob) {
   const size_t file_size = data.size();
   HWY_DASSERT(file_size != 0);
 
@@ -196,8 +199,9 @@ void EncodeInterleaved(const std::vector<uint8_t>& data,
   HWY_DASSERT(static_cast<size_t>(dst - enc_buf.data()) == enc_buf.size());
 }
 
-bool DecodeInterleavedScalar(const uint8_t* src, size_t comp_size, uint8_t* dst,
-                             size_t orig_size, const uint32_t* table) {
+HWY_CONTRIB_DLLEXPORT bool DecodeInterleavedScalar(
+    const uint8_t* src, size_t comp_size, uint8_t* dst,
+    size_t orig_size, const uint32_t* table) {
   // Decode from a zero-padded copy so a truncated/corrupt stream can never read
   // out of bounds; a valid stream never reads past `comp_size`.
   std::vector<uint8_t> buf;
@@ -228,7 +232,7 @@ bool DecodeInterleavedScalar(const uint8_t* src, size_t comp_size, uint8_t* dst,
   return static_cast<size_t>(p - p_start) <= comp_size;
 }
 
-const RangeShuffleTables& GetRangeShuffleTables() {
+HWY_CONTRIB_DLLEXPORT const RangeShuffleTables& GetRangeShuffleTables() {
   static const RangeShuffleTables tables = [] {
     RangeShuffleTables t;
     memset(&t, 0, sizeof(t));

--- a/hwy/contrib/coder/range_coder.h
+++ b/hwy/contrib/coder/range_coder.h
@@ -34,7 +34,7 @@
 
 #include <vector>
 
-#include "hwy/base.h"  // HWY_DASSERT
+#include "hwy/base.h"  // HWY_DASSERT, HWY_CONTRIB_DLLEXPORT
 
 namespace hwy {
 
@@ -193,30 +193,34 @@ class RangeDecoder {
 // probability table `scaled_cum_prob` of size freq.size() + 1, summing to
 // kRangeProbScale. `freq` may be modified if only one symbol was used. Returns
 // false if the model is degenerate.
-bool CreateCumulativeProbs(std::vector<uint32_t>& scaled_cum_prob,
-                           std::vector<uint32_t>& freq);
+HWY_CONTRIB_DLLEXPORT bool CreateCumulativeProbs(
+    std::vector<uint32_t>& scaled_cum_prob,
+    std::vector<uint32_t>& freq);
 
 // Builds the 4096-entry decode lookup table from `scaled_cum_prob` (as produced
 // by CreateCumulativeProbs for `num_syms` symbols). Each entry packs
 // sym | (cum_prob << 8) | (prob_range << 20).
-void BuildDecodeTable(uint32_t num_syms,
-                      const std::vector<uint32_t>& scaled_cum_prob,
-                      std::vector<uint32_t>& table);
+HWY_CONTRIB_DLLEXPORT void BuildDecodeTable(
+    uint32_t num_syms,
+    const std::vector<uint32_t>& scaled_cum_prob,
+    std::vector<uint32_t>& table);
 
 // ------------------------------ Interleaved codec
 
 // Encodes `data` into 16 interleaved range-coded streams, appending the result
 // to `enc_buf` layout expected by DecodeInterleaved (48 header bytes, then the
 // renormalization bytes in stream-round-robin order, then 2 zero pad bytes).
-void EncodeInterleaved(const std::vector<uint8_t>& data,
-                       std::vector<uint8_t>& enc_buf,
-                       const std::vector<uint32_t>& scaled_cum_prob);
+HWY_CONTRIB_DLLEXPORT void EncodeInterleaved(
+    const std::vector<uint8_t>& data,
+    std::vector<uint8_t>& enc_buf,
+    const std::vector<uint32_t>& scaled_cum_prob);
 
 // Scalar reference decoder for data produced by EncodeInterleaved. `table` is
 // from BuildDecodeTable. Returns false if the input is truncated. The SIMD
 // version (range_coder-inl.h) produces identical output.
-bool DecodeInterleavedScalar(const uint8_t* src, size_t comp_size, uint8_t* dst,
-                             size_t orig_size, const uint32_t* table);
+HWY_CONTRIB_DLLEXPORT bool DecodeInterleavedScalar(
+    const uint8_t* src, size_t comp_size, uint8_t* dst,
+    size_t orig_size, const uint32_t* table);
 
 // ------------------------------ SIMD decoder shuffle tables
 
@@ -230,7 +234,7 @@ struct RangeShuffleTables {
 };
 
 // Returns a lazily-built, immutable instance (thread-safe since C++11).
-const RangeShuffleTables& GetRangeShuffleTables();
+HWY_CONTRIB_DLLEXPORT const RangeShuffleTables& GetRangeShuffleTables();
 
 }  // namespace hwy
 

--- a/hwy/contrib/iguana/ans.cc
+++ b/hwy/contrib/iguana/ans.cc
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include "hwy/base.h"  // HWY_DASSERT
+#include "hwy/base.h"  // HWY_DASSERT, HWY_CONTRIB_DLLEXPORT
 #include "hwy/contrib/iguana/ans_detail.h"
 
 namespace hwy {
@@ -170,7 +170,8 @@ void BuildDenseTable(AnsDenseTable& table, const uint32_t freqs[256]) {
 
 }  // namespace
 
-AnsStatistics AnsStatistics::FromData(const uint8_t* data, size_t size) {
+HWY_CONTRIB_DLLEXPORT AnsStatistics AnsStatistics::FromData(
+    const uint8_t* data, size_t size) {
   RawStats s;
   if (size == 0) {
     s.freqs[254] = kAnsWordM / 2;
@@ -196,7 +197,8 @@ AnsStatistics AnsStatistics::FromData(const uint8_t* data, size_t size) {
   return out;
 }
 
-void AnsStatistics::Serialize(std::vector<uint8_t>& out) const {
+HWY_CONTRIB_DLLEXPORT void AnsStatistics::Serialize(
+    std::vector<uint8_t>& out) const {
   BitWriter ctrl, data;
   for (int i = 0; i < 256; ++i) {
     const uint32_t f = Freq(static_cast<size_t>(i));
@@ -227,8 +229,9 @@ void AnsStatistics::Serialize(std::vector<uint8_t>& out) const {
   out.push_back(0);  // "full table" compression level
 }
 
-size_t DeserializeAnsTable(AnsDenseTable& table, const uint8_t* src,
-                           size_t size) {
+HWY_CONTRIB_DLLEXPORT size_t DeserializeAnsTable(AnsDenseTable& table,
+                                                 const uint8_t* src,
+                                                 size_t size) {
   if (size < 1 + kAnsCtrlBlockSize) return SIZE_MAX;
   const uint8_t level = src[size - 1];
   if (level != 0) return SIZE_MAX;  // only the full table is supported here
@@ -276,7 +279,8 @@ size_t DeserializeAnsTable(AnsDenseTable& table, const uint8_t* src,
 
 // ------------------------------ ANS32 encoder (scalar; unchanged from Iguana)
 
-std::vector<uint8_t> Ans32Encode(const uint8_t* data, size_t size) {
+HWY_CONTRIB_DLLEXPORT std::vector<uint8_t> Ans32Encode(const uint8_t* data,
+                                                       size_t size) {
   const AnsStatistics stats = AnsStatistics::FromData(data, size);
 
   uint32_t state[kAnsLanes];
@@ -327,9 +331,9 @@ std::vector<uint8_t> Ans32Encode(const uint8_t* data, size_t size) {
 
 // ------------------------------ ANS32 scalar reference decoder
 
-bool Ans32DecodePayloadScalar(const uint8_t* src, size_t src_size,
-                              const AnsDenseTable& table, uint8_t* dst,
-                              size_t orig_size) {
+HWY_CONTRIB_DLLEXPORT bool Ans32DecodePayloadScalar(
+    const uint8_t* src, size_t src_size, const AnsDenseTable& table,
+    uint8_t* dst, size_t orig_size) {
   if (src_size < 128) return false;
 
   uint32_t state[kAnsLanes];
@@ -379,8 +383,9 @@ bool Ans32DecodePayloadScalar(const uint8_t* src, size_t src_size,
   return true;
 }
 
-bool Ans32DecodeScalar(const uint8_t* src, size_t src_size, uint8_t* dst,
-                       size_t orig_size) {
+HWY_CONTRIB_DLLEXPORT bool Ans32DecodeScalar(const uint8_t* src,
+                                             size_t src_size, uint8_t* dst,
+                                             size_t orig_size) {
   AnsDenseTable table;
   const size_t payload = DeserializeAnsTable(table, src, src_size);
   if (payload == SIZE_MAX) return false;

--- a/hwy/contrib/iguana/ans.h
+++ b/hwy/contrib/iguana/ans.h
@@ -34,6 +34,8 @@
 
 #include <vector>
 
+#include "hwy/base.h"  // HWY_CONTRIB_DLLEXPORT
+
 namespace hwy {
 namespace iguana {
 
@@ -51,7 +53,7 @@ constexpr uint32_t kAnsFreqMask = kAnsWordM - 1;
 
 // Normalized per-symbol frequencies, summing to kAnsWordM. `packed[i]` is
 // (cumulative_freq[i] << 12) | freq[i]; `Freq()` / `CumFreq()` unpack it.
-struct AnsStatistics {
+struct HWY_CONTRIB_DLLEXPORT AnsStatistics {
   uint32_t packed[256] = {};
 
   uint32_t Freq(size_t sym) const { return packed[sym] & kAnsFreqMask; }
@@ -73,26 +75,31 @@ using AnsDenseTable = std::vector<uint32_t>;
 // Parses a table serialized by AnsStatistics::Serialize from the END of
 // `src[0, size)`. Returns the length of the data that precedes it (the rANS
 // payload), or SIZE_MAX on malformed input.
-size_t DeserializeAnsTable(AnsDenseTable& table, const uint8_t* src,
-                           size_t size);
+HWY_CONTRIB_DLLEXPORT size_t DeserializeAnsTable(AnsDenseTable& table,
+                                                 const uint8_t* src,
+                                                 size_t size);
 
 // ------------------------------ ANS32 codec
 
 // Encodes `data` into the 32-way interleaved rANS payload followed by the
 // serialized frequency table (i.e. a complete ANS32 block).
-std::vector<uint8_t> Ans32Encode(const uint8_t* data, size_t size);
+HWY_CONTRIB_DLLEXPORT std::vector<uint8_t> Ans32Encode(const uint8_t* data,
+                                                       size_t size);
 
 // Scalar reference decoder for a block produced by Ans32Encode. `orig_size` is
 // the decompressed length. Returns false on malformed input. The SIMD decoder
 // (ans-inl.h) produces identical output.
-bool Ans32DecodeScalar(const uint8_t* src, size_t src_size, uint8_t* dst,
-                       size_t orig_size);
+HWY_CONTRIB_DLLEXPORT bool Ans32DecodeScalar(const uint8_t* src,
+                                             size_t src_size, uint8_t* dst,
+                                             size_t orig_size);
 
 // Same, but the frequency table has already been parsed: `payload` is the rANS
 // data only (DeserializeAnsTable's prefix length), `table` its dense table.
-bool Ans32DecodePayloadScalar(const uint8_t* payload, size_t payload_size,
-                              const AnsDenseTable& table, uint8_t* dst,
-                              size_t orig_size);
+HWY_CONTRIB_DLLEXPORT bool Ans32DecodePayloadScalar(const uint8_t* payload,
+                                                    size_t payload_size,
+                                                    const AnsDenseTable& table,
+                                                    uint8_t* dst,
+                                                    size_t orig_size);
 
 }  // namespace iguana
 }  // namespace hwy


### PR DESCRIPTION
### Description

When building Highway with shared libraries (`BUILD_SHARED_LIBS=ON`), `CMakeLists.txt` sets `CMAKE_CXX_VISIBILITY_PRESET hidden`. Consequently, non-inline functions in `libhwy_contrib.so` require `HWY_CONTRIB_DLLEXPORT` annotation to be exported and linked by external consumers and test binaries.

Recently added modules `hwy/contrib/coder` and `hwy/contrib/iguana` were missing `HWY_CONTRIB_DLLEXPORT` on their public function declarations and definitions, leading to undefined symbol linker errors during test linkage:
```
undefined reference to `hwy::CreateCumulativeProbs`
undefined reference to `hwy::BuildDecodeTable`
undefined reference to `hwy::EncodeInterleaved`
undefined reference to `hwy::DecodeInterleavedScalar`
undefined reference to `hwy::GetRangeShuffleTables()`
```

### Changes

1. In `hwy/contrib/coder/range_coder.h` and `range_coder.cc`:
   - Annotate `CreateCumulativeProbs`, `BuildDecodeTable`, `EncodeInterleaved`, `DecodeInterleavedScalar`, and `GetRangeShuffleTables` with `HWY_CONTRIB_DLLEXPORT`.
2. In `hwy/contrib/iguana/ans.h` and `ans.cc`:
   - Include `hwy/base.h` and annotate `AnsStatistics`, `DeserializeAnsTable`, `Ans32Encode`, `Ans32DecodeScalar`, and `Ans32DecodePayloadScalar` with `HWY_CONTRIB_DLLEXPORT`.

Fixes #3378
